### PR TITLE
fix(init): inline source.d based init scripts for now

### DIFF
--- a/src/penguin/gen_config.py
+++ b/src/penguin/gen_config.py
@@ -201,14 +201,13 @@ def make_config(fs, out, artifacts, settings, timeout=None, auto_explore=False):
     }
 
     # Copy over the scripts that /igloo/init sources so that users can modify them
-    base_source_d = os.path.join(output_dir, "base", "source.d")
-    shutil.copytree(os.path.join(*[dirname(dirname(__file__)), "resources", "source.d"]),
-                    base_source_d, dirs_exist_ok=True)
-    data["static_files"]["/igloo/source.d/*"] = {
-        "type": "host_file",
-        "host_path": f"{base_source_d}/*",
-        "mode": 0o755,
-    }
+    source_d_dir = join(*[dirname(dirname(__file__)), "resources", "source.d"])
+    for f in os.listdir(source_d_dir):
+        data["static_files"][f"/igloo/source.d/{f}"] = {
+            "type": "inline_file",
+            "contents": open(os.path.join(source_d_dir, f)).read(),
+            "mode": 0o755,
+        }
 
     data["static_files"]["/igloo/keys/*"] = {
         "type": "host_file",


### PR DESCRIPTION
This PR is to address a bug introduced in the refactoring of init.sh in #413. This is intended to be a stopgap fix as discussed in #439. It makes what's going with init a bit more opaque, but I don't think we intend for this to be a long-term solution. 