### PR TITLE
shims: only trim leading char if it's a .

### DIFF
--- a/src/penguin/config_patchers.py
+++ b/src/penguin/config_patchers.py
@@ -1345,7 +1345,7 @@ class ShimBinaries:
     def make_shims(self, shim_targets):
         result = defaultdict(dict)
         for fname in self.files:
-            path = fname.path[1:]  # Trim leading .
+            path = fname.path.lstrip('.')  # Trim leading .
             basename = os.path.basename(path)
 
             if path.startswith("/igloo/utils/"):
@@ -1362,6 +1362,7 @@ class ShimBinaries:
 
             # Is the current file one we want to shim?
             if basename in shim_targets:
+                logger.debug(f"making shim for {basename}, full path: {path}, fname.path: {fname.path}")
                 result["static_files"][path] = {
                     "type": "shim",
                     "target": f"/igloo/utils/{shim_targets[basename]}",


### PR DESCRIPTION
`fw2tar` generates paths in `./`, which we assume and remove when making shims. This PR just makes sure that what we remove is actually a `.` in case we get a rootfs without `./`.