### PR TITLE
Add ability to change CPU model to config

### DIFF
--- a/penguin/penguin/penguin_run.py
+++ b/penguin/penguin/penguin_run.py
@@ -210,7 +210,9 @@ def run_config(conf_yaml, out_dir=None, qcow_dir=None):
     else:
         args = args + root_shell + console_out
 
-    if archend == 'mips64eb':
+    if conf['core'].get('cpu', None):
+        args += ['-cpu', conf['core']['cpu']]
+    elif archend == 'mips64eb':
         args += ['-cpu', 'MIPS64R2-generic']
 
     ############# Reduce determinism #############

--- a/penguin/resources/config_schema.yaml
+++ b/penguin/resources/config_schema.yaml
@@ -95,6 +95,10 @@ properties:
         examples:
           - false
           - true
+      cpu:
+        title: CPU model
+        description: Specify non-default QEMU CPU model
+        type: string
       show_output:
         title: Write serial to stdout
         description: Whether to print QEMU serial output to stdout instead of writing to a log file


### PR DESCRIPTION
This is a tiny feature addition. This PR adds the config option for `core: cpu: MODEL_NAME` so that a non-default cpu model can be specified.

This change was inspired by a device that required this option.