### PR TITLE
Live image permission/efficiency updates

### DIFF
--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -265,7 +265,7 @@ class LiveImage(Plugin):
         script_lines = [
             "#!/igloo/boot/busybox sh",
             "export PATH=/igloo/boot:$PATH",
-            # "exec > /igloo/boot/live_image_guest.log 2>&1",
+            "exec > /igloo/boot/live_image_guest.log 2>&1",
             "for util in chmod echo cp mkdir rm ln mknod tar mv time stat readlink dirname sh; do /igloo/boot/busybox ln -sf /igloo/boot/busybox /igloo/boot/$util; done",
             "",
             "run_or_report() {",


### PR DESCRIPTION
This PR fixes two issues:
- chmod on igloo files in nvram and others make a very long set of files to chmod so we group them
- extracting files to paths that contain invalid symlinks causes an error. We choose to make the directories along the way if necessary (replicating earlier behavior)