### PR TITLE
Dockerfile: optimize llvm installation size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -337,20 +337,20 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Update and install prerequisites
 RUN apt-get update && apt-get install -y \
-    wget \
+    curl \
     gnupg \
+    ca-certificates \
     software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
-# Add the LLVM repository
-RUN wget https://apt.llvm.org/llvm.sh && \
-    chmod +x llvm.sh && \
-    ./llvm.sh 20
+# Add the LLVM repository (proper key import + HTTPS)
+RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm-toolchain-jammy-20.list
 
 # Install apt dependencies - first line for penguin - second for fw2tar
 RUN apt-get update && apt-get install -q -y \
-    fakeroot genext2fs graphviz graphviz-dev libarchive13 libgcc-s1 liblinear4 liblua5.3-0 libpcap0.8 libpcre3 libssh2-1 libssl3 libstdc++6 libxml2 lua-lpeg nmap python3 python3-lxml python3-venv sudo telnet vim wget zlib1g pigz clang-20 lldb-20 lld-20 \
-    android-sdk-libsparse-utils arj automake build-essential bzip2 cabextract clang cpio cramfsswap curl default-jdk e2fsprogs fakeroot gcc git gzip lhasa libarchive-dev libfontconfig1-dev libacl1-dev libcap-dev liblzma-dev liblzo2-dev liblz4-dev libbz2-dev libssl-dev libmagic1 locales lz4 lziprecover lzop mtd-utils openssh-client p7zip p7zip-full python3 python3-pip qtbase5-dev sleuthkit squashfs-tools srecord tar unar unrar unrar-free unyaffs unzip wget xz-utils zlib1g-dev zstd && \
+    fakeroot genext2fs graphviz graphviz-dev libarchive13 libgcc-s1 liblinear4 liblua5.3-0 libpcap0.8 libpcre3 libssh2-1 libssl3 libstdc++6 libxml2 lua-lpeg nmap python3 python3-lxml python3-venv sudo telnet vim wget zlib1g pigz clang-20 lld-20 \
+    android-sdk-libsparse-utils arj automake build-essential bzip2 cabextract cpio cramfsswap curl default-jdk e2fsprogs fakeroot gcc git gzip lhasa libarchive-dev libfontconfig1-dev libacl1-dev libcap-dev liblzma-dev liblzo2-dev liblz4-dev libbz2-dev libssl-dev libmagic1 locales lz4 lziprecover lzop mtd-utils openssh-client p7zip p7zip-full python3 python3-pip qtbase5-dev sleuthkit squashfs-tools srecord tar unar unrar unrar-free unyaffs unzip xz-utils zlib1g-dev zstd && \
     apt install -yy -f /tmp/pandare.deb -f /tmp/pandare-plugins.deb \
     -f /tmp/glow.deb -f /tmp/gum.deb -f /tmp/ripgrep.deb && \
     rm -rf /var/lib/apt/lists/* /tmp/*.deb
@@ -370,7 +370,7 @@ COPY --from=python_builder /app/wheels /wheels
 # Remove python_lzo 1.0 to resolve depdency collision with vmlinux-to-elf
 RUN rm -rf /wheels/python_lzo*
 
-RUN pip install --no-cache /wheels/*
+RUN pip install --no-cache /wheels/* && rm -rf /wheels
 
 RUN poetry config virtualenvs.create false
 


### PR DESCRIPTION
The LLVM installation in penguin costs us 1.1GB. This is significant and something of an issue because we don't use most of the LLVM features.

This PR saves us 800MB by switching us to the signed llvm installation.