### PR TITLE
fix(pseudofiles): handle non-latin characters

### DIFF
--- a/pyplugins/pseudofiles.py
+++ b/pyplugins/pseudofiles.py
@@ -333,8 +333,8 @@ class FileFailures(PyPlugin):
         # assert(ret == -2), f"Unexpected return value {ret} from igloo_syscall"
         # assert name not in ('open', 'openat', 'ioctl', 'close'), f"Unexpected syscall {name} in igloo_syscall"
 
-        # Use null terminator and interpret as UTF-8
-        strings = [s.split(b"\0", 1)[0].decode() for s in strings]
+        # Use null terminator and interpret as latin-1
+        strings = [s.split(b"\0", 1)[0].decode("latin-1", errors="ignore") for s in strings]
 
         fnames = (
             strings[i]


### PR DESCRIPTION
Kept hitting this on a firmware:
```
ESC[32m22:09:45ESC[0m ESC[34mpenguin.runnerESC[0m ESC[1;30mERRORESC[0m ESC[31m'utf-8' codec can't decode byte 0xc0 in position 16: invalid start byteESC[0m
Traceback (most recent call last):
  File "ESC[1;34m/pkg/penguin/penguin_run.py",ESC[0m line 534, in _run
    panda.run()
  File "ESC[1;34m/usr/local/lib/python3.10/dist-packages/pandare/panda.py",ESC[0m line 556, in run
    raise saved_exception
  File "ESC[1;34m/usr/local/lib/python3.10/dist-packages/pandare/panda.py",ESC[0m line 3509, in _run_and_catch
    fun(*args, **kwargs)
  File "ESC[1;34m/pandata/core.py",ESC[0m line 295, in generic_hypercall
    fn(*args)
  File "ESC[1;34m/pandata/pseudofiles.py",ESC[0m line 337, in on_syscall
    strings = [s.split(b"\0", 1)[0].decode() for s in strings]
  File "ESC[1;34m/pandata/pseudofiles.py",ESC[0m line 337, in <listcomp>
    strings = [s.split(b"\0", 1)[0].decode() for s in strings]
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc0 in position 16: invalid start byte-
```

This PR makes it so we start with utf-8 and then explicitly fall back to latin-1 for characters that fail.