### PR TITLE
Add lib_inject field

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG DOWNLOAD_TOKEN="github_pat_11AACH7QA0tuVodqXUxSAy_Wq5btZcV0nnuFbRv2XDZRAci4A
 ARG PANDA_VERSION="1.8.17"
 ARG BUSYBOX_VERSION="0.0.1"
 ARG LINUX_VERSION="2.2.0"
-ARG LIBNVRAM_VERSION="0.0.1"
+ARG LIBNVRAM_VERSION="0.0.2"
 ARG CONSOLE_VERSION="1.0.2"
 ARG PENGUIN_PLUGINS_VERSION="1.5.6"
 ARG UTILS_VERSION="4"
@@ -203,6 +203,8 @@ RUN apt-get update && apt-get install -y \
     telnet \
     vim \
     wget \
+    clang \
+    lld \
     zlib1g && \
     apt install -yy -f /tmp/pandare.deb && \
     rm -rf /var/lib/apt/lists/* /tmp/pandare.deb

--- a/penguin/penguin/penguin_config.py
+++ b/penguin/penguin/penguin_config.py
@@ -442,6 +442,30 @@ UBootEnv = _newtype(
     default=dict(),
 )
 
+LibInjectAliases = _newtype(
+    class_name="LibInjectAliases",
+    type_=dict[str,str],
+    title="Injected library aliases",
+    description="Mapping between names of external library functions and names of functions defined in the injected library. This allows replacing arbitrary library functions with your own code.",
+    default=dict(),
+    examples=[
+        dict(fputs="false", nvram_load="nvram_init"),
+    ],
+)
+
+class LibInject(BaseModel):
+    """Configuration for a dynamically-linked C library to be injected into all dynamically-linked programs in the guest"""
+    model_config = ConfigDict(title="Injected library configuration", extra="forbid")
+
+    aliases: Optional[LibInjectAliases] = None
+    extra: Annotated[
+        Optional[str],
+        Field(
+            None,
+            title="Extra injected library code",
+            description="Additional custom source code to include in the library",
+        ),
+    ]
 
 StaticFileAction = _union(
     class_name="StaticFileAction",
@@ -575,6 +599,7 @@ class Main(BaseModel):
     netdevs: Optional[NetDevs] = None
     uboot_env: Optional[UBootEnv] = None
     blocked_signals: Optional[BlockedSignals] = None
+    lib_inject: Optional[LibInject] = None
     static_files: StaticFiles
     plugins: Annotated[dict[str, Plugin], Field(title="Plugins")]
 

--- a/penguin/penguin/utils.py
+++ b/penguin/penguin/utils.py
@@ -203,7 +203,7 @@ def hash_image_inputs(conf):
     args = str(inspect.signature(penguin_prep.derive_qcow_from))
     assert args == '(qcow_file, out_dir, files, out_filename=None)'
 
-    return hash_yaml([static_files, qcow_hash])
+    return hash_yaml([static_files, qcow_hash, conf.get('lib_inject')])
 
 
 def _load_penguin_analysis_from(plugin_file):

--- a/penguin/resources/init.sh
+++ b/penguin/resources/init.sh
@@ -67,7 +67,7 @@ fi
 if [ ! -z "${WWW}" ]; then
   if [ -e /igloo/utils/www_cmds ]; then
     echo '[IGLOO INIT] Force-launching webserver commands';
-    LD_PRELOAD=/igloo/utils/libnvram.so /igloo/utils/sh /igloo/utils/www_cmds &
+    LD_PRELOAD=/igloo/utils/libnvram.so:/igloo/lib_inject.so /igloo/utils/sh /igloo/utils/www_cmds &
   fi
   unset WWW
 fi
@@ -134,7 +134,7 @@ fi
 
 if [ ! -z "${igloo_init}" ]; then
   echo '[IGLOO INIT] Running specified init binary';
-  LD_PRELOAD=/igloo/utils/libnvram.so exec "${igloo_init}"
+  LD_PRELOAD=/igloo/utils/libnvram.so:/igloo/lib_inject.so exec "${igloo_init}"
 fi
 echo "[IGLOO INIT] Fatal: no igloo_init specified in env. Abort"
 exit 1


### PR DESCRIPTION
This PR adds a `lib_inject` field to the config that contains C source code that is cross compiled to a library and `LD_PRELOAD`ed inside the guest. It can be used for overriding functions to have different behavior. Originally, I was trying to make a library that could do arbitrary library substitutions at runtime by parsing ELF symbol tables and overwriting shellcode to avoid this PR's approach, but it turned out to be really complicated and have lots of issues. And I figured out that clang is natively a cross-compiler, but it doesn't come with headers or system libraries for other targets, so we will have to manually add prototypes for all functions we want to call instead of just `#include`ing a header, or just ignore the compile warnings and call the functions without prototypes.

## Testing

This PR doesn't have any unit tests, because we don't really have an infrastructure for unit tests that involve dynamic linking, but I did verify that this config makes a guest print the message and then kernel panic when the init binary exits.

```yaml
lib_inject:
  void ioctl() {
    puts("Hello world!");
    abort();
  }
```

## TODO

What are some examples for functions we would want to inject? We should add a few to the `examples` list in the Pydantic spec.