### PR TITLE
Fix assumed arguments in main

### DIFF
--- a/src/penguin/__main__.py
+++ b/src/penguin/__main__.py
@@ -146,7 +146,7 @@ def penguin_init(args):
             "Please provide a firmware file"
         )
 
-    if "/host_" in args.rootfs or (args.output and "/host_" in args.output):
+    if "/host_" in args.rootfs or (args.output and args.output.startswith("/host_")):
         logger.info(
             "Note messages referencing /host paths reflect automatically-mapped shared directories based on your command line arguments"
         )


### PR DESCRIPTION
Easy fix. Our current __main__.py assumes that args.output exists. This always exists when we run in ephemeral mode in docker, but isn't actually a required argument.

This fix just checks that it exists first.