### PR TITLE
Remove mode property on symlink static files

### DIFF
--- a/penguin/penguin/penguin_prep.py
+++ b/penguin/penguin/penguin_prep.py
@@ -53,7 +53,6 @@ def _rebase_and_add_files(qcow_file, new_qcow_file, files):
         elif ftype == 'symlink':
             target = file['target'] # This is what we point to
             linkpath = file_path # This is what we create
-            mode = file['mode']
             # Delete linkpath if it already exists
             if g.exists(linkpath):
                 g.rm(linkpath)
@@ -63,7 +62,6 @@ def _rebase_and_add_files(qcow_file, new_qcow_file, files):
                 raise ValueError(f"Can't add symlink to {target} as it doesn't exist in requested symlink from {linkpath}")
 
             g.ln_s(target, linkpath)
-            g.chmod(mode, linkpath)
         elif ftype == 'dev':
             print("WARN: devices should now be dynamic")
             major = file['major']

--- a/penguin/penguin/penguin_static.py
+++ b/penguin/penguin/penguin_static.py
@@ -179,7 +179,6 @@ def pre_shim(config):
             config['static_files']['/bin/sh'] = {
                 'type': 'symlink',
                 'target': '/igloo/utils/busybox',
-                'mode': 0o755
             }
 
         # Find any files named insmod or modprobe, we want to replace these with symlinks to exit0
@@ -189,7 +188,6 @@ def pre_shim(config):
                 config['static_files'][f] = {
                     'type': 'symlink',
                     'target': '/igloo/utils/exit0.sh',
-                    'mode': 0o755
                 }
 
 		# Ensure we have an entry for localhost in /etc/hosts
@@ -279,7 +277,6 @@ def shim_configs(config):
         config['static_files'][guest_path] = {
             'type': 'symlink',
             'target': shim_path,
-            'mode': 0o755
         }
 
 def _is_init_script(tarinfo):


### PR DESCRIPTION
Symlinks on Linux ([unlike macOS](https://superuser.com/questions/303040/how-do-file-permissions-apply-to-symlinks/303063#303063)) don't have their own permissions, so the current behavior edits the mode of the target file. We can add a way to edit permissions of existing files in the config with another option later, if needed.