### PR TITLE
Pseudofiles ignore /proc/vmcore

### DIFF
--- a/src/penguin/static_analyses.py
+++ b/src/penguin/static_analyses.py
@@ -511,7 +511,7 @@ class PseudofileFinder(StaticAnalysis):
     # Directories that we want to just ignore entirely - don't create any entries
     # within these directories. IRQs and device-tree are related to the emulated CPU
     # self and PID are related to the process itself and dynamically created
-    PROC_IGNORE = ["irq", "self", "PID", "device-tree", "net"]
+    PROC_IGNORE = ["irq", "self", "PID", "device-tree", "net", "vmcore"]
 
     def __init__(self):
         # Load ../resources/proc_sys.txt, add each line to IGLOO_PROCFS


### PR DESCRIPTION
This PR adds `/proc/vmcore` to the ignore list for dynamic pseudofile generation since some systems might check for a kernel core dump and start and we don't want to give the impression that one exists.