### PR TITLE
feat(init): always bring lo up

### DIFF
--- a/src/resources/init.sh
+++ b/src/resources/init.sh
@@ -103,6 +103,7 @@ for iface in $(/igloo/utils/busybox cat /proc/penguin_net); do
   /igloo/utils/busybox ip link set $iface up
 done
   /igloo/utils/busybox ip link delete dummy0 || true
+  /igloo/utils/busybox ip link set lo up || true
 
 
 ## Add a bridge with eth0 and assign it an IP

--- a/tests/unit_tests/test_target/scripts/init.sh
+++ b/tests/unit_tests/test_target/scripts/init.sh
@@ -103,6 +103,7 @@ for iface in $(/igloo/utils/busybox cat /proc/penguin_net); do
   /igloo/utils/busybox ip link set $iface up
 done
   /igloo/utils/busybox ip link delete dummy0 || true
+  /igloo/utils/busybox ip link set lo up || true
 
 
 ## Add a bridge with eth0 and assign it an IP


### PR DESCRIPTION
Trying to fix issues we've seen with the VPN where `lo` ends up down breaking our ability to connect to localhost.