### PR TITLE
Expand unit tests

### DIFF
--- a/tests/unit_tests/_in_container_run.sh
+++ b/tests/unit_tests/_in_container_run.sh
@@ -15,7 +15,7 @@ mkdir /tmp/hostfile
 cat <<EOF > /tmp/hostfile/init.bin
 #!/igloo/utils/sh
 echo custom bin runs;
-/igloo/utils/busybox ps;
+/igloo/utils/busybox touch /tmp/success
 EOF
 
 # Share qcows between tests (only) if FS hashes match

--- a/tests/unit_tests/configs/env_cmp.yaml
+++ b/tests/unit_tests/configs/env_cmp.yaml
@@ -10,11 +10,16 @@ static_files:
       # Env test
       v=`/igloo/utils/busybox cat /proc/cmdline | /igloo/utils/busybox awk '{for (i=1; i<=NF; i++) if ($i ~ /^envvar=/) print substr($i, 8)}'`
 
-      if [ "$v" != "target" ]; then
-        echo "Bad envvar $v"
+      if [ "$v" == "firsttarget" ]; then
+        echo "Unexpected, envvar is set to first target"
+        exit 1
+      fi
+
+      if [ "$v" == "secondtarget" ]; then
+        echo "Unexpected, envvar is set to second target"
         exit 1
       fi
       
-      echo "Everything is good"
-      echo "Passed all init checks"
+      echo "tests pass"
+      exit 0
     mode: 73

--- a/tests/unit_tests/configs/env_unset.yaml
+++ b/tests/unit_tests/configs/env_unset.yaml
@@ -1,4 +1,12 @@
-# yaml-language-server: $schema=https://rehosti.ng/igloo/config_schema.yaml
+env:
+  # These are *not* the variables we're looking for below
+  #envvar_: "trailing_underscore"
+  #_envvar: "prefix_underscore" # Grep below would actually match this. Skip
+  var2_: "trailing_underscore"
+  _var2: "prefix_underscore"
+  anothervar_: "trailing_underscore"
+  _anothervar: "prefix_underscore"
+
 static_files:
   /init:
     type: inline_file
@@ -8,17 +16,25 @@ static_files:
 
       # Env test. Kernel boot args make it through to init binaries so we'll inherit envvar
       # We should be able to detect this with our busybox instrumentation
-      # XXX: we wouldn't detect this if it operated directly on /proc/cmdline as busybox
-      # is statically linked and we won't see a strstr search
 
-      # This wouldn't work 
+      # XXX: we can't detect this as busybox (and its grep)
+      # is statically linked so there won't be a strstr call to detect
       #envvar=$(/igloo/utils/busybox cat /proc/cmdline | /igloo/utils/busybox grep -o "envvar=[^ ]*" |  /igloo/utils/busybox cut -d'=' -f2)
+      #if [ ! -z "$envvar" ]; then
+      #  echo "envvar is set when it should not be: $envvar"
+      #  exit 1
+      #fi
 
-      if [ -z "$envvar" ]; then
-        echo "Unset envvar!"
+      if [ ! -z "$var2" ]; then
+        echo "var2 is set when it should not be: $var2"
         exit 1
       fi
 
-      echo "Everything is good"
-      echo "Passed all init checks"
+      if [ ! -z "$anothervar" ]; then
+        echo "anothervar is set when it should not be: $anothervar"
+        exit 1
+      fi
+
+      echo "tests pass"
+      exit 0
     mode: 73

--- a/tests/unit_tests/configs/hostfile.yaml
+++ b/tests/unit_tests/configs/hostfile.yaml
@@ -5,13 +5,53 @@ static_files:
       #!/igloo/utils/sh
       set -eu
 
+      # Does /hostpasswd exist?
+      if [ ! -e /hostpasswd ]; then
+        echo "Missing /hostpasswd (unexpected)"
+        exit 1
+      fi
+
+      # Does /etc/hostpasswd exist?
+      if [ ! -e /etc/hostpasswd ]; then
+        echo "Missing /etc/hostpasswd (unexpected)"
+        exit 1
+      fi
+
+      # Does /etc/new/hostpasswd exist?
+      if [ ! -e /etc/new/hostpasswd ]; then
+        echo "Missing /etc/new/hostpasswd (unexpected)"
+        exit 1
+      fi
+
       # Run our test file mapped in from the host as binary data
-      /igloo/utils/busybox ls -al /init.bin
-      /igloo/utils/busybox cat /init.bin
-      exec /init.bin
+      /init.bin
+
+      # Check if /tmp/success exists
+      if [ ! -e /tmp/success ]; then
+        echo "Missing /tmp/success (unexpected)"
+        exit 1
+      fi
+
+      echo "tests pass"
+      exit 0
     mode: 00555
 
   /init.bin:
     type: host_file
     host_path: /tmp/hostfile/init.bin
+    mode: 00555
+
+  /hostpasswd:
+    type: host_file
+    host_path: /etc/passwd
+    mode: 00555
+
+  /etc/hostpasswd:
+    type: host_file
+    host_path: /etc/passwd
+    mode: 00555
+
+  /etc/new/hostpasswd:
+    type: host_file
+    host_path: /etc/passwd
     mode: 00555

--- a/tests/unit_tests/configs/pseudofile_ioctl.yaml
+++ b/tests/unit_tests/configs/pseudofile_ioctl.yaml
@@ -1,5 +1,8 @@
 pseudofiles:
   /dev/missing: {}
+  /dev/fs/missing: {}
+  /dev/foo/missing: {}
+
 static_files:
   /init:
     type: inline_file
@@ -7,16 +10,18 @@ static_files:
       #!/igloo/utils/sh
       set -ux
       
-      # First check existance of device explicitly (hdparam does this too)
+      # First check existance of device explicitly to make sure that it's present
       if [ ! -e /dev/missing ]; then
         /igloo/utils/busybox ls -alt /dev/missing
         echo "Missing /dev/missing (unexpected)"
         exit 1
       fi
 
-      # Run hdparam on /dev/missing which issues ioctl HDIO_DRIVE_CMD twice
+      # Run hdparam on each device which issues ioctl HDIO_DRIVE_CMD twice
       /igloo/utils/busybox hdparm -I /dev/missing
+      /igloo/utils/busybox hdparm -I /dev/fs/missing
+      /igloo/utils/busybox hdparm -I /dev/foo/missing
 
-      echo "Everything is good"
-      echo "Passed all init checks"
+      echo "tests pass"
+      exit 0
     mode: 73

--- a/tests/unit_tests/configs/pseudofile_missing.yaml
+++ b/tests/unit_tests/configs/pseudofile_missing.yaml
@@ -5,12 +5,15 @@ static_files:
       #!/igloo/utils/sh
       set -eux
 
-      if [ ! -e /dev/missing ]; then
-        echo "Missing /dev/missing (expected)"
-        exit 1
-      fi
-      echo "FAIL /dev/misisng present when we didn't expect it to be"
+      paths="/dev/missing /dev/net/missing /dev/foo/missing /proc/missing /proc/fs/missing /proc/foo/missing /sys/missing /sys/fs/missing /sys/foo/missing"
 
-      /igloo/utils/busybox cat /dev/missing
-      exit 1
+      for path in $paths; do
+          if [ -e "$path" ]; then
+              echo "Unexpected: $path present when we didn't expect it to be"
+              exit 1
+          fi
+      done
+
+      echo "tests pass"
+      exit 0
     mode: 73

--- a/tests/unit_tests/configs/shared_dir.yaml
+++ b/tests/unit_tests/configs/shared_dir.yaml
@@ -9,4 +9,7 @@ static_files:
       #!/igloo/utils/sh
       set -eux
       echo 'Hello from guest!' > /igloo/shared/from_guest.txt
+
+      echo "tests pass"
+      exit 0
     mode: 73


### PR DESCRIPTION
Changes each of the unit tests to be a bit more comprehensive. Changes our test framework to support testing multiple things after each run.

For pseudofiles we check in the root of a directory like /dev, as well as within an existing subdirectory and a missing subdirectory.

The env_cmp test is partly disabled as it is failing to detect a 2nd comparison. I created #111 to track this. Since this PR detects this failure (and doesn't introduce it), I'm planning to merge this before we fix that.