### PR TITLE
fix(penguin_static): do not try to recreate existing files in /mnt

### DIFF
--- a/src/penguin/penguin_static.py
+++ b/src/penguin/penguin_static.py
@@ -341,6 +341,8 @@ def pre_shim(proj_dir, config, settings):
                 for dest in list(
                     set(find_strings_in_file(f, "^/mnt/[a-zA-Z0-9._/]+$"))
                 ):
+                    if dest in existing:
+                        continue
                     config["static_files"][dest] = {"type": "dir", "mode": 0o755}
 
         for fname in settings.get("always_add", []):


### PR DESCRIPTION
Previously our static analysis might suggest we need to create a directory in `/mnt` which was a file that would already exist. That would trigger a fatal error while creating the image.

This PR simply adds a check to ensure the directory being added into a config doesn't already exist in the filesystem.