### PR TITLE
warning if input rootfs doesn't have leading ./

### DIFF
--- a/src/penguin/gen_image.py
+++ b/src/penguin/gen_image.py
@@ -535,8 +535,9 @@ def make_image(fs, out, artifacts, proj_dir, config_path):
         MODIFIED_TARBALL = Path(ARTIFACTS, f"fs_out_{suffix}.tar")
         config = load_config(proj_dir, config_path)
         with tempfile.TemporaryDirectory() as TMP_DIR:
-            first_entry = check_output(["tar", "xvpsf", IN_TARBALL, "-C", TMP_DIR]).splitlines()[0]
-            if first_entry != b"./":
+            contents = check_output(["tar", "xvpsf", IN_TARBALL, "-C", TMP_DIR]).splitlines()
+            # Gracefully handle emptyfs
+            if contents and contents[0] != b"./":
                 logger.warning("Filesystem tar does not have a leading ./")
                 logger.warning("You may encounter strange errors due to unexpected rootfs format!")
                 logger.warning("You can resolve this by running fw2tar on your filesystem.")


### PR DESCRIPTION
This PR adds a warning if the input filesystem does not have a leading `./`. Even though we tell users [they can bring hand-packages filesystems](https://github.com/rehosting/penguin/blob/main/README.md?plain=1#L16) our filesystem analyses can be fragile (e.g., #534) and expect that format. It would be good to make those analyses more robust, but also difficult to catch all edge cases so I'm proposing this warning.

In the future, we could also consider looking for fw2tar metadata since we now [insert metadata into our rootfs archives](https://github.com/rehosting/fw2tar/commit/c16b25ee79bc931227a86c880eeadecffff277e5).