### PR TITLE
full_config_paths typo for penguin_static nvram

### DIFF
--- a/src/penguin/penguin_static.py
+++ b/src/penguin/penguin_static.py
@@ -1002,7 +1002,7 @@ def add_nvram_meta(proj_dir, config, output_dir):
         with open(output_dir + "/nvram.csv", 'a') as f:
             writer = csv.writer(f)
             for (path, k), v in path_nvrams.items():
-                writer.writerow(['nvram', path, k, v])
+                writer.writerow(['full_config_paths', path, k, v])
 
     wild_nvrams = {}
     # Still haven't found anything. Try widening the search to include these files as basenames, not full paths


### PR DESCRIPTION
When searching for default nvram values, there was a typo that caused values from `full_config_paths` to be skipped. 

The check:
https://github.com/rehosting/penguin/blob/5797744d7a4299e1dd1830af66ffdffeb87f4dc1/src/penguin/penguin_static.py#L1076
skipped the values from the source `full_config_paths` since they had a source of `nvram`