### PR TITLE
Handle almost localhost IP addresses

### DIFF
--- a/pyplugins/netbinds.py
+++ b/pyplugins/netbinds.py
@@ -41,7 +41,11 @@ class NetBinds(PyPlugin):
             if sin_addr != 0:
                 if not is_le:
                     sin_addr = struct.pack("<I", struct.unpack(">I", sin_addr)[0])
+                # some programs will list themselves as binding to 0.0.0.X
+                # we map these to 0.0.0.0
                 ip = socket.inet_ntop(socket.AF_INET, sin_addr)
+                if ip.startswith("0."):
+                    ip = "0.0.0.0"
         else:
             ip = '::1'
             if sin_addr != 0:


### PR DESCRIPTION
This PR proposes mapping every IP address where the first octet is 0 to "0.0.0.0".

This seems to be in line with the range of IP addresses that would otherwise be mapped to the loopback interface and the reservations under IANA. https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml

This change should fix behavior exhibited in #193.

CLOSES: #193 