### PR TITLE
Change `#!/bin/bash` to `#!/usr/bin/env bash`

### DIFF
--- a/penguin
+++ b/penguin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 


### PR DESCRIPTION
This is more portable, since `bash` isn't guaranteed to be in `/bin/bash`, but `/usr/bin/env` is much more likely to exist.