### PR TITLE
Fix core.guest_cmd option being ignored

### DIFF
--- a/src/penguin/config_patchers.py
+++ b/src/penguin/config_patchers.py
@@ -444,17 +444,6 @@ class BasePatch(PatchGenerator):
                     "mode": 0o444,
                     "host_path": os.path.join(*[STATIC_DIR, "ltrace", "*"]),
                 },
-                # GuestCmd stuff
-                "/igloo/utils/guesthopper": {
-                    "type": "host_file",
-                    "mode": 0o755,
-                    "host_path": "/igloo_static/guesthopper/guesthopper."+self.arch_dir
-                },
-                "/igloo/init.d/guesthopper": {
-                    "type": "inline_file",
-                    "mode": 0o755,
-                    "contents": "RUST_LOG=info /igloo/utils/guesthopper -s /igloo/utils/sh &",
-                },
 
                 # Dynamic libraries
                 "/igloo/dylibs/*": {


### PR DESCRIPTION
The `core.guest_cmd` option is intended to allow disabling guesthopper, but guesthopper seems to be enabled no matter what. This PR makes guesthopper only enabled when `core.guest_cmd: true`, but it will only work for configs generated after this change.