### PR TITLE
Delete untagged docker versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,3 +112,10 @@ jobs:
       with:
         tag_name: ${{ github.sha }}
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: actions/delete-package-versions@v5
+      with: 
+        package-name: 'penguin'
+        package-type: 'container'
+        min-versions-to-keep: 0
+        delete-only-untagged-versions: 'true'


### PR DESCRIPTION
The previous PR only untagged them. This needs to _delete_ them.

Worth noting that we only delete untagged items so we don't end up with race conditions around CI jobs deleting other docker containers.