### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
         run: python3 $GITHUB_WORKSPACE/tests/unit_tests/test.py --kernel-version ${{ matrix.kernel }} --arch ${{ matrix.arch }} --test ${{ matrix.test }}
 
   push_docker_and_release:
-    needs: run_tests
+    needs: build_container
     runs-on: self-hosted
     if: github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
`push_docker_and_release` has the following conditions:
- requires `run_tests`
- `github.ref` must point to `refs/heads/main`


`run_tests` only runs if `github.ref` != `refs/heads/main`

Effectively this means `push_docker_and_release` never runs.

This PR changes the conditions for `push_docker_and_release` to be:
- requires `build_container` (instead of `run_tests)
- `github.ref` must point to `refs/heads/main`

This means this should only run on merges to main.
