### PR TITLE
Throw away most monitoring input right before starting guest init

### DIFF
--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -406,6 +406,23 @@ false
 true
 ```
 
+### `core.early_monitoring` Includde early boot in monitoring output
+
+|||
+|-|-|
+|__Type__|boolean|
+|__Default__|`false`|
+
+Whether to enable monitoring of all boot activity (mostly rehosting initialization irrelavant to the firmware)
+
+```yaml
+false
+```
+
+```yaml
+true
+```
+
 ## `patches` Patches
 
 |||

--- a/pyplugins/analysis/coverage.py
+++ b/pyplugins/analysis/coverage.py
@@ -5,9 +5,17 @@ from pandare2 import PyPlugin
 class Coverage(PyPlugin):
     def __init__(self, panda):
         self.outdir = self.get_arg("outdir")
-        panda.load_plugin("track_proc_hc")
-        panda.load_plugin("proc_map", {"outfile": self.outdir + "/coverage_tree.csv"})
-        panda.load_plugin("pandata_cov", {"outfile": self.outdir + "/coverage.csv"})
+        config = self.get_arg("conf")
+        self.panda = panda
+        if config["core"].get("early_monitoring", False):
+            self.start_coverage()
+        else:
+            self.panda.subscribe("igloo_init_done", self.start_coverage)
+
+    def start_coverage(self, *args, **kwargs):
+        self.panda.load_plugin("track_proc_hc")
+        self.panda.load_plugin("proc_map", {"outfile": self.outdir + "/coverage_tree.csv"})
+        self.panda.load_plugin("pandata_cov", {"outfile": self.outdir + "/coverage.csv"})
 
         # Must enable this in kernel boot args, otherwise kernel won't hypercall with memory layout info
         self.get_arg("conf")["env"]["igloo_log_cov"] = "1"

--- a/pyplugins/core.py
+++ b/pyplugins/core.py
@@ -8,6 +8,7 @@ from pandare2 import PyPlugin
 
 from penguin import getColoredLogger
 from penguin.defaults import vnc_password
+from penguin import plugins as penguin_plugins
 
 try:
     from penguin import yaml
@@ -150,6 +151,15 @@ class Core(PyPlugin):
                 args=(panda, timeout, self.shutdown_event),
             )
             self.shutdown_thread.start()
+
+        penguin_plugins.subscribe(penguin_plugins.Events, "igloo_init_done", self.init_done)
+
+    def init_done(self, *args, **kwargs):
+        self.logger.debug("Received igloo_init_done event, executing igloo_init task")
+        config = self.get_arg("conf")
+        if not config["core"].get("early_monitoring", False):
+            with open(os.path.join(self.outdir, "console.log"), "r+") as f:
+                f.truncate(0)
 
     def shutdown_after_timeout(self, panda, timeout, shutdown_event):
         wait_time = 0

--- a/pyplugins/hyper/events.py
+++ b/pyplugins/hyper/events.py
@@ -26,6 +26,8 @@ EVENTS = {
     0xB335A535:         ('igloo_send_hypercall',  (None, int, int)),
     # crc32("busybox")
     0x8507FAE1:         ('igloo_shell',           (int, int, int)),
+    # Bad 1337speak for INITDONE
+    0x1417D04E:         ('igloo_init_done',        ()),
 }
 
 

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -271,6 +271,15 @@ class Core(BaseModel):
             examples=[False, True],
         ),
     ]
+    early_monitoring: Annotated[
+        bool,
+        Field(
+            False,
+            title="Includde early boot in monitoring output",
+            description="Whether to enable monitoring of all boot activity (mostly rehosting initialization irrelavant to the firmware)",
+            examples=[False, True],
+        ),
+    ]
 
 
 EnvVal = _newtype(

--- a/src/resources/init.sh
+++ b/src/resources/init.sh
@@ -17,6 +17,7 @@ fi
 
 if [ ! -z "${igloo_init}" ]; then
   echo '[IGLOO INIT] Running specified init binary';
+  /igloo/utils/send_hypercall_raw 0x1417D04E > /dev/null
   exec "${igloo_init}"
 fi
 echo "[IGLOO INIT] Fatal: no igloo_init specified in env. Abort"


### PR DESCRIPTION
This PR is an attempt to increase the signal-to-noise ratio when troubleshooting rehostings. We add a new `early_monitoring` option to `core`, which is default `false`.

In `init.sh`, we now issue a hypercall right before calling `igloo_init`. If `early_monitoring` is not true we:
* discard buffered db events
* truncate `console.log` - messy since PANDA has it open, if we really wanted we could add a `reset` thing to PANDA 
* reset the state of the health plugin

The implementation might be somewhat messy and a few different approaches are taken per monitoring plugin. For simplicity, this event is used only by plugins where their state seemed relevant (e.g., `netbinds` really shouldn't be hit during early boot).