### PR TITLE
events: fix import

### DIFF
--- a/pyplugins/testing/verifier.py
+++ b/pyplugins/testing/verifier.py
@@ -11,7 +11,7 @@ import time
 
 from sqlalchemy.orm import Session
 from sqlalchemy import create_engine
-from db.events.utils.cli_syscalls import syscall_filter
+from events.utils.cli_syscalls import syscall_filter
 
 
 class Verifier(Plugin):


### PR DESCRIPTION
In some rehostings I have seen:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/pkg/penguin/penguin_run.py", line 579, in <module>
    main()
  File "/pkg/penguin/penguin_run.py", line 573, in main
    run_config(
  File "/pkg/penguin/penguin_run.py", line 468, in run_config
    plugins.load_plugins(conf_plugins)
  File "/pkg/penguin/plugin_manager.py", line 512, in load_plugins
    self.load_plugin(plugin)
  File "/pkg/penguin/plugin_manager.py", line 488, in load_plugin
    plugins_loaded = self.load_all(path, args)
  File "/pkg/penguin/plugin_manager.py", line 598, in load_all
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/pyplugins/testing/verifier.py", line 14, in <module>
    from db.events.utils.cli_syscalls import syscall_filter
ModuleNotFoundError: No module named 'db'
```

The safe way to fix this is to import directly from the events module.