### PR TITLE
feat(pseudofiles): build syscall info table in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -370,6 +370,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # this from the host during development. In the long term we'll
 # merge these into the main penguin module
 COPY ./pyplugins/ /pandata
+RUN python3 /pandata/build_syscall_info_table.py
 
 # Default command: echo install instructions
 CMD ["/usr/local/bin/banner.sh"]

--- a/pyplugins/build_syscall_info_table.py
+++ b/pyplugins/build_syscall_info_table.py
@@ -1,0 +1,79 @@
+import re
+import pycparser
+import pickle
+
+
+def make_syscall_info_table():
+    """
+    Table format: arch -> nr -> (name, arg_names).
+    The names do not have a sys_ prefix.
+    """
+
+    def parse_c(input):
+        input = re.sub(r"\b__user\b", "", input)
+        # We don't care about the types. Just replace them with int so parsing succeeds.
+        types = [
+            "size_t",
+            "umode_t",
+            "time_t",
+            "old_uid_t",
+            "old_gid_t",
+            "off_t",
+            "pid_t",
+            "old_sigset_t",
+            "qid_t",
+            "loff_t",
+            "fd_set",
+            "sigset_t",
+            "siginfo_t",
+            "cap_user_header_t",
+            "cap_user_data_t",
+            "uid_t",
+            "gid_t",
+            "timer_t",
+            "u64",
+            "u32",
+            "aio_context_t",
+            "clockid_t",
+            "mqd_t",
+            "key_t",
+            "key_serial_t",
+            "__s32",
+            "old_time32_t",
+            "__sighandler_t",
+            "caddr_t",
+            "__u32",
+            "rwf_t",
+            "uint32_t",
+        ]
+        input = re.sub(rf"\b({'|'.join(types)})\b", "int", input)
+        return pycparser.c_parser.CParser().parse(input)
+
+    def parse_protos_file(arch):
+        with open(f"/igloo_static/syscalls/linux_{arch}_prototypes.txt") as f:
+            lines = [
+                line.split(maxsplit=1)
+                for line in f.readlines()
+                if not line.startswith("//")
+            ]
+
+        return [(int(nr), parse_c(sig)) for nr, sig in lines]
+
+    vals = {
+        arch: {
+            nr: (
+                ast.ext[0].name.replace("sys_", ""),
+                tuple(p.name for p in ast.ext[0].type.args.params),
+            )
+            for nr, ast in parse_protos_file(arch)
+        }
+        for arch in ("arm", "arm64", "mips", "mips64")
+    }
+
+    vals["aarch64"] = vals["arm64"]
+    return vals
+
+
+if __name__ == "__main__":
+    with open("/igloo_static/syscall_info_table.pkl", "wb") as f:
+        pickle.dump(make_syscall_info_table(), f)

--- a/pyplugins/pseudofiles.py
+++ b/pyplugins/pseudofiles.py
@@ -1,4 +1,5 @@
 import logging
+import pickle
 import re
 import struct
 from collections import Counter
@@ -7,10 +8,7 @@ from os.path import dirname, isfile
 from os.path import join as pjoin
 from sys import path as syspath
 from typing import List
-
-import pycparser
 from pandare import PyPlugin
-
 from penguin import getColoredLogger
 
 syspath.append(dirname(__file__))
@@ -108,77 +106,6 @@ def ignore_ioctl_path(path):
     if "/pipe:[" in path:
         return True
     return False
-
-
-def make_syscall_info_table():
-    """
-    Table format: arch -> nr -> (name, arg_names).
-    The names do not have a sys_ prefix.
-    """
-
-    def parse_c(input):
-        input = re.sub(r"\b__user\b", "", input)
-        # We don't care about the types. Just replace them with int so parsing succeeds.
-        types = [
-            "size_t",
-            "umode_t",
-            "time_t",
-            "old_uid_t",
-            "old_gid_t",
-            "off_t",
-            "pid_t",
-            "old_sigset_t",
-            "qid_t",
-            "loff_t",
-            "fd_set",
-            "sigset_t",
-            "siginfo_t",
-            "cap_user_header_t",
-            "cap_user_data_t",
-            "uid_t",
-            "gid_t",
-            "timer_t",
-            "u64",
-            "u32",
-            "aio_context_t",
-            "clockid_t",
-            "mqd_t",
-            "key_t",
-            "key_serial_t",
-            "__s32",
-            "old_time32_t",
-            "__sighandler_t",
-            "caddr_t",
-            "__u32",
-            "rwf_t",
-            "uint32_t",
-        ]
-        input = re.sub(rf"\b({'|'.join(types)})\b", "int", input)
-        return pycparser.c_parser.CParser().parse(input)
-
-    def parse_protos_file(arch):
-        with open(f"/igloo_static/syscalls/linux_{arch}_prototypes.txt") as f:
-            lines = [
-                line.split(maxsplit=1)
-                for line in f.readlines()
-                if not line.startswith("//")
-            ]
-
-        return [(int(nr), parse_c(sig)) for nr, sig in lines]
-
-    vals = {
-        arch: {
-            nr: (
-                ast.ext[0].name.replace("sys_", ""),
-                tuple(p.name for p in ast.ext[0].type.args.params),
-            )
-            for nr, ast in parse_protos_file(arch)
-        }
-        for arch in ("arm", "arm64", "mips", "mips64")
-    }
-
-    vals["aarch64"] = vals["arm64"]
-    return vals
 
 
 class FileFailures(PyPlugin):
@@ -320,7 +247,8 @@ class FileFailures(PyPlugin):
         # Clear results file - we'll update it as we go
         self.dump_results()
 
-        self.syscall_info_table = make_syscall_info_table()
+        with open("/igloo_static/syscall_info_table.pkl", "rb") as f:
+            self.syscall_info_table = pickle.load(f)
 
         self.ppp.Events.listen("igloo_syscall", self.on_syscall)
 
@@ -329,6 +257,8 @@ class FileFailures(PyPlugin):
         # did it in the kernel
         self.ppp.Events.listen("igloo_open", self.fail_detect_opens)
         self.ppp.Events.listen("igloo_ioctl", self.fail_detect_ioctl)
+
+        self.ppp.Events.listen('igloo_proc_mtd', self.proc_mtd_check)
 
         # On ioctl return we might want to start symex. We detect failures with a special handler though
         if need_ioctl_hooks:


### PR DESCRIPTION
This PR simply pickles the results of the pseudofile table build and adds it to the docker build.

In effect, this makes our docker build 11 seconds slower, but every subsequent run nearly 11 seconds faster.

CLOSES: #320 