### PR TITLE
make kernel cmdline option "quiet" a parameter

### DIFF
--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -351,6 +351,23 @@ Allows users to customize memory allocation for guest
 2G
 ```
 
+### `core.kernel_quiet` Whether to include quiet flag in kernel command line
+
+|||
+|-|-|
+|__Type__|boolean|
+|__Default__|`true`|
+
+If true, the kernel command line will include the quiet flag, otherwise all kernel boot messages will be printed to the console
+
+```yaml
+false
+```
+
+```yaml
+true
+```
+
 ## `patches` Patches
 
 |||

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -259,6 +259,15 @@ class Core(BaseModel):
             examples=["16K", "512M", "1G", "2G"],
             ),
     ]
+    kernel_quiet: Annotated[
+        bool,
+        Field(
+            True,
+            title="Whether to include quiet flag in kernel command line",
+            description="If true, the kernel command line will include the quiet flag, otherwise all kernel boot messages will be printed to the console",
+            examples=[False, True],
+        ),
+    ]
 
 
 EnvVal = _newtype(

--- a/src/penguin/penguin_run.py
+++ b/src/penguin/penguin_run.py
@@ -273,7 +273,9 @@ def run_config(
             "vhost-user-vsock-pci,chardev=char0",
         ]
 
-    append = f"root={ROOTFS} init=/igloo/init console=ttyS0 rw quiet panic=1"  # Required
+    append = f"root={ROOTFS} init=/igloo/init console=ttyS0 rw panic=1"  # Required
+    if "kernel_quiet" in conf["core"] and conf["core"]["kernel_quiet"]:
+        append += " quiet"
     append += " rootfstype=ext2 norandmaps nokaslr"  # Nice to have
     append += (
         " clocksource=jiffies nohz_full nohz=off no_timer_check"  # Improve determinism?


### PR DESCRIPTION
This PR parametrizes adding `quiet` to the kernel command line, which can be helpful for troubleshooting/debugging.