### PR TITLE
Penguin shell

### DIFF
--- a/db/events/utils/cli_execs.py
+++ b/db/events/utils/cli_execs.py
@@ -35,7 +35,7 @@ execs --procname myproc --fd 3 --filename log.txt --output results.txt
 
 import click
 from events import Exec
-from events.utils.util_base import wrapper
+from events.utils.util_base import wrapper, get_default_results_path
 
 
 def exec_filter(sess, procname, fd, filename):
@@ -64,8 +64,8 @@ def exec_filter(sess, procname, fd, filename):
 @click.command()
 @click.option(
     "--results",
-    default="./results/latest",
-    help="Path to results folder (default is ./results/latest/)",
+    default=get_default_results_path(),
+    help="Path to results folder (default is ./results/)",
 )
 @click.option(
     "--procname", default=None, help="Process name to filter for (looks for substring)"

--- a/db/events/utils/cli_fds.py
+++ b/db/events/utils/cli_fds.py
@@ -33,13 +33,14 @@ from sqlalchemy.orm import Session
 from rich import print
 from time import sleep
 from os.path import join, exists
+from events.utils.util_base import get_default_results_path
 
 
 @click.command()
 @click.option(
     "--results",
-    default="./results/latest",
-    help="Path to results folder (default is ./results/latest)",
+    default=get_default_results_path(),
+    help="Path to results folder (default is ./results)",
 )
 @click.option(
     "--procname", default=None, help="Process name to filter for (looks for substring)"

--- a/db/events/utils/cli_reads.py
+++ b/db/events/utils/cli_reads.py
@@ -30,7 +30,7 @@ reads --procname myproc --fd 3 --filename input.txt --output results.txt
 
 import click
 from events import Read
-from events.utils.util_base import wrapper
+from events.utils.util_base import wrapper, get_default_results_path
 
 
 def read_filter(sess, procname, fd, filename):
@@ -59,8 +59,8 @@ def read_filter(sess, procname, fd, filename):
 @click.command()
 @click.option(
     "--results",
-    default="./results/latest",
-    help="Path to results folder (default is ./results/latest/)",
+    default=get_default_results_path(),
+    help="Path to results folder (default is ./results/)",
 )
 @click.option(
     "--procname", default=None, help="Process name to filter for (looks for substring)"

--- a/db/events/utils/cli_syscalls.py
+++ b/db/events/utils/cli_syscalls.py
@@ -30,7 +30,7 @@ syscalls --procname myproc --syscall open --errors --output results.txt
 
 import click
 from events import Syscall
-from events.utils.util_base import wrapper
+from events.utils.util_base import wrapper, get_default_results_path
 
 
 def syscall_filter(sess, procname, syscall, errors):
@@ -63,8 +63,8 @@ def syscall_filter(sess, procname, syscall, errors):
 @click.command()
 @click.option(
     "--results",
-    default="./results/latest",
-    help="Path to results folder (default is ./results/latest)",
+    default=get_default_results_path(),
+    help="Path to results folder (default is ./results)",
 )
 @click.option(
     "--procname", default=None, help="Process name to filter for (looks for substring)"

--- a/db/events/utils/cli_tasks.py
+++ b/db/events/utils/cli_tasks.py
@@ -28,13 +28,14 @@ from sqlalchemy import create_engine
 from rich import print as rprint
 from events import Event
 from os.path import join, exists
+from events.utils.util_base import get_default_results_path
 
 
 @click.command()
 @click.option(
     "--results",
-    default="./results/latest",
-    help="Path to results folder (default is ./results/latest/)",
+    default=get_default_results_path(),
+    help="Path to results folder (default is ./results/)",
 )
 @click.option(
     "--output", default="/dev/stdout", help="Output to file instead of stdout"

--- a/db/events/utils/cli_writes.py
+++ b/db/events/utils/cli_writes.py
@@ -30,7 +30,7 @@ writes --procname myproc --fd 3 --filename output.txt --output results.txt
 
 import click
 from events import Write
-from events.utils.util_base import wrapper
+from events.utils.util_base import wrapper, get_default_results_path
 
 
 def write_filter(sess, procname, fd, filename):
@@ -59,8 +59,8 @@ def write_filter(sess, procname, fd, filename):
 @click.command()
 @click.option(
     "--results",
-    default="./results/latest",
-    help="Path to results folder (default is ./results/latest/)",
+    default=get_default_results_path(),
+    help="Path to results folder (default is ./results/)",
 )
 @click.option(
     "--procname", default=None, help="Process name to filter for (looks for substring)"

--- a/db/events/utils/util_base.py
+++ b/db/events/utils/util_base.py
@@ -32,6 +32,18 @@ from os.path import join, exists
 from events import Event
 
 
+def get_default_results_path():
+    """Get the default results path"""
+    import os
+
+    project_dir = os.getenv("PENGUIN_PROJECT_DIR")
+    if project_dir:
+        return os.path.join(project_dir, "results/latest")
+
+    # Fall back to current directory (old default)
+    return "./results"
+
+
 def wrapper(results, output, print_procname, follow, filter_func, args):
     """
     ### Wrapper function to execute a filtered query and output results.

--- a/penguin
+++ b/penguin
@@ -372,15 +372,6 @@ penguin_run() {
         # Add env variable CONTAINER_IP=ip
         docker_cmd+=("-e" "CONTAINER_IP=$ip")
 
-	# Add env variable of penguin bash script hash
-        hash=$(sha256sum "$0" | awk '{print $1}')
-        docker_cmd+=("-e" "PENGUIN_HASH=$hash")
-
-        # Add container name if set
-        if [ -n "$container_name" ]; then
-            docker_cmd+=("-e" "CONTAINER_NAME=$container_name")
-        fi
-
         if $verbose; then
             echo "${BOLD}Docker network setup:${RESET}"
             echo "  Network name: $network_name"
@@ -393,6 +384,46 @@ penguin_run() {
         if $verbose; then
             echo "${BOLD}Docker network setup:${RESET}"
             echo "  Skipped due to --subnet none flag"
+            echo
+        fi
+    fi
+
+    # Add penguin bash script hash environment variable
+    hash=$(sha256sum "$0" | awk '{print $1}')
+    docker_cmd+=("-e" "PENGUIN_HASH=$hash")
+
+    # Add container name if set
+    if [ -n "$container_name" ]; then
+        docker_cmd+=("-e" "CONTAINER_NAME=$container_name")
+    fi
+
+    project_dir=""
+    for ((i=${#cmd[@]}-1; i>0; i--)); do
+        if [[ -e "${cmd[$i]}" ]]; then
+            local host_realpath=$(realpath "${cmd[$i]}")
+            if [[ -f "$host_realpath" ]]; then
+                host_realpath=$(dirname "$host_realpath")
+            fi
+
+            # Convert host path to container path using same logic as mappings
+            local host_parent=$(dirname "$host_realpath")
+            local container_path="/host_$(basename "$host_parent")"
+            local relative_path="${host_realpath#$host_parent/}"
+
+            # If the relative path is empty (i.e., we're at the mapped directory), use just the container path
+            if [ -z "$relative_path" ] || [ "$relative_path" = "$host_realpath" ]; then
+                project_dir="$container_path"
+            else
+                project_dir="$container_path/$relative_path"
+            fi
+            break
+        fi
+    done
+    if [ -n "$project_dir" ]; then
+        docker_cmd+=("-e" "PENGUIN_PROJECT_DIR=$project_dir")
+        if $verbose; then
+            echo "${BOLD}Setting environment variables:${RESET}"
+            echo "  PENGUIN_PROJECT_DIR=$project_dir"
             echo
         fi
     fi

--- a/penguin
+++ b/penguin
@@ -67,6 +67,7 @@ penguin_run() {
     local pydev=false
     local verbose=false
     local reproduce=false
+    local shell_mode=false
     local subnet=""
     local container_name="" # Name of the instance
     local image="rehosting/penguin" # Container to run
@@ -269,8 +270,8 @@ penguin_run() {
      # Build Docker command
     docker_cmd=("docker" "run" "--rm")
 
-    # If we have a name set, ensure it's available. We only really care about this for run/guest_cmd (and maybe explore) action
-    if [[ ${#cmd[@]} -gt 1 && ( "${cmd[0]}" == "run" || "${cmd[0]}" == "guest_cmd" ) ]]; then
+    # If we have a name set, ensure it's available. We only really care about this for run/guest_cmd/shell (and maybe explore) action
+    if [[ ${#cmd[@]} -gt 1 && ( "${cmd[0]}" == "run" || "${cmd[0]}" == "guest_cmd" || "${cmd[0]}" == "shell" ) ]]; then
         if [ -z "$container_name" ]; then
             # No name set - try to grab it - find last argument with host path and use that
             for ((i=${#cmd[@]}-1; i>0; i--)); do
@@ -311,7 +312,7 @@ penguin_run() {
             fi
         fi
 
-        if [[ -n "$container_name" && "${cmd[0]}" != "guest_cmd" ]]; then
+        if [[ -n "$container_name" && "${cmd[0]}" != "guest_cmd" && "${cmd[0]}" != "shell" ]]; then
             if docker ps --all --format '{{.Names}}' | grep -q "^$container_name$"; then
                 echo "${BOLD}ERROR: Container name ${RED}$container_name${RESET}${BOLD} is already in use!${RESET}"
                 echo "  Please specify a different name with ${BOLD}--name${RESET}"
@@ -329,6 +330,21 @@ penguin_run() {
         docker_cmd=("docker" "exec" "-it" "${container_name}" "python3" "/igloo_static/guesthopper/guest_cmd.py" "${cmd[@]:2}")
         "${docker_cmd[@]}"
         exit $?
+    fi
+
+    # Similarly if we are running a shell in the container, start it if it's not already running, otherwise exec into that container
+    if [[ ${#cmd[@]} -gt 1 && ( "${cmd[0]}" == "shell" ) ]]; then
+        # Check if container is running
+        if [[ -n "$container_name" ]] && docker ps --format '{{.Names}}' | grep -q "^$container_name$"; then
+            # Container is running, exec into it and bail
+            docker_cmd=("docker" "exec" "-it" "${container_name}" "bash")
+            "${docker_cmd[@]}"
+            exit $?
+        else
+            # Container is not running, we need to start it
+            # We'll continue with the normal docker run flow but override the command to be bash
+            shell_mode=true
+        fi
     fi
 
     # Check if we're in an interactive terminal, if so add -it
@@ -475,8 +491,12 @@ penguin_run() {
 
         # reproduce runs the default commmand
         if ! $reproduce; then
-            docker_cmd+=("penguin")
-            docker_cmd+=("${new_cmd[@]}")
+            if $shell_mode; then
+                docker_cmd+=("bash")
+            else
+                docker_cmd+=("penguin")
+                docker_cmd+=("${new_cmd[@]}")
+            fi
         fi
     fi
 

--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -262,6 +262,8 @@ class LiveImage(Plugin):
             f"Creating filesystem tarball at {tarball_host_path}...")
         with tarfile.open(tarball_host_path, "w") as tar:
             tar.add(staging_dir, arcname='.')
+        self.logger.info(
+            f"Filesystem tarball created at {tarball_host_path}")
 
         # --- Phase 3: Assemble the final guest script ---
         script_lines = [

--- a/src/penguin/__main__.py
+++ b/src/penguin/__main__.py
@@ -615,6 +615,11 @@ contains details on the configuration file format and options.
     parser_cmd_run = subparsers.add_parser("run", help="Run from a config")
     add_run_arguments(parser_cmd_run)
 
+    parser_cmd_shell = subparsers.add_parser(
+        "shell", help="Get a shell inside the penguin container (will attach to running container if available)"
+    )
+    add_run_arguments(parser_cmd_shell)
+
     parser_cmd_docs = subparsers.add_parser("docs", help="Show documentation")
     add_docs_arguments(parser_cmd_docs)
 
@@ -627,10 +632,6 @@ contains details on the configuration file format and options.
         "guest_cmd", help="Execute a command inside a guest and capture stdout/stderr"
     )
     parser_cmd_guest_cmd.add_argument('args', nargs=argparse.REMAINDER, help='Pass remaining arguments as a command to the guest')
-    parser_cmd_shell = subparsers.add_parser(
-        "shell", help="Get a shell inside the penguin container (will attach to running container if available)"
-    )
-    add_run_arguments(parser_cmd_shell)
     parser_cmd_ga_explore = subparsers.add_parser(
         "ga_explore", help="Search for alternative configurations to improve system health by using a genetic algorithm."
     )

--- a/src/penguin/__main__.py
+++ b/src/penguin/__main__.py
@@ -627,6 +627,10 @@ contains details on the configuration file format and options.
         "guest_cmd", help="Execute a command inside a guest and capture stdout/stderr"
     )
     parser_cmd_guest_cmd.add_argument('args', nargs=argparse.REMAINDER, help='Pass remaining arguments as a command to the guest')
+    parser_cmd_shell = subparsers.add_parser(
+        "shell", help="Get a shell inside the penguin container (will attach to running container if available)"
+    )
+    add_run_arguments(parser_cmd_shell)
     parser_cmd_ga_explore = subparsers.add_parser(
         "ga_explore", help="Search for alternative configurations to improve system health by using a genetic algorithm."
     )
@@ -692,8 +696,9 @@ contains details on the configuration file format and options.
         guest_cmd(args)
     elif args.cmd in ["explore", "ga_explore", "patch_explore", "minimize"]:
         penguin_explore(args)
-    elif args.cmd == "guest_cmd":
-        pass
+    elif args.cmd == "shell":
+        logger.error("The 'shell' command is not available in this context. Please use the 'penguin' wrapper script to start a container shell.")
+        return 1
     else:
         parser.print_help()
 


### PR DESCRIPTION
This PR introduces the `shell` subcommand to the penguin launch script as well as passing the project directory into the various CLI utilities so the results dir defaults to `proj_dir/results/latest`.  You can now do something like:
```bash
penguin run ./projects/foo
# ... separate window ...
penguin shell ./projects/foo
# you're inside the container now
syscalls --follow 
```