### PR TITLE
config(schema): use patch model instead of full config

### DIFF
--- a/src/penguin/penguin_config/gen_docs.py
+++ b/src/penguin/penguin_config/gen_docs.py
@@ -260,7 +260,7 @@ def main():
     sp.add_parser(
         "schema",
         help="Write JSON schema for config to stdout",
-    ).set_defaults(func=lambda: print(yaml.dump(structure.Main.model_json_schema(), indent=2)))
+    ).set_defaults(func=lambda: print(yaml.dump(structure.Patch.model_json_schema(), indent=2)))
 
     sp.add_parser(
         "docs",


### PR DESCRIPTION
Change the generated config JSON schema for yaml-language-server LSP to use the partial `Patch` model instead of the full `Main` model so that it doesn't give extraneous missing field errors when used on patch files.