### PR TITLE
(fix) use base_config["core"]["version"] for explore, not VERSION

### DIFF
--- a/src/penguin/manager.py
+++ b/src/penguin/manager.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from threading import Thread
 from typing import List, Tuple
 
-from penguin import getColoredLogger, VERSION
+from penguin import getColoredLogger
 
 from .common import yaml
 from .graphs import Configuration, ConfigurationManager, Failure, Mitigation
@@ -661,7 +661,7 @@ class GlobalState:
             "kernel": base_config["core"]["kernel"],
             "show_output": show_output,
             "root_shell": root_shell,
-            "version": VERSION,
+            "version": base_config["core"]["version"],
         }
         del base_config["core"]  # Nobody should use base, ask us instead!
         if not os.path.isfile(os.path.join(proj_dir, self.info["fs"])):


### PR DESCRIPTION
This PR avoids a bug where we end up comparing the penguin version to the config version when validating configs during exploration.