### PR TITLE
fix(auto_patching): parsing bug when autopatching enabled; make auto_patching default on again

### DIFF
--- a/src/penguin/gen_config.py
+++ b/src/penguin/gen_config.py
@@ -146,6 +146,7 @@ class ConfigBuilder:
                 "strace": False,
                 "ltrace": False,
                 "version": DEFAULT_VERSION,
+                "auto_patching": True,
             },
             "patches": patch_filenames,
             "env": {},

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -759,7 +759,7 @@ def load_config(proj_dir, path, validate=True):
         config = yaml.load(f, Loader=CoreLoader)
     # look for files called patch_*.yaml in the same directory as the config file
     if config["core"].get("auto_patching", False) is True:
-        patch_files = list(proj_dir.glob("patch_*.yaml"))
+        patch_files = list(Path(proj_dir).glob("patch_*.yaml"))
         patches_dir = Path(proj_dir, "patches")
         if patches_dir.exists():
             patch_files += list(patches_dir.glob("*.yaml"))


### PR DESCRIPTION
Addresses a bug from the exps/main rebase. 

When auto_patching was enabled (see #374), this error would occur:
```
  File "/pkg/penguin/penguin_config/structure.py", line 762, in load_config
    patch_files = list(proj_dir.glob("patch_*.yaml"))
 ```
But auto_patching was set to default off so this was a hidden from new configs. This PR also restores auto_patching to on by default.