### PR TITLE
Fix mistakenly renamed nvramd.pid missing file intervention

### DIFF
--- a/src/penguin/config_patchers.py
+++ b/src/penguin/config_patchers.py
@@ -1159,7 +1159,7 @@ class GenerateShellMounts(PatchGenerator):
 
 class GenerateMissingFiles(PatchGenerator):
     '''
-    Ensure we have /bin/sh, /etc/TZ, /var/run/libnvram.pid.
+    Ensure we have /bin/sh, /etc/TZ, /var/run/nvramd.pid.
     Ensure /etc/hosts has an entry for localhost
     '''
 
@@ -1176,16 +1176,22 @@ class GenerateMissingFiles(PatchGenerator):
         result = defaultdict(dict)
 
         model = {
+            # Ensure /bin/sh exists if not already present
             "/bin/sh": {
                 "type": "symlink",
                 "target": "/igloo/utils/busybox"
             },
+
+            # Set timezone to EST
             "/etc/TZ": {
                 "type": "inline_file",
                 "contents": "EST5EDT",
                 "mode": 0o755,
             },
-            "/var/run/libnvram.pid": {
+
+            # Needed for Ralink and D-Link
+            # See https://github.com/firmadyne/libnvram/blob/e33692277d475d61a03e0772efeef5c829872f34/nvram.c#L189
+            "/var/run/nvramd.pid": {
                 "type": "inline_file",
                 "contents": "",
                 "mode": 0o644,


### PR DESCRIPTION
Our previous implementation referenced nvramd.pid: https://github.com/rehosting/penguin/blob/c7f1c6ff9c09dae8a3c0f8010c25489feb6857e5/src/penguin/penguin_static.py#L376-L380

However it appears the conversation in this issue https://github.com/rehosting/penguin/issues/196#issuecomment-2176290083

resulted in nvramd.pid being renamed to libnvram.pid (which has no results in literature and doesn't really make sense).


PR is to revert that and add some comments about the context surrounding this intervention.