### PR TITLE
More bugfixes for pydantic validation. 

### DIFF
--- a/penguin/penguin/penguin_config.py
+++ b/penguin/penguin/penguin_config.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Literal, Annotated
+from typing import Optional, Union, Literal, Annotated, Dict
 
 from pydantic import BaseModel, RootModel, Field
 from pydantic.config import ConfigDict
@@ -361,10 +361,27 @@ IoctlCommand = _union(
 
 Ioctls = _newtype(
     class_name="Ioctls",
-    type_=dict[int,IoctlCommand],
+    type_=Dict[Union[int, str], IoctlCommand], # TODO: str should only allow for "*" but we need a custom validator for that
     title="ioctl",
     description="How to handle ioctl() calls",
     default=dict(),
+    examples=[
+        {
+            "*": dict(
+                model="return_const",
+                val=0,
+            ),
+            "1000": dict(
+                model="return_const",
+                val=5,
+            ),
+        },
+        {
+            "*": dict(
+                model="return_const",
+            ),
+        },
+    ],
 )
 
 

--- a/penguin/penguin/penguin_prep.py
+++ b/penguin/penguin/penguin_prep.py
@@ -152,7 +152,7 @@ def _modify_guestfs(g, file_path, file):
                 raise ValueError(f"Can't delete {file_path} as it doesn't exist")
             g.rm_rf(file_path) # We make this one fatal if there's an error.
 
-        elif action == 'move_from':
+        elif action == 'move':
             # Move a file (or directory and children) TO
             # the key in yaml (so we can avoid duplicate keys)
             if g.is_symlink(file['from']):
@@ -383,7 +383,7 @@ def prepare_run(conf, out_dir, out_filename="image.qcow2"):
             raise ValueError(f"Unknown type for nvram value {k}: {type(val)}")
 
         config_files[f"/igloo/libnvram/{k}"] = {
-            'type': "file",
+            'type': "inline_file",
             'contents': encoded,
             'mode': 0o644,
         }


### PR DESCRIPTION
Allow `*` for ioctl key
`move_from`->`move` in penguin_prep
`file`->`inline_file` for nvram values
