### PR TITLE
Optionally pull custom nmap when building

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -27,6 +27,19 @@ Note that the standard `penguin` wrapper command that we recommend users install
 supports these development options, so you can use these wrapper flags even if
 the `penguin` command is installed for a user or system.
 
+## Private dependencies
+
+Members of penguin development team who wish to use our private nmap fork may build it
+by first launching ssh-agent and then rebuilding their penguin container. This fork is not
+distributed externally (as binaries or source) due to licensing restrictions, but the changes
+are minor.
+
+```sh
+eval $(ssh-agent)
+ssh-agent add ~/.ssh/id_rsa
+penguin --build
+```
+
 ## Dependency Development
 
 If you wish to prototype changes to a Penguin dependency, you can develop the

--- a/penguin
+++ b/penguin
@@ -356,7 +356,13 @@ penguin_run() {
             echo "Current directory is not named penguin and you requested a container rebuild"
             exit 1
         fi
-        DOCKER_BUILDKIT=1 docker build -t $image .
+
+        if [ ! -z "${SSH_AUTH_SOCK+x}" ]; then
+            # Build with ssh
+            DOCKER_BUILDKIT=1 docker build --build-arg SSH=1 --ssh default -t $image .
+        else
+            DOCKER_BUILDKIT=1 docker build -t $image .
+        fi
 
         # If we have no other args, and not build_singularity exit 0
         if [[ ${#new_cmd[@]} -eq 0 && $build_singularity == false ]]; then

--- a/pyplugins/nmap.py
+++ b/pyplugins/nmap.py
@@ -13,6 +13,7 @@ class Nmap(PyPlugin):
         self.ppp.VsockVPN.ppp_reg_cb('on_bind', self.nmap_on_bind)
         self.subprocesses = []
         self.lock = Lock()
+        self.custom_nmap = os.path.isfile("/etc/nmap/.custom")
 
     def nmap_on_bind(self, proto, guest_ip, guest_port, host_port, procname):
         '''
@@ -46,7 +47,7 @@ class Nmap(PyPlugin):
                                    # port (i.e., if 80 we scan for http, even if we're going through 4321)
             ]
             + (["--redirect-port", str(guest_port), str(host_port)  # Pretend we're connecting to guest_port, but internally connect to host_port
-              ] if guest_port != host_port else []) # If ports actually match, we skip this
+              ] if (self.custom_nmap and guest_port != host_port) else []) # If unsupported or guest-host ports actually match, we skip this
             + [
                 "-unprivileged", # Don't try anything privileged
                 "-n", # Do not do DNS resolution


### PR DESCRIPTION
We cannot currently distribute our nmap fork due to licensing issues (trying to resolve!), but we can still use it for local prototyping. Add instructions and modify `penguin --build` and the Dockerfile to support optionally cloning and building our fork. By default standard `nmap` from apt is used instead.

Prior to this PR the head of main will currently fail to build because our nmap repo is private.