### PR TITLE
CI: install deps before releasing container

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,6 +71,10 @@ jobs:
     runs-on: rehosting-arc
     if: github.ref == 'refs/heads/main'
     steps:
+      - name: Setup runner
+        run: |
+              sudo apt-get update;
+              sudo apt-get install -yy curl jq
       - name: Get next version
         uses: reecetech/version-increment@2023.10.1
         id: version


### PR DESCRIPTION
Trying to fix the failure at https://github.com/rehosting/penguin/actions/runs/9388998809/job/25855806691