### PR TITLE
Use ghcr as temporary storage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,17 @@ jobs:
       packages: write
 
     steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: rehosting
+          password: ${{secrets.DOCKERHUB_TOKEN}}
+      
+      - name: Pull latest Docker image for cache
+        run: docker pull rehosting/penguin:latest || true
+      
+      - name: Logout
+        run: docker logout
       
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -26,9 +37,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
-      
-      # - name: Pull latest Docker image for cache
-        # run: docker pull ghcr.io/rehosting/penguin:most_recent_build || true
 
       - name: Build Docker image and push to GHCR
         uses: docker/build-push-action@v5

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,23 +5,6 @@ on:
     branches:
       - main
 jobs:
-    # remove-docker-tag:
-    #   runs-on: ubuntu-latest
-    #   if:  always()
-
-    #   # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
-    #   # (required)
-    #   permissions:
-    #     contents: read
-    #     packages: write
-
-    #   steps:
-    #   - name: Remove Docker Tag
-    #     uses: rafalkk/remove-dockertag-action@v1
-    #     with:
-    #       tag_name: most_recent_build
-    #       github_token: ${{ secrets.GITHUB_TOKEN }}
-
     build_container:
         runs-on: ubuntu-latest
 
@@ -60,9 +43,6 @@ jobs:
               registry: ghcr.io
               username: ${{ github.actor }}
               password: ${{ secrets.GITHUB_TOKEN }}
-
-        #   - name: Push most recent release to GHCR
-            # run: docker tag rehosting/penguin:latest ghcr.io/rehosting/penguin:most_recent_build && docker push ghcr.io/rehosting/penguin:${{ github.sha }}
 
           - name: Create release
             id: create_release


### PR DESCRIPTION
In order to resolve our dockerhub rate limit issues I am proposing a path by which we use ghcr as a temporary storage mechanism for pull requests.

Finalized images will still go to dockerhub.

See discussion #280 

CLOSES: #280 