### PR TITLE
Restore privileged run

### DIFF
--- a/run
+++ b/run
@@ -1,5 +1,6 @@
 #!/bin/sh
 docker run --rm -it \
+    --privileged \
     -v $(pwd)/fws:/fws -v $(pwd)/results:/results \
     -p 8000:80 \
     rehosting/penguin \


### PR DESCRIPTION
Without `--privileged` the docker containers can't access `/dev` which means `/dev/kvm` isn't accessible and therefore guestmount is incredibly slow.

This PR just adds back the privileged flag by default.