### PR TITLE
handle broken libc symlinks

### DIFF
--- a/src/penguin/penguin_static.py
+++ b/src/penguin/penguin_static.py
@@ -1475,6 +1475,9 @@ def add_lib_inject_symlinks(proj_dir, conf):
         except ELFError:
             # Not an ELF. It could be for example a GNU ld script.
             continue
+        except KeyError:
+            # it is possible to have bad libc symlinks
+            continue
         abi = arch_filter(e).abi
         resolved_path = str(Path("/", os.path.dirname(p), "lib_inject.so"))
         conf["static_files"][resolved_path] = dict(


### PR DESCRIPTION
#461 describes a situation where our lib_inject symbols can fail.

Our lib_inject injects itself into any library where libc* is present.

Here we run into an odd scenario where libc is a broken symlink.

This fix just allows us to notice the broken symlink and move on.

In all scenarios I looked at in #461 there was a correct libc in the folder where the symlink was wrong.