### PR TITLE
feat(show_output): have output in both console.log and stdout

### DIFF
--- a/src/penguin/penguin_run.py
+++ b/src/penguin/penguin_run.py
@@ -326,7 +326,10 @@ def run_config(
 
     if "show_output" in conf["core"] and conf["core"]["show_output"]:
         logger.info("Logging console output to stdout")
-        console_out = ["-serial", "mon:stdio"]
+        console_out = [
+                "-chardev", f"stdio,id=char1,logfile={out_dir}/console.log,signal=off",
+                "-serial", "chardev:char1"
+                ]
     else:
         logger.info(f"Logging console output to {out_dir}/console.log")
         console_out = [


### PR DESCRIPTION
Resolves https://github.com/rehosting/penguin/issues/407
i can make it such that the telnet will be logged to telnet.log with 
```
"-chardev", f"socket,id=telnet0,port=4444,host=0.0.0.0,logfile={out_dir}/telnet.log,server=on,wait=off",
"-serial", "chardev:telnet0"
```
in replace of how telnet is currently spun up. however, this makes the telnet session slightly grosser because it will get echos. we could make an additional config option for when we want to log our telnet sessions and then depending on that option start telnet accordingly. 