### PR TITLE
make manual default instead of single_shot

### DIFF
--- a/src/penguin/config_patchers.py
+++ b/src/penguin/config_patchers.py
@@ -579,7 +579,7 @@ class SingleShotFICD(PatchGenerator):
 
     def __init__(self):
         self.patch_name = "single_shot_ficd"
-        self.enabled = True
+        self.enabled = False
 
     def generate(self, patches):
         return {
@@ -664,7 +664,7 @@ class ManualInteract(PatchGenerator):
 
     def __init__(self):
         self.patch_name = "manual"
-        self.enabled = False
+        self.enabled = True
 
     def generate(self, patches):
         return {

--- a/src/penguin/gen_config.py
+++ b/src/penguin/gen_config.py
@@ -172,7 +172,6 @@ class ConfigBuilder:
             CP.BasePatch(static_results['ArchId'], static_results['InitFinder']),
             CP.RootShell(),
             CP.DynamicExploration(),
-            # SingleShot(),
             CP.SingleShotFICD(),
             CP.ManualInteract(),
             CP.NetdevsDefault(),


### PR DESCRIPTION
In the recently merged `exps` branch, `penguin run` defaults to starting rehosting with "single shot, exit on www response or initialization complete." This PR changes to default to match current behavior and a more interactive rehosting that runs indefinitely.