### PR TITLE
config: remove type equality assert on patch merge

### DIFF
--- a/src/penguin/common.py
+++ b/src/penguin/common.py
@@ -63,8 +63,6 @@ def patch_config(logger, base_config, patch):
         if new is None:
             return base
 
-        assert type(base) is type(new)
-
         if hasattr(base, "merge"):
             return base.merge(new)
 


### PR DESCRIPTION
This assert is false when there is a conflict between union types