### PR TITLE
Fix: regresion in patch_config

### DIFF
--- a/src/penguin/penguin_config/__init__.py
+++ b/src/penguin/penguin_config/__init__.py
@@ -240,10 +240,14 @@ def load_config(proj_dir, path, validate=True):
             raise ValueError("No core.arch specified in config")
 
         if config["core"].get("fs", None) is None:
-            config["core"]["fs"] = "./base/empty_fs.tar.gz"
-            empty_fs_path = os.path.join(proj_dir, "./base/empty_fs.tar.gz")
-            if not os.path.exists(empty_fs_path):
-                construct_empty_fs(empty_fs_path)
+            if Path(proj_dir, "base/fs.tar.gz").exists():
+                config["core"]["fs"] = "./base/fs.tar.gz"
+            else:
+                logger.info("No core.fs specified in config - using empty fs - most likely a test")
+                config["core"]["fs"] = "./base/empty_fs.tar.gz"
+                empty_fs_path = os.path.join(proj_dir, "./base/empty_fs.tar.gz")
+                if not os.path.exists(empty_fs_path):
+                    construct_empty_fs(empty_fs_path)
     return config
 
 

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -126,7 +126,7 @@ class Core(PartialModelMixin, BaseModel):
     fs: Annotated[
         Optional[str],
         Field(
-            None,
+            "./base/fs.tar.gz",
             title="Project-relative path to filesystem tarball",
             examples=["base/fs.tar.gz"],
         ),


### PR DESCRIPTION
This PR fixes a small regression in our default values for our `core.fs` value.

It was changed to None in #630, but it needs to be `base/fs.tar.gz`.

In order to ensure that this is easier to debug in the future, we've also restructured our load_config logic so that in the event we do not provide a `core.fs` value we check for `base/fs.tar.gz` before proceeding to our test behavior of creating an empty filesystem. Further, we will now log if we are using an empty filesystem.