### PR TITLE
(fix) empty_fs: don't prepend project path twice

### DIFF
--- a/src/penguin/penguin_config.py
+++ b/src/penguin/penguin_config.py
@@ -715,9 +715,10 @@ def load_config(path):
             config = patch_config(config, patch_relocated)
     _validate_config(config)
     if config["core"]["fs"] is None:
-        config["core"]["fs"] = os.path.join(config_folder, "./base/empty_fs.tar.gz")
-        if not os.path.exists(config["core"]["fs"]):
-            construct_empty_fs(config["core"]["fs"])
+        config["core"]["fs"] = "./base/empty_fs.tar.gz"
+        empty_fs_path = os.path.join(config_folder, "./base/empty_fs.tar.gz")
+        if not os.path.exists(empty_fs_path):
+            construct_empty_fs(empty_fs_path)
     return config
 
 


### PR DESCRIPTION
When constructing an empty_fs we prepend the project path to `config["core"]["fs"]` twice:
https://github.com/rehosting/penguin/blob/f41fef48bf80acf2508be6278fdbce86f8cf97b0/src/penguin/penguin_config.py#L717-L720

https://github.com/rehosting/penguin/blob/f41fef48bf80acf2508be6278fdbce86f8cf97b0/src/penguin/penguin_run.py#L202

This PR changes it so that we set the config to use `./base/empty_fs.tar.gz` when we detect `config["core"]["fs"]` is unset