### PR TITLE
simplify CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Install dependencies


### PR DESCRIPTION
This PR simplifies our process for external contributors by allowing them to interact with a separate container registry/username/password/etc.

PRs from external contributors still need to be explicitly approved.