### PR TITLE
build.yaml: slow setup-python use github hosted

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: rehosting-arc
     steps:
     - uses: actions/checkout@v5
       with:


### PR DESCRIPTION
For some reason the lint setup-python has gotten outrageously slow (used to be under 10s). We're changing the target runs-on to github to try to get around this.

Edit: this didn't work because our jobs use setup-python