### PR TITLE
fix(vhost-device-vsock): pin to a working version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,14 @@ ARG GUM_VERSION="0.14.5"
 ARG LTRACE_PROTOTYPES_VERSION="0.7.91"
 ARG LTRACE_PROTOTYPES_HASH="9db3bdee7cf3e11c87d8cc7673d4d25b"
 ARG MUSL_VERSION="1.2.5"
+ARG VHOST_DEVICE_VERSION="vhost-device-vsock-v0.2.0"
 
 FROM rust as vhost_builder
-RUN git clone -q https://github.com/rust-vmm/vhost-device/ /root/vhost-device
+RUN git clone --depth 1 -q https://github.com/rust-vmm/vhost-device/ /root/vhost-device
+ARG VHOST_DEVICE_VERSION
 RUN cd /root/vhost-device/ && \
+  git fetch --depth 1 origin tag $VHOST_DEVICE_VERSION && \
+  git checkout $VHOST_DEVICE_VERSION && \
   RUSTFLAGS="-C target-feature=+crt-static" PATH="/root/.cargo/bin:${PATH}" cargo build --release --bin vhost-device-vsock --target x86_64-unknown-linux-gnu
 
 ### DOWNLOADER ###


### PR DESCRIPTION
Some dependencies in [vhost-device](https://github.com/rust-vmm/vhost-device) have changed and break fresh penguin container builds. This PR pins us to the latest tagged release of vhost-device-vsock