### PR TITLE
Drop args-too-long warning as it's no longer an issue 

### DIFF
--- a/penguin/penguin/penguin_run.py
+++ b/penguin/penguin/penguin_run.py
@@ -379,10 +379,7 @@ def run_config(conf_yaml, out_dir=None, qcow_dir=None, logger=None, init=None, t
     # args first, but we need to know the start of the string too. So let's say a user can't change
     # the root=/dev/vda argument and put that first. Then config args. Then the rest of the args
     root_str = f"root={ROOTFS}"
-    full_append = root_str + " " + " ".join(config_args) +  panda.panda_args[append_idx].replace(root_str, "")
-    if len(full_append) > 255:
-        logger.warning(f"WARNING append may be too long. The following will be passed through reliably: {full_append[:255]}. The rest may be dropped: {full_append[255:]}")
-    panda.panda_args[append_idx] = full_append
+    panda.panda_args[append_idx] = root_str + " " + " ".join(config_args) + panda.panda_args[append_idx].replace(root_str, "")
 
     @panda.cb_pre_shutdown
     def pre_shutdown():


### PR DESCRIPTION
After #103 and, in particular, https://github.com/panda-re/panda/commit/24134d1d555a3950abfd793baac0dec293ca2eb7, we should be able to pass longer command line arguments to our guests. As such the warning about truncation is no longer relevant.