### PR TITLE
Add development script

### DIFF
--- a/dev
+++ b/dev
@@ -1,0 +1,8 @@
+#!/bin/sh
+docker build -t penguin .
+docker run --rm -it \
+    --privileged \
+    -v $(pwd)/fws:/fws -v $(pwd)/results:/results \
+    -v $(pwd)/penguin:/pkg \
+    penguin \
+    bash -c "pip install -e /pkg && bash"


### PR DESCRIPTION
This PR adds an example script for easy dev with penguin.

Primarily it builds a docker container, runs the docker container with fws, results, AND the penguin code in the local directory mounted in the docker container.

It must directly install the package to use it before it exits into bash.