### PR TITLE
hash binaries going into /igloo/boot; refactor arch_dir

### DIFF
--- a/src/penguin/config_patchers.py
+++ b/src/penguin/config_patchers.py
@@ -22,6 +22,7 @@ from .defaults import (
     DEFAULT_KERNEL,
     static_dir as STATIC_DIR
 )
+from .utils import get_arch_subdir
 
 logger = getColoredLogger("penguin.config_patchers")
 
@@ -372,35 +373,21 @@ class BasePatch(PatchGenerator):
         if arch is None:
             raise NotImplementedError(f"Architecture {arch_identified} not supported ({arch}, {endian})")
 
-        self.dylib_dir = None
-        if arch == "aarch64":
-            # TODO: We should use a consistent name here. Perhaps aarch64eb?
-            self.arch_name = "aarch64"
-            self.arch_dir = "aarch64"
+        mock_config = {"core": {"arch": arch_identified}}
+
+        self.arch_name = arch_identified
+        self.arch_dir = get_arch_subdir(mock_config)
+
+        if arch_identified == "aarch64":
             self.dylib_dir = "arm64"
-        elif arch == "intel64":
-            self.arch_name = "intel64"
-            self.arch_dir = "x86_64"
-        elif arch == "loongarch64":
-            self.arch_name = "loongarch64"
-            self.arch_dir = "loongarch64"
+        elif arch_identified == "intel64":
+            self.dylib_dir = "x86_64"
+        elif arch_identified == "loongarch64":
             self.dylib_dir = "loongarch"
-        elif arch == "riscv64":
-            self.arch_name = "riscv64"
-            self.arch_dir = "riscv64"
-        elif arch == "powerpc":
-            self.arch_name = "powerpc"
-            self.arch_dir = "powerpc"
-        elif arch == "powerpc64":
-            self.arch_name = "powerpc64"
-            self.arch_dir = "powerpc64"
+        elif arch_identified in ["powerpc64", "powerpc64el"]:
             self.dylib_dir = "ppc64"
-        elif arch == "powerpc64el":
-            self.arch_name = "powerpc64"
-            self.arch_dir = "powerpc64"
         else:
-            self.arch_name = arch + endian
-            self.arch_dir = f"{arch}{endian}"
+            self.dylib_dir = self.arch_dir
 
     def generate(self, patches):
         # Add serial device in pseudofiles

--- a/src/penguin/gen_image.py
+++ b/src/penguin/gen_image.py
@@ -6,7 +6,8 @@ import tempfile
 from pathlib import Path
 from subprocess import check_output
 from random import randint
-from penguin.defaults import default_preinit_script, static_dir as STATIC_DIR
+from penguin.defaults import default_preinit_script
+from penguin.utils import get_arch_dir
 import tarfile
 import time
 import io
@@ -39,13 +40,7 @@ def get_mount_type(path):
 
 
 def tar_add_min_files(tf_path, config):
-    arch = config["core"]["arch"]
-    if arch == "intel64":
-        arch_dir = "x86_64"
-    elif arch == "powerpc64el":
-        arch_dir = "powerpc64"
-    else:
-        arch_dir = arch
+    arch_dir = get_arch_dir(config)
     with tarfile.open(tf_path, "a") as tf:
         # Add igloo/ directory
         igloo_dir = tarfile.TarInfo(name="igloo/")
@@ -73,13 +68,13 @@ def tar_add_min_files(tf_path, config):
         ti.gname = "root"
         tf.addfile(ti, fileobj=io.BytesIO(init_bytes))
         # /igloo/boot/busybox
-        busybox_path = f"{STATIC_DIR}/{arch_dir}/busybox"
+        busybox_path = os.path.join(arch_dir, "busybox")
         tf.add(busybox_path, arcname="igloo/boot/busybox", filter=lambda ti: (setattr(ti, 'mode', 0o755) or ti))
         # /igloo/boot/hyp_file_op
-        shr = f"{STATIC_DIR}/{arch_dir}/hyp_file_op"
+        shr = os.path.join(arch_dir, "hyp_file_op")
         tf.add(shr, arcname="igloo/boot/hyp_file_op", filter=lambda ti: (setattr(ti, 'mode', 0o755) or ti))
         # /igloo/boot/send_portalcall
-        spc = f"{STATIC_DIR}/{arch_dir}/send_portalcall"
+        spc = os.path.join(arch_dir, "send_portalcall")
         tf.add(spc, arcname="igloo/boot/send_portalcall", filter=lambda ti: (setattr(ti, 'mode', 0o755) or ti))
         # /igloo/boot/sh (symlink)
         symlink_info = tarfile.TarInfo(name="igloo/boot/sh")


### PR DESCRIPTION
This PR ensures that we generate a new qcow if binaries we place `/igloo/boot` change from the last time we generated an image. Also wound up with a minor refactor.