### PR TITLE
live_image: shim symlink should point to target, not .orig

### DIFF
--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -208,9 +208,9 @@ class LiveImage(Plugin):
                 shim_orig_names.add(orig_path)
                 post_tar_commands.append(
                     f"mv {shlex.quote(file_path)} {shlex.quote(orig_path)}")
-                # Symlink to the new .orig path
+                # Symlink to the target specified in configuration
                 post_tar_commands.append(
-                    f"ln -sf {shlex.quote(orig_path)} {shlex.quote(file_path)}")
+                    f"ln -sf {shlex.quote(action['target'])} {shlex.quote(file_path)}")
             elif action_type == "move":
                 post_tar_commands.append(
                     f"cp {shlex.quote(action['from'])} {shlex.quote(file_path)}")

--- a/tests/unit_tests/test_target/patches/tests/live_image.yaml
+++ b/tests/unit_tests/test_target/patches/tests/live_image.yaml
@@ -82,6 +82,9 @@ static_files:
     type: binary_patch
     file_offset: 0
     hex_bytes: "11223344"
+  /shim.txt:
+    type: shim
+    target: /shimtarget.txt
   /tests/live_image.sh:
     type: inline_file
     contents: |
@@ -175,6 +178,10 @@ static_files:
       # Check binary patch for /testfile2.bin
       if ! /igloo/utils/busybox head -c 4 /testfile2.bin | /igloo/utils/busybox hexdump -v -e '4/1 "%02X"' | /igloo/utils/busybox grep -q "11223344"; then
         echo "/testfile2.bin binary patch failed"; exit 1
+      fi
+      # Check shim
+      if ! /igloo/utils/busybox grep target /shim.txt ; then
+        echo "/shim.txt contents are incorrect"; exit 1
       fi
       echo "live_image.sh PASS"
       exit 0

--- a/tests/unit_tests/test_target/test.py
+++ b/tests/unit_tests/test_target/test.py
@@ -65,6 +65,8 @@ def run_test(kernel, arch, image, test_file=None):
         "helloworld": b"helloworld\0",
         "testfile1.bin": b"\x01\x02\x03\x04",
         "testfile2.bin": b"\x10\x20\x30\x40",
+        "shim.txt": b"original data\0",
+        "shimtarget.txt": b"target data\0",
     }
     create_tar_gz_with_binaries(f"{TEST_DIR}/empty_fs.tar.gz", files_dict)
     base_config = str(Path(TEST_DIR, "base_config.yaml"))


### PR DESCRIPTION
This PR fixes an in issue with `shim` static_files where we used to point the original instead of the target.

E.g, with
```yaml
static_files:
  /sbin/insmod:
    target: /igloo/utils/exit0.sh
    type: shim
```

we would get:
```
# ls -l /sbin/insmod
lrwxrwxrwx    1 0        0               24 Jan  1  2023 /sbin/insmod -> /igloo/shims/insmod.orig
```

now we get the expected:
```
# ls -l /sbin/insmod
lrwxrwxrwx    1 0        0               21 Jan  1  2023 /sbin/insmod -> /igloo/utils/exit0.sh
```
