### PR TITLE
library_symbols: support ar; ignore nm output for stripped libs

### DIFF
--- a/src/penguin/static_analyses.py
+++ b/src/penguin/static_analyses.py
@@ -743,7 +743,8 @@ class LibrarySymbols(StaticAnalysis):
                     for symname, offset in found_syms.items():
                         symbols[(tmpless_path, symname)] = offset
                     for key, value in found_nvram.items():
-                        nvram[(tmpless_path, key)] = value
+                        nvram_key = key.rsplit(":", 1)[-1]  # Handle case of value coming from ar
+                        nvram[(tmpless_path, nvram_key)] = value
 
         # Raw data will be library path -> key -> value
         nvram_values = {}


### PR DESCRIPTION
Closes #565
When a `.so`is an `ar` archive `nm` rightfully analyzes it but penguin's nm parsing does not handle this well. 

Originally mitigated with a simple:
```
elif "no symbols" in line or line.endswith(".o:"):                                                                     
  continue  
```
but opted to unpack the archive and analyze each file individually, just to be a little more robust. `LibrarySymbols.yaml` would now have colon-separated output to make it more clear that there would be e.g., a `.o` inside a `.so`