### PR TITLE
Update root shell prompt to use colors and show project name

### DIFF
--- a/pyplugins/core.py
+++ b/pyplugins/core.py
@@ -75,6 +75,10 @@ class Core(PyPlugin):
             else:
                 conf['env']['WWW'] = "1"
 
+        # Add PROJ_NAME into env based on dirname of config
+        if proj_name := self.get_arg("proj_name"):
+            conf['env']['PROJ_NAME'] = proj_name
+
         # Record loaded plugins
         with open(os.path.join(self.outdir, "core_plugins.yaml"), "w") as f:
             f.write(yaml.dump(plugins)) # Names and args

--- a/src/penguin/penguin_run.py
+++ b/src/penguin/penguin_run.py
@@ -360,6 +360,7 @@ def run_config(conf_yaml, proj_dir=None, out_dir=None, logger=None, init=None, t
             'CID': CID,
             'vhost_socket': uds_path,
             'conf': conf,
+            'proj_name': os.path.basename(proj_dir).replace("host_",""),
             'fs': config_fs,
             'fw': config_image,
             'outdir': out_dir,

--- a/utils/igloo_profile.all
+++ b/utils/igloo_profile.all
@@ -2,3 +2,9 @@ for cmd in $(/igloo/utils/busybox --list); do
   alias "$cmd"="/igloo/utils/busybox $cmd"
 done
 export PATH="/igloo/utils:$PATH"
+
+# Show project name in prompt if we have it, otherwise hostname
+if [ -z "${PROJ_NAME}" ]; then
+  PROJ_NAME="\h"
+fi
+export PS1='\[\e[32m\]\u@$PROJ_NAME \[\e[34m\]\w \[\e[35m\](penguin shell) \[\e[33m\]\$\[\e[0m\] '


### PR DESCRIPTION
Update default PS1 to indicate that the root shell is from penguin and not a normal guest network service. Also pass the project name into the guest env and show it in the prompt.

Previously our shell looked like:
<img width="415" alt="Screenshot 2024-05-13 at 9 34 54 AM" src="https://github.com/rehosting/penguin/assets/294848/6ba6a881-0dbc-41ed-82c0-25b1d9e7c4d2">

And now it looks like:
<img width="417" alt="Screenshot 2024-05-13 at 9 34 22 AM" src="https://github.com/rehosting/penguin/assets/294848/e4470f77-ec60-4469-a06d-b29b76ede5df">
