### PR TITLE
fix(dockerfile): copy libnvram from local_packages if present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -431,8 +431,11 @@ RUN if [ -d /tmp/local_packages ]; then \
             rm -rf /result && \
             for f in  /igloo_static/utils.bin/*.arm64; do mv -- "$f" "${f%.arm64}.aarch64"; done; \
         fi; \
+        if [ -f /tmp/local_packages/libnvram-latest.tar.gz ]; then \
+            rm -rf /igloo_static/libnvram; \
+            tar xzf /tmp/local_packages/libnvram-latest.tar.gz -C /igloo_static; \
+        fi; \
         if [ -f /tmp/local_packages/pandare-*.whl ]; then \
-            echo "Installing local pandare wheel"; \
             pip install /tmp/local_packages/pandare-*.whl; \
         fi; \
     fi


### PR DESCRIPTION
Minor enhancement to help with development - previously libnvram wouldn't be copied from a local (source!) archive