### PR TITLE
LD_PRELOAD for root shell so interactive users can access nvram

### DIFF
--- a/penguin/resources/init.sh
+++ b/penguin/resources/init.sh
@@ -53,7 +53,7 @@ fi
 
 if [ ! -z "${ROOT_SHELL}" ]; then
   echo '[IGLOO INIT] Launching root shell';
-  ENV=/igloo/utils/igloo_profile /igloo/utils/console &
+  LD_PRELOAD=/igloo/lib_inject.so ENV=/igloo/utils/igloo_profile /igloo/utils/console &
   unset ROOT_SHELL
 fi
 


### PR DESCRIPTION
Previously a user who connected to the root shell would get significantly different behavior when running `nvram` commands unless they manually did `LD_PRELOAD=/igloo/lib_inject.so nvram ...`. This should reduce some confusion.