### PR TITLE
gen_config: fix unreadable files

### DIFF
--- a/src/penguin/gen_config.py
+++ b/src/penguin/gen_config.py
@@ -43,6 +43,14 @@ class ConfigBuilder:
         extracted_fs.mkdir()
         subprocess.check_output(["tar", "-xf", archive_fs, "-C", str(extracted_fs)])
 
+        # ensure every file is readable by the current user
+        subprocess.check_output(
+            ["find", str(extracted_fs), "-type", "f", "-exec", "chmod", "u+r", "{}", "+"])
+
+        # ensure every directory is readable by the current user (requires exec)
+        subprocess.check_output(
+            ["find", str(extracted_fs), "-type", "d", "-exec", "chmod", "u+rx", "{}", "+"])
+
         try:
             # First run static analyses and produce info about the filesystem
             # This informs how we generate configs (e.g., what's the arch, what's the init prog)


### PR DESCRIPTION
During config generation we occasionally see files/folders that have strange permissions set in such a way that they both cannot be analyzed by our gen_config process and/or cause the config generation to fail/stall.

This PR introduces a change so that it is impossible for any file/folder to not be readable to the process doing analysis.

This change does not impact image generation results.