### PR TITLE
Include 32-bit lib_inject.so in 64-bit guests

### DIFF
--- a/src/resources/init.sh
+++ b/src/resources/init.sh
@@ -39,7 +39,7 @@ fi
 
 if [ ! -z "${ROOT_SHELL}" ]; then
   echo '[IGLOO INIT] Launching root shell';
-  LD_PRELOAD=/igloo/lib_inject.so ENV=/igloo/utils/igloo_profile /igloo/utils/console &
+  LD_PRELOAD='/igloo/${LIB}_inject.so' ENV=/igloo/utils/igloo_profile /igloo/utils/console &
   unset ROOT_SHELL
 fi
 
@@ -53,7 +53,7 @@ fi
 if [ ! -z "${WWW}" ]; then
   if [ -e /igloo/utils/www_cmds ]; then
     echo '[IGLOO INIT] Force-launching webserver commands';
-    LD_PRELOAD=/igloo/lib_inject.so /igloo/utils/sh /igloo/utils/www_cmds &
+    LD_PRELOAD='/igloo/${LIB}_inject.so' /igloo/utils/sh /igloo/utils/www_cmds &
   fi
   unset WWW
 fi
@@ -120,7 +120,7 @@ fi
 
 if [ ! -z "${igloo_init}" ]; then
   echo '[IGLOO INIT] Running specified init binary';
-  LD_PRELOAD=/igloo/lib_inject.so exec "${igloo_init}"
+  LD_PRELOAD='/igloo/${LIB}_inject.so' exec "${igloo_init}"
 fi
 echo "[IGLOO INIT] Fatal: no igloo_init specified in env. Abort"
 exit 1


### PR DESCRIPTION
This is finished, but it is a draft PR for now because I didn't test it. We need a mips64eb firmware that uses 32-bit dynamically-linked programs to test it.