### PR TITLE
Drop unionfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG CONSOLE_VERSION="1.0.2"
 ARG PENGUIN_PLUGINS_VERSION="1.5.6"
 ARG UTILS_VERSION="4"
 ARG VPN_VERSION="1.0.5"
-ARG HYPERFS_VERSION="0.0.5"
+ARG HYPERFS_VERSION="0.0.8"
 
 FROM rust as vhost_builder
 RUN git clone -q https://github.com/rust-vmm/vhost-device/ /root/vhost-device

--- a/penguin/resources/init.sh
+++ b/penguin/resources/init.sh
@@ -8,31 +8,17 @@ done
 /igloo/utils/busybox mount -t proc proc /igloo/pfs/real/proc
 /igloo/utils/busybox mount -t devtmpfs devtmpfs /igloo/pfs/real/dev
 
-# Make temporary /dev symlink for FUSE
-/igloo/utils/busybox ln -s /igloo/pfs/real/dev /dev
-
 # Make hyperfs in /igloo/pfs/fake
 /igloo/utils/busybox mkdir -p /igloo/pfs/fake
-/igloo/utils/hyperfs /igloo/pfs/fake -o dev --hyperfile-paths="$IGLOO_HYPERFILE_PATHS"
-
-# Merge real and pseudofile dirs with unionfs
-for f in sys proc dev; do
-  fake_dir=/igloo/pfs/fake/$f
-  real_dir=/igloo/pfs/real/$f
-  merged_dir=/igloo/pfs/merged/$f
-  /igloo/utils/busybox mkdir -p $merged_dir
-  if [ -d $fake_dir ]; then
-    /igloo/utils/unionfs-fuse -o dev,direct_io $fake_dir=RW:$real_dir=RW $merged_dir
-  else
-    /igloo/utils/busybox mount --bind $real_dir $merged_dir
-  fi
-done
-
-# Finally bind /sys,/proc,/dev to merged dirs
+/igloo/utils/busybox rm -rf /dev # Remove /dev provided by firmware
+/igloo/utils/busybox ln -s /igloo/pfs/real/dev /dev # Temp /dev symlink for FUSE
+/igloo/utils/hyperfs /igloo/pfs/fake -o dev --passthrough-path=/igloo/pfs/real --hyperfile-paths="$IGLOO_HYPERFILE_PATHS"
 /igloo/utils/busybox rm /dev
+
+# Bind /sys,/proc,/dev to fake dirs
 for f in sys proc dev; do
     /igloo/utils/busybox mkdir -p /$f
-    /igloo/utils/busybox mount --bind /igloo/pfs/merged/$f /$f
+    /igloo/utils/busybox mount --bind /igloo/pfs/fake/$f /$f
 done
 
 for p in /run /tmp /igloo/libnvram_tmpfs; do
@@ -40,8 +26,8 @@ for p in /run /tmp /igloo/libnvram_tmpfs; do
   /igloo/utils/busybox mount -t tmpfs tmpfs $p
 done
 
-/igloo/utils/busybox mkdir -p /igloo/pfs/real/dev/pts
-/igloo/utils/busybox mount -t devpts devpts /igloo/pfs/real/dev/pts
+/igloo/utils/busybox mkdir -p /dev/pts
+/igloo/utils/busybox mount -t devpts devpts /dev/pts
 
 # Populate tmpfs with hardcoded libnvram values
 /igloo/utils/busybox cp /igloo/libnvram/* /igloo/libnvram_tmpfs/ || true
@@ -82,21 +68,21 @@ fi
 # We can't set these up as static files because /dev would get mounted
 # after we populate it statically.
 if [ ! -c /dev/console ]; then
-  /igloo/utils/busybox mknod /igloo/pfs/real/dev/console c 5 1
+  /igloo/utils/busybox mknod /dev/console c 5 1
 fi
 if [ ! -c /dev/ttyS0 ]; then
   # Must be arm with default /dev/ttyAMA0, let's add ttyS0 for good measure
-  /igloo/utils/busybox mknod /igloo/pfs/real/dev/ttyS0 c 204 64
+  /igloo/utils/busybox mknod /dev/ttyS0 c 204 64
 fi
 
 if [ ! -e /dev/root ]; then
   # Symlink to root partition: /dev/vda
-  /igloo/utils/busybox ln -s /dev/vda /igloo/pfs/real/dev/root
+  /igloo/utils/busybox ln -s /dev/vda /dev/root
 fi
 
 if [ ! -e /dev/ram ]; then
   # Symlink to ramdisk
-  /igloo/utils/busybox ln -s /dev/ram0 /igloo/pfs/real/dev/ram
+  /igloo/utils/busybox ln -s /dev/ram0 /dev/ram
 fi
 
 # Pretend we have some network interfaces. Note these aren't

--- a/tests/unit_tests/configs/proc_self.yaml
+++ b/tests/unit_tests/configs/proc_self.yaml
@@ -1,0 +1,23 @@
+# The /proc/self symlink location depends on the accessing PID, which has the potential for issues with hyperfs, so we test it here
+
+static_files:
+  /init:
+    type: inline_file
+    contents: |
+      #!/igloo/utils/sh
+      set -eux
+
+      if [ "$(/igloo/utils/busybox readlink /proc/self/exe)" != "/igloo/utils/busybox" ]; then
+        echo "Readlink /proc/self/exe wrong result"
+        exit 1
+      fi
+
+      cd /proc/self
+      if [ "$(/igloo/utils/busybox readlink cwd)" != "/proc/$$" ]; then
+        echo "Readlink /proc/self/cwd wrong result"
+        exit 1
+      fi
+
+      echo "tests pass"
+      exit 0
+    mode: 73

--- a/tests/unit_tests/configs/pseudofile_readdir.yaml
+++ b/tests/unit_tests/configs/pseudofile_readdir.yaml
@@ -1,0 +1,28 @@
+# Ensure that readdir() lists both pseudofiles and real files, and that it filters duplicates
+
+pseudofiles:
+  /dev/a/c: {}
+  /dev/a/e: {}
+  /dev/a/b: {}
+
+static_files:
+  /init:
+    type: inline_file
+    contents: |
+      #!/igloo/utils/sh
+      set -eux
+
+      for dir in b d f; do
+        /igloo/utils/busybox mkdir -p "/igloo/pfs/real/dev/a/$dir"
+      done
+
+      /igloo/utils/strace /igloo/utils/busybox ls -a /dev/a
+
+      if [ "$(cd /dev/a && echo *)" != "b c d e f" ]; then
+        echo "wrong readdir result"
+        exit 1
+      fi
+
+      echo "tests pass"
+      exit 0
+    mode: 73

--- a/tests/unit_tests/test.py
+++ b/tests/unit_tests/test.py
@@ -175,6 +175,8 @@ def main():
         "shared_dir": assert_generic("shared/from_guest.txt", "Hello from guest"),
         "net_missing": assert_generic("iface.log", ["eth0", "ens3"]),
         "netdevs": assert_generic("console.log", "tests pass"),
+        "proc_self": assert_generic("console.log", "tests pass"),
+        "pseudofile_readdir": assert_generic("console.log", "tests pass"),
     }
 
     parser = argparse.ArgumentParser(description="Run PENGUIN unit tests.")


### PR DESCRIPTION
Upgrade to non-unionfs hyperfs. This fixes the /proc/self issue and adds a proc_self test, and also fixes the issue with /dev mkdir failing. The init script changes back the mkdirs from /igloo/pfs/real/dev to /dev, because that works now. There is also a new pseudofile_readdir test, because readdir() had some bugs during development.