### PR TITLE
Remove extraneous libnvram

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN /get_release.sh rehosting console ${CONSOLE_VERSION} ${DOWNLOAD_TOKEN} | \
 # Download libnvram from CI. Populate /igloo_static/libnvram
 ARG LIBNVRAM_VERSION
 RUN /get_release.sh rehosting libnvram ${LIBNVRAM_VERSION} ${DOWNLOAD_TOKEN} | \
-    tar xzf - -C /igloo_static
+    tar xzf - -C /igloo_static --exclude 'libnvram.so.*'
 
 # Download VPN from CI pushed to panda.re. Populate /igloo_static/vpn
 ARG VPN_VERSION

--- a/penguin/resources/init.sh
+++ b/penguin/resources/init.sh
@@ -67,7 +67,7 @@ fi
 if [ ! -z "${WWW}" ]; then
   if [ -e /igloo/utils/www_cmds ]; then
     echo '[IGLOO INIT] Force-launching webserver commands';
-    LD_PRELOAD=/igloo/utils/libnvram.so:/igloo/lib_inject.so /igloo/utils/sh /igloo/utils/www_cmds &
+    LD_PRELOAD=/igloo/lib_inject.so /igloo/utils/sh /igloo/utils/www_cmds &
   fi
   unset WWW
 fi
@@ -134,7 +134,7 @@ fi
 
 if [ ! -z "${igloo_init}" ]; then
   echo '[IGLOO INIT] Running specified init binary';
-  LD_PRELOAD=/igloo/utils/libnvram.so:/igloo/lib_inject.so exec "${igloo_init}"
+  LD_PRELOAD=/igloo/lib_inject.so exec "${igloo_init}"
 fi
 echo "[IGLOO INIT] Fatal: no igloo_init specified in env. Abort"
 exit 1


### PR DESCRIPTION
Now that libnvram is included in lib_inject, we don't need to include dynamically-linked libnvram in the container or LD_PRELOAD it.