### PR TITLE
Pydantic spec bugfix:

### DIFF
--- a/penguin/penguin/penguin_config.py
+++ b/penguin/penguin/penguin_config.py
@@ -214,7 +214,7 @@ NetDevs = _newtype(
 
 BlockedSignals = _newtype(
     class_name="BlockedSignals",
-    type_=list[str],
+    type_=list[int],
     title="Signals to block",
     description="Signals numbers to block within guest",
     examples=[


### PR DESCRIPTION
Blocked signals are ints, not strings.

Maybe later we could support strings though.