### PR TITLE
Include nvram keys in fs hash

### DIFF
--- a/src/penguin/utils.py
+++ b/src/penguin/utils.py
@@ -127,6 +127,18 @@ def hash_image_inputs(proj_dir, conf):
             if not data:
                 break
             fs_hash.update(data)
+
+    # Include nvram keys in the hash
+    config_nvram = conf['nvram'] if 'nvram' in conf else {}
+    for k, val in config_nvram.items():
+        if isinstance(val, str):
+            encoded = val.encode()
+        elif isinstance(val, int):
+            encoded = str(val).encode()
+        else:
+            raise ValueError(f"Unknown type for nvram value {k}: {type(val)}")
+        fs_hash.update(encoded)
+
     fs_hash = fs_hash.hexdigest()
 
     # If we ever add other ways to import static files, this assert should


### PR DESCRIPTION
While looking into rehosting/vpnguin#5, I noticed that the lighttpd instance wasn't staying alive on that FW likely due to missing nvram keys. When I modified config.yaml I saw those keys weren't being added to /igloo/libnvram. This PR includes nvram keys in the fs_hash so that we generate a new fs when they update. 