### PR TITLE
Add MicroPython to guest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG LIBNVRAM_VERSION="0.0.4"
 ARG CONSOLE_VERSION="1.0.3"
 ARG PENGUIN_PLUGINS_VERSION="1.5.6"
 ARG VPN_VERSION="1.0.8"
-ARG HYPERFS_VERSION="0.0.12"
+ARG HYPERFS_VERSION="0.0.15"
 ARG GLOW_VERSION="1.5.1"
 ARG LTRACE_PROTOTYPES_VERSION="0.7.91"
 ARG LTRACE_PROTOTYPES_HASH="9db3bdee7cf3e11c87d8cc7673d4d25b"
@@ -96,8 +96,9 @@ RUN /get_release.sh rehosting vpnguin ${VPN_VERSION} ${DOWNLOAD_TOKEN} | \
 ARG HYPERFS_VERSION
 RUN /get_release.sh rehosting hyperfs ${HYPERFS_VERSION} ${DOWNLOAD_TOKEN} | \
   tar xzf - -C / && \
-  mv /result/* /igloo_static/utils.bin/ && \
-  rmdir /result
+  mv /result/utils/* /igloo_static/utils.bin/ && \
+  mv /result/dylibs /igloo_static/dylibs && \
+  rm -rf /result
 
 # Download prototype files for ltrace.
 #

--- a/src/penguin/gen_config.py
+++ b/src/penguin/gen_config.py
@@ -256,20 +256,13 @@ def make_config(fs, out, artifacts, timeout=None, auto_explore=False):
             'mode': 0o444,
         }
 
-    data['static_files']["/igloo"] = {
-        'type': "dir",
-        'mode': 0o755,
-    }
-    data['static_files']["/igloo/utils"] = {
-        'type': "dir",
-        'mode': 0o755,
-    }
+    for dir in ("/igloo", "/igloo/utils", "/igloo/dylibs", "/igloo/ltrace"):
+        data['static_files'][dir] = dict(type="dir", mode=0o755)
 
     # Add ltrace prototype files.
     #
     # They to go in `/igloo/ltrace`, because `/igloo` is treated as ltrace's
     # `/usr/share`, and the files are normally in `/usr/share/ltrace`.
-    data['static_files']['/igloo/ltrace'] = dict(type="dir", mode=0o755)
     ltrace_prots_dir = join(static_dir, "ltrace")
     for f in os.listdir(ltrace_prots_dir):
         data['static_files'][f'/igloo/ltrace/{f}'] = dict(
@@ -280,6 +273,7 @@ def make_config(fs, out, artifacts, timeout=None, auto_explore=False):
 
     arch_suffix = f".{arch}{end}"
 
+    # Add executable binaries
     for util_dir in ["console", "libnvram", "utils.bin", "utils.source", "vpn"]:
         for f in os.listdir(join(static_dir, util_dir)):
             if f.endswith(arch_suffix) or f.endswith(".all"):
@@ -289,6 +283,15 @@ def make_config(fs, out, artifacts, timeout=None, auto_explore=False):
                     'host_path': f"/igloo_static/{util_dir}/{f}",
                     'mode': 0o755,
                 }
+
+    # Add dynamically-linked libraries
+    dylib_dir = join(static_dir, "dylibs", arch+end)
+    for f in os.listdir(dylib_dir):
+        data['static_files'][f"/igloo/dylibs/{f}"] = dict(
+            type="host_file",
+            host_path=join(dylib_dir, f),
+            mode=0o755,
+        )
 
     data['plugins'] =  default_plugins
 


### PR DESCRIPTION
Note that this PR changes hyperfs, bash, strace, gdbserver, and ltrace to be dynamically linked with musl. The libraries are stored in /igloo/dylibs. MicroPython (and CPython) need dynamic linking for FFI, so I figured it would be easier to just dynamically link everything instead of having a special case for MicroPython.

Closes #220 