### PR TITLE
loongarch64: update to newer BIOS from Fedora

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ARG FW2TAR_TAG="v2.0.6"
 ARG PANDA_VERSION="pandav0.0.49"
 ARG PANDANG_VERSION="0.0.34"
 ARG RIPGREP_VERSION="14.1.1"
+ARG LOONGARCH64_BIOS_URL="https://kojipkgs.fedoraproject.org/compose/43/Fedora-43-20250910.2/compose/Everything/x86_64/os/Packages/e/edk2-loongarch64-20250523-18.fc43.noarch.rpm"
 
 FROM ${REGISTRY}/rust:1.86 AS rust_builder
 RUN git clone --depth 1 -q https://github.com/rust-vmm/vhost-device/ /root/vhost-device
@@ -49,6 +50,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
     bzip2 \
+    libarchive-tools \
     ca-certificates \
     curl \
     jq \
@@ -152,7 +154,9 @@ ARG IGLOO_DRIVER_VERSION
 RUN /get_release.sh rehosting igloo_driver ${IGLOO_DRIVER_VERSION} igloo_driver.tar.gz | \
     tar xzf - -C /igloo_static
 
-RUN wget https://github.com/wtdcode/DebianOnQEMU/releases/download/v2024.01.05/bios-loong64-8.1.bin -O /igloo_static/loongarch64/bios-loong64-8.1.bin
+ARG LOONGARCH64_BIOS_URL
+RUN wget -qO- ${LOONGARCH64_BIOS_URL} | \
+    bsdtar -xOf - ./usr/share/edk2/loongarch64/QEMU_EFI.fd > /igloo_static/loongarch64/QEMU_EFI.fd
 
 # Download prototype files for ltrace.
 #

--- a/src/penguin/penguin_run.py
+++ b/src/penguin/penguin_run.py
@@ -283,7 +283,7 @@ def run_config(
         *drive_args,
     ]
     if q_config["arch"] == "loongarch64":
-        args += ["-bios", "/igloo_static/loongarch64/bios-loong64-8.1.bin"]
+        args += ["-bios", "/igloo_static/loongarch64/QEMU_EFI.fd"]
 
     args += ["-no-reboot"]
 


### PR DESCRIPTION
Fixes #608. I was able to reproduce that issue locally before this change, but after this change I ran the Loongarch64 tests 20 times with no issues.

When the tests hang, console.log is empty, and when connecting through QEMU's GDB server, the guest repeats this sequence of instructions forever:

```
0x1c004f48      nop
0x1c004f4c      nop
0x1c004f50      nop
0x1c004f54      nop
0x1c004f58      nop
0x1c004f5c      nop
0x1c004f60      nop
0x1c004f64      nop
0x1c004f68      ret
0x1c004ea4      b               -28     # 0x1c004e88
0x1c004e88      ld.d            $t0, $sp, 8
0x1c004e8c      beqz            $t0, 20 # 0x1c004ea0
0x1c004ea0      jirl            $ra, $s0, 0
```

Searching for these relevant byte sequences in our build kernel objects gives no results, but they do give results for our downloaded Loongarch64 BIOS, which made me think it was a BIOS issue.

Previously, we downloaded the BIOS from https://github.com/wtdcode/DebianOnQEMU/releases/download/v2024.01.05/bios-loong64-8.1.bin, which obtained it from [a package mirror from a Loongarch64 Arch Linux port](https://github.com/wtdcode/DebianOnQEMU/blob/7a220f52659072fcfb253dd2170244994b801fd9/.github/workflows/build.yaml#L348-L352). The latest version was uploaded Jan 5, 2024, and many important-seeming [changes](https://github.com/tianocore/edk2/commits/master/OvmfPkg/LoongArchVirt?since=2024-01-05&until=2025-10-01) were made since then.

This PR instead downloads the BIOS from a recent Fedora package, from [Fedora's build server](https://kojipkgs.fedoraproject.org), which seems more likely to keep older package versions indefinitely (to prevent future PENGUIN builds from breaking), compared to the standard Fedora package mirrors. But if that ends up not being the case, we can always host a copy of it ourselves.