### PR TITLE
support for changing source addr in vpn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ ARG LINUX_VERSION="2.4.19"
 ARG LIBNVRAM_VERSION="0.0.16"
 ARG CONSOLE_VERSION="1.0.5"
 ARG PENGUIN_PLUGINS_VERSION="1.5.15"
-ARG VPN_VERSION="1.0.18"
+ARG VPN_VERSION="1.0.19"
 ARG HYPERFS_VERSION="0.0.38"
-ARG GUESTHOPPER_VERSION="1.0.12"
+ARG GUESTHOPPER_VERSION="1.0.15"
 ARG GLOW_VERSION="1.5.1"
 ARG GUM_VERSION="0.14.5"
 ARG LTRACE_PROTOTYPES_VERSION="0.7.91"
@@ -262,7 +262,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
       setuptools \
       sqlalchemy \
       yamlcore \
-      junit-xml
+      junit-xml \
+      jc
 
 
 FROM python_builder AS version_generator


### PR DESCRIPTION
This PR closes #498 , adding a feature to vpnguin where users can specify a source address for services that expect a particular source ip. We accomplish this by configuring one of the dummy devices on the system with that address and then have the client side of vpnguin bind to that address.

We use the `guest_cmd` feature to stand up the interface if it is not configured.

Example usage:
```yaml
plugins:
  vpn:
    depends_on: core
    spoof:
      "tcp:192.168.1.1:5678":
        source: 10.10.10.1
        dev: eth1
      "udp:192.168.1.1:12345":
        source: 10.10.10.1
        dev: eth1
```

Tested with TCP and UDP services that process the incoming source address, as well as various firmware that we've seen stand up multiple network services.

Note: this PR should be merged after https://github.com/rehosting/vpnguin/pull/19 , with the correct `VPN_VERSION` in the penguin Dockerfile. The current `VPN_VERSION` in this branch is a guess and build will fail for now.