### PR TITLE
Live image permissions fix

### DIFF
--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -272,8 +272,8 @@ class LiveImage(Plugin):
         if paths_to_delete:
             add_run_or_report(f"rm -rf {' '.join([shlex.quote(p) for p in paths_to_delete])}")
         # Use hyp_file_op to get the tarball and extract
-        add_run_or_report("/igloo/boot/hyp_file_op get filesystem.tar /igloo/filesystem.tar")
-        add_run_or_report("tar -xf /igloo/filesystem.tar -C /")
+        add_run_or_report("/igloo/boot/hyp_file_op get filesystem.tar /igloo/boot/filesystem.tar")
+        add_run_or_report("tar x -om -f /igloo/boot/filesystem.tar -C / --no-same-permissions")
 
         # --- Phase 4: Batch-process binary patches ---
         if self.patch_queue:


### PR DESCRIPTION
When we depended on tar's normal extraction behavior it overwrote both permissions and ownership for not just the files we intended, but also for unrelated files (like /, /etc).

We fix this by adding flags to tar that force it to only care about changing the content in the file.

Because we care about the permissions of a subset of those files we add a chmod at the end for those files. Because that would normally be expensive in terms of the number of commands we add code to group those commands.