### PR TITLE
Dockerfile: fix failing python_lzo "no such file or directory"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -368,7 +368,7 @@ RUN git clone --depth=1 https://github.com/ReFirmLabs/binwalk /binwalk && \
 COPY --from=python_builder /app/wheels /wheels
 
 # Remove python_lzo 1.0 to resolve depdency collision with vmlinux-to-elf
-RUN rm /wheels/python_lzo*
+RUN rm -rf /wheels/python_lzo*
 
 RUN pip install --no-cache /wheels/*
 


### PR DESCRIPTION
Our dockerfile fails attempting to delete python_lzo for a claimed collision with vmlinux-to-elf.

It's not clear that this is still necessary, but making it so that the `rm` doesn't fail is a simple fix.