### PR TITLE
KFFI Callbacks and Symbol Lookup

### DIFF
--- a/pyplugins/apis/kffi.py
+++ b/pyplugins/apis/kffi.py
@@ -513,11 +513,11 @@ class KFFI(Plugin):
             "status": tramp_struct.status,
         }
 
-    def callback(self, func) -> 'KFFI.Callback':
+    def callback(self, func) -> Generator[Any, Any, Any]:
         """
-        ### Register a trampoline callback and return a Callback object
+        ### Register a trampoline callback and return an integer guest virtual address
 
-        Immediately generates the trampoline, sets up the interrupt handler, and returns the Callback object.
+        Immediately generates the trampoline, sets up the interrupt handler, and returns an integer address.
         """
         if func in self._tramp_addresses:
             return self._tramp_addresses[func]

--- a/pyplugins/apis/kffi.py
+++ b/pyplugins/apis/kffi.py
@@ -530,6 +530,20 @@ class KFFI(Plugin):
         self._tramp_addresses[func] = tramp_addr
         return tramp_addr
 
+    def get_callback_id(self, f: Union[int, Any]) -> Optional[int]:
+        """
+        ### Get the trampoline ID for a registered callback function or trampoline address
+
+        **Args:**
+        - `f` (`int` or `Any`): Callback function or trampoline address.
+
+        **Returns:**
+        - `int` or `None`: Trampoline ID, or None if not found.
+        """
+        if isinstance(f, int):
+            return self._tramp_callbacks.get(f)
+        return self._tramp_callbacks.get(f)
+
     def _tramp_interrupt_handler(self):
         """
         Interrupt handler to register trampoline callbacks.

--- a/pyplugins/apis/kffi.py
+++ b/pyplugins/apis/kffi.py
@@ -71,9 +71,10 @@ class KFFI(Plugin):
         self.ffi = VtypeJsonGroup([self.igloo_ko_isf, self.isf])
         self._tramp_callbacks = {}
         self._tramp_addresses = {}
+        self.tramp_init = False
 
     def __init_tramp_functionality(self):
-        if hasattr(self, 'tramp_init') and self.tramp_init:
+        if self.tramp_init:
             return
         self.tramp_init = True
         # Register trampoline hit hypercall handler

--- a/pyplugins/apis/kffi.py
+++ b/pyplugins/apis/kffi.py
@@ -588,14 +588,14 @@ class KFFI(Plugin):
             # Determine callback arg count
             sig = inspect.signature(callback)
             num_args = len(sig.parameters)
-            # Get syscall args from pt_regs
+            # Get args from pt_regs
             if num_args > 1:
-                # Get syscall args from pt_regs
-                syscall_args = yield from pt_regs.get_args_portal(num_args - 1, convention="syscall")
+                # Get args from pt_regs
+                args = yield from pt_regs.get_args_portal(num_args - 1, convention="userland")
             else:
-                syscall_args = []
-            # Call callback with pt_regs and syscall args
-            result = callback(pt_regs, *syscall_args)
+                args = []
+            # Call callback with pt_regs and args
+            result = callback(pt_regs, *args)
             if isinstance(result, Iterator):
                 result = yield from result
             # If callback returns int, set as return value

--- a/pyplugins/apis/kffi.py
+++ b/pyplugins/apis/kffi.py
@@ -541,9 +541,7 @@ class KFFI(Plugin):
         **Returns:**
         - `int` or `None`: Trampoline ID, or None if not found.
         """
-        if isinstance(f, int):
-            return self._tramp_callbacks.get(f)
-        return self._tramp_callbacks.get(f)
+        return self._tramp_callbacks.get(f, None)
 
     def _tramp_interrupt_handler(self):
         """

--- a/pyplugins/apis/kffi.py
+++ b/pyplugins/apis/kffi.py
@@ -77,10 +77,10 @@ class KFFI(Plugin):
             return
         self.tramp_init = True
         # Register trampoline hit hypercall handler
-        IGLOO_HYP_TRAMP_HIT = 0x7903  # Update with correct value if needed
+        from hyper.consts import igloo_hypercall_constants as iconsts
         self.portal = plugins.portal
         self._on_tramp_hit_hypercall = self.portal.wrap(self._on_tramp_hit_hypercall)
-        self.panda.hypercall(IGLOO_HYP_TRAMP_HIT)(self._on_tramp_hit_hypercall)
+        self.panda.hypercall(iconsts.IGLOO_HYP_TRAMP_HIT)(self._on_tramp_hit_hypercall)
 
         # Register with portal's interrupt handler system
         self.portal.register_interrupt_handler(

--- a/pyplugins/testing/kffi_test.py
+++ b/pyplugins/testing/kffi_test.py
@@ -51,7 +51,6 @@ class KFFITest(Plugin):
         yield from kffi.call("igloo_printk", level + b"test printk %d %d %d %d\x00", 1, 2, 3, 4)
 
         tramp_addr = yield from kffi.callback(self.callback)
-        print(tramp_addr)
         ret = yield from kffi.call(tramp_addr, *self.cb_args)
 
         assert ret == 42, f"Expected 42 from callback, got {ret}"

--- a/pyplugins/testing/kffi_test.py
+++ b/pyplugins/testing/kffi_test.py
@@ -23,12 +23,12 @@ class KFFITest(Plugin):
         self.outdir = self.get_arg("outdir")
         if self.get_arg_bool("verbose"):
             self.logger.setLevel("DEBUG")
-        
+
         if self.panda.bits == 32:
             self.mask = 0xffffffff
         else:
             self.mask = 0xffffffffffffffff
-        
+
         self.cb_args = [
             i & self.mask for i in CALLBACK_ARGS
         ]
@@ -39,7 +39,7 @@ class KFFITest(Plugin):
                 raise ValueError(f"Expected {CALLBACK_ARGS[i]} for arg {i}, got {val}")
 
         with open(join(self.outdir, "kffi_test.txt"), "a") as f:
-            f.write(f"Callback called with expected values!\n")
+            f.write("Callback called with expected values!\n")
         return 42
 
     @syscalls.syscall("on_sys_ioctl_return", arg_filters=[0x14, 0x15, 0x16])

--- a/pyplugins/wrappers/ptregs_wrap.py
+++ b/pyplugins/wrappers/ptregs_wrap.py
@@ -627,22 +627,37 @@ class AArch64PtRegsWrapper(PtRegsWrapper):
         self._register_map = {
             # Access through the nested union and struct
             # regs array for general registers x0-x30
-            **{f"x{i}": ("computed", lambda obj, i=i: obj.unnamed_field_0.unnamed_field_0.regs[i]) for i in range(31)},
+            **{f"x{i}": ("computed", 
+                        lambda obj, i=i: obj.unnamed_field_0.unnamed_field_0.regs[i],
+                        lambda obj, val, i=i: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(i, val)) 
+               for i in range(31)},
             # Special registers
-            "sp": ("computed", lambda obj: obj.unnamed_field_0.unnamed_field_0.sp),
-            "pc": ("computed", lambda obj: obj.unnamed_field_0.unnamed_field_0.pc),
-            "pstate": ("computed", lambda obj: obj.unnamed_field_0.unnamed_field_0.pstate),
+            "sp": ("computed", 
+                  lambda obj: obj.unnamed_field_0.unnamed_field_0.sp,
+                  lambda obj, val: setattr(obj.unnamed_field_0.unnamed_field_0, 'sp', val)),
+            "pc": ("computed", 
+                  lambda obj: obj.unnamed_field_0.unnamed_field_0.pc,
+                  lambda obj, val: setattr(obj.unnamed_field_0.unnamed_field_0, 'pc', val)),
+            "pstate": ("computed", 
+                      lambda obj: obj.unnamed_field_0.unnamed_field_0.pstate,
+                      lambda obj, val: setattr(obj.unnamed_field_0.unnamed_field_0, 'pstate', val)),
             # Other fields directly in pt_regs
             "syscallno": "syscallno",
             "orig_x0": "orig_x0",
             # Aliases
             # x0 holds the return value
-            "retval": ("computed", lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[0]),
+            "retval": ("computed", 
+                      lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[0],
+                      lambda obj, val: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(0, val)),
             # Common aliases for named registers
             # x29
-            "fp": ("computed", lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[29]),
+            "fp": ("computed", 
+                  lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[29],
+                  lambda obj, val: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(29, val)),
             # x30
-            "lr": ("computed", lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[30]),
+            "lr": ("computed", 
+                  lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[30],
+                  lambda obj, val: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(30, val)),
         }
 
         # Create a delegate for ARM mode access (but don't initialize it yet)
@@ -885,26 +900,59 @@ class PowerPCPtRegsWrapper(PtRegsWrapper):
         # PowerPC has numbered registers in the gpr array, nested two levels deep in unions/structs
         self._register_map = {
             # General purpose registers are in the gpr array inside two levels of anonymous struct/union
-            **{f"r{i}": ("computed", lambda obj, i=i: obj_container.gpr[i]) for i in range(32)},
+            **{f"r{i}": ("computed", 
+                        lambda obj, i=i: obj_container.gpr[i],
+                        lambda obj, val, i=i: obj_container.gpr.__setitem__(i, val)) 
+               for i in range(32)},
             # Special registers are direct fields in the anonymous struct
-            "nip": ("computed", lambda obj: obj_container.nip),
-            "msr": ("computed", lambda obj: obj_container.msr),
-            "orig_r3": ("computed", lambda obj: obj_container.orig_gpr3),
-            "ctr": ("computed", lambda obj: obj_container.ctr),
-            "lr": ("computed", lambda obj: obj_container.link),
-            "xer": ("computed", lambda obj: obj_container.xer),
-            "ccr": ("computed", lambda obj: obj_container.ccr),
-            "softe": ("computed", lambda obj: obj_container.softe),
-            "trap": ("computed", lambda obj: obj_container.trap),
-            "dar": ("computed", lambda obj: obj_container.dar),
-            "dsisr": ("computed", lambda obj: obj_container.dsisr),
-            "result": ("computed", lambda obj: obj_container.result),
+            "nip": ("computed", 
+                   lambda obj: obj_container.nip,
+                   lambda obj, val: setattr(obj_container, 'nip', val)),
+            "msr": ("computed", 
+                   lambda obj: obj_container.msr,
+                   lambda obj, val: setattr(obj_container, 'msr', val)),
+            "orig_r3": ("computed", 
+                       lambda obj: obj_container.orig_gpr3,
+                       lambda obj, val: setattr(obj_container, 'orig_gpr3', val)),
+            "ctr": ("computed", 
+                   lambda obj: obj_container.ctr,
+                   lambda obj, val: setattr(obj_container, 'ctr', val)),
+            "lr": ("computed", 
+                  lambda obj: obj_container.link,
+                  lambda obj, val: setattr(obj_container, 'link', val)),
+            "xer": ("computed", 
+                   lambda obj: obj_container.xer,
+                   lambda obj, val: setattr(obj_container, 'xer', val)),
+            "ccr": ("computed", 
+                   lambda obj: obj_container.ccr,
+                   lambda obj, val: setattr(obj_container, 'ccr', val)),
+            "softe": ("computed", 
+                     lambda obj: obj_container.softe,
+                     lambda obj, val: setattr(obj_container, 'softe', val)),
+            "trap": ("computed", 
+                    lambda obj: obj_container.trap,
+                    lambda obj, val: setattr(obj_container, 'trap', val)),
+            "dar": ("computed", 
+                   lambda obj: obj_container.dar,
+                   lambda obj, val: setattr(obj_container, 'dar', val)),
+            "dsisr": ("computed", 
+                     lambda obj: obj_container.dsisr,
+                     lambda obj, val: setattr(obj_container, 'dsisr', val)),
+            "result": ("computed", 
+                      lambda obj: obj_container.result,
+                      lambda obj, val: setattr(obj_container, 'result', val)),
             # Aliases
             # r1 is stack pointer
-            "sp": ("computed", lambda obj: obj_container.gpr[1]),
-            "pc": ("computed", lambda obj: obj_container.nip),
+            "sp": ("computed", 
+                  lambda obj: obj_container.gpr[1],
+                  lambda obj, val: obj_container.gpr.__setitem__(1, val)),
+            "pc": ("computed", 
+                  lambda obj: obj_container.nip,
+                  lambda obj, val: setattr(obj_container, 'nip', val)),
             # r3 holds return values
-            "retval": ("computed", lambda obj: obj_container.gpr[3]),
+            "retval": ("computed", 
+                      lambda obj: obj_container.gpr[3],
+                      lambda obj, val: obj_container.gpr.__setitem__(3, val)),
         }
 
     def get_syscall_arg(self, num: int) -> Optional[int]:
@@ -1118,8 +1166,8 @@ class Riscv32PtRegsWrapper(PtRegsWrapper):
             "x31": "t6",
 
             # Alias for x0 (always zero)
-            "x0": ("computed", lambda obj: 0),
-            "zero": ("computed", lambda obj: 0),
+            "x0": ("computed", lambda obj: 0, lambda obj, val: None),  # x0 is hardwired to zero
+            "zero": ("computed", lambda obj: 0, lambda obj, val: None),  # x0 is hardwired to zero
 
             # Common aliases
             "pc": "epc",

--- a/pyplugins/wrappers/ptregs_wrap.py
+++ b/pyplugins/wrappers/ptregs_wrap.py
@@ -627,37 +627,37 @@ class AArch64PtRegsWrapper(PtRegsWrapper):
         self._register_map = {
             # Access through the nested union and struct
             # regs array for general registers x0-x30
-            **{f"x{i}": ("computed", 
-                        lambda obj, i=i: obj.unnamed_field_0.unnamed_field_0.regs[i],
-                        lambda obj, val, i=i: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(i, val)) 
+            **{f"x{i}": ("computed",
+                         lambda obj, i=i: obj.unnamed_field_0.unnamed_field_0.regs[i],
+                         lambda obj, val, i=i: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(i, val))
                for i in range(31)},
             # Special registers
-            "sp": ("computed", 
-                  lambda obj: obj.unnamed_field_0.unnamed_field_0.sp,
-                  lambda obj, val: setattr(obj.unnamed_field_0.unnamed_field_0, 'sp', val)),
-            "pc": ("computed", 
-                  lambda obj: obj.unnamed_field_0.unnamed_field_0.pc,
-                  lambda obj, val: setattr(obj.unnamed_field_0.unnamed_field_0, 'pc', val)),
-            "pstate": ("computed", 
-                      lambda obj: obj.unnamed_field_0.unnamed_field_0.pstate,
-                      lambda obj, val: setattr(obj.unnamed_field_0.unnamed_field_0, 'pstate', val)),
+            "sp": ("computed",
+                   lambda obj: obj.unnamed_field_0.unnamed_field_0.sp,
+                   lambda obj, val: setattr(obj.unnamed_field_0.unnamed_field_0, 'sp', val)),
+            "pc": ("computed",
+                   lambda obj: obj.unnamed_field_0.unnamed_field_0.pc,
+                   lambda obj, val: setattr(obj.unnamed_field_0.unnamed_field_0, 'pc', val)),
+            "pstate": ("computed",
+                       lambda obj: obj.unnamed_field_0.unnamed_field_0.pstate,
+                       lambda obj, val: setattr(obj.unnamed_field_0.unnamed_field_0, 'pstate', val)),
             # Other fields directly in pt_regs
             "syscallno": "syscallno",
             "orig_x0": "orig_x0",
             # Aliases
             # x0 holds the return value
-            "retval": ("computed", 
-                      lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[0],
-                      lambda obj, val: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(0, val)),
+            "retval": ("computed",
+                       lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[0],
+                       lambda obj, val: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(0, val)),
             # Common aliases for named registers
             # x29
-            "fp": ("computed", 
-                  lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[29],
-                  lambda obj, val: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(29, val)),
+            "fp": ("computed",
+                   lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[29],
+                   lambda obj, val: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(29, val)),
             # x30
-            "lr": ("computed", 
-                  lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[30],
-                  lambda obj, val: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(30, val)),
+            "lr": ("computed",
+                   lambda obj: obj.unnamed_field_0.unnamed_field_0.regs[30],
+                   lambda obj, val: obj.unnamed_field_0.unnamed_field_0.regs.__setitem__(30, val)),
         }
 
         # Create a delegate for ARM mode access (but don't initialize it yet)
@@ -900,59 +900,59 @@ class PowerPCPtRegsWrapper(PtRegsWrapper):
         # PowerPC has numbered registers in the gpr array, nested two levels deep in unions/structs
         self._register_map = {
             # General purpose registers are in the gpr array inside two levels of anonymous struct/union
-            **{f"r{i}": ("computed", 
-                        lambda obj, i=i: obj_container.gpr[i],
-                        lambda obj, val, i=i: obj_container.gpr.__setitem__(i, val)) 
+            **{f"r{i}": ("computed",
+                         lambda obj, i=i: obj_container.gpr[i],
+                         lambda obj, val, i=i: obj_container.gpr.__setitem__(i, val))
                for i in range(32)},
             # Special registers are direct fields in the anonymous struct
-            "nip": ("computed", 
-                   lambda obj: obj_container.nip,
-                   lambda obj, val: setattr(obj_container, 'nip', val)),
-            "msr": ("computed", 
-                   lambda obj: obj_container.msr,
-                   lambda obj, val: setattr(obj_container, 'msr', val)),
-            "orig_r3": ("computed", 
-                       lambda obj: obj_container.orig_gpr3,
-                       lambda obj, val: setattr(obj_container, 'orig_gpr3', val)),
-            "ctr": ("computed", 
-                   lambda obj: obj_container.ctr,
-                   lambda obj, val: setattr(obj_container, 'ctr', val)),
-            "lr": ("computed", 
-                  lambda obj: obj_container.link,
-                  lambda obj, val: setattr(obj_container, 'link', val)),
-            "xer": ("computed", 
-                   lambda obj: obj_container.xer,
-                   lambda obj, val: setattr(obj_container, 'xer', val)),
-            "ccr": ("computed", 
-                   lambda obj: obj_container.ccr,
-                   lambda obj, val: setattr(obj_container, 'ccr', val)),
-            "softe": ("computed", 
-                     lambda obj: obj_container.softe,
-                     lambda obj, val: setattr(obj_container, 'softe', val)),
-            "trap": ("computed", 
-                    lambda obj: obj_container.trap,
-                    lambda obj, val: setattr(obj_container, 'trap', val)),
-            "dar": ("computed", 
-                   lambda obj: obj_container.dar,
-                   lambda obj, val: setattr(obj_container, 'dar', val)),
-            "dsisr": ("computed", 
-                     lambda obj: obj_container.dsisr,
-                     lambda obj, val: setattr(obj_container, 'dsisr', val)),
-            "result": ("computed", 
-                      lambda obj: obj_container.result,
-                      lambda obj, val: setattr(obj_container, 'result', val)),
+            "nip": ("computed",
+                    lambda obj: obj_container.nip,
+                    lambda obj, val: setattr(obj_container, 'nip', val)),
+            "msr": ("computed",
+                    lambda obj: obj_container.msr,
+                    lambda obj, val: setattr(obj_container, 'msr', val)),
+            "orig_r3": ("computed",
+                        lambda obj: obj_container.orig_gpr3,
+                        lambda obj, val: setattr(obj_container, 'orig_gpr3', val)),
+            "ctr": ("computed",
+                    lambda obj: obj_container.ctr,
+                    lambda obj, val: setattr(obj_container, 'ctr', val)),
+            "lr": ("computed",
+                   lambda obj: obj_container.link,
+                   lambda obj, val: setattr(obj_container, 'link', val)),
+            "xer": ("computed",
+                    lambda obj: obj_container.xer,
+                    lambda obj, val: setattr(obj_container, 'xer', val)),
+            "ccr": ("computed",
+                    lambda obj: obj_container.ccr,
+                    lambda obj, val: setattr(obj_container, 'ccr', val)),
+            "softe": ("computed",
+                      lambda obj: obj_container.softe,
+                      lambda obj, val: setattr(obj_container, 'softe', val)),
+            "trap": ("computed",
+                     lambda obj: obj_container.trap,
+                     lambda obj, val: setattr(obj_container, 'trap', val)),
+            "dar": ("computed",
+                    lambda obj: obj_container.dar,
+                    lambda obj, val: setattr(obj_container, 'dar', val)),
+            "dsisr": ("computed",
+                      lambda obj: obj_container.dsisr,
+                      lambda obj, val: setattr(obj_container, 'dsisr', val)),
+            "result": ("computed",
+                       lambda obj: obj_container.result,
+                       lambda obj, val: setattr(obj_container, 'result', val)),
             # Aliases
             # r1 is stack pointer
-            "sp": ("computed", 
-                  lambda obj: obj_container.gpr[1],
-                  lambda obj, val: obj_container.gpr.__setitem__(1, val)),
-            "pc": ("computed", 
-                  lambda obj: obj_container.nip,
-                  lambda obj, val: setattr(obj_container, 'nip', val)),
+            "sp": ("computed",
+                   lambda obj: obj_container.gpr[1],
+                   lambda obj, val: obj_container.gpr.__setitem__(1, val)),
+            "pc": ("computed",
+                   lambda obj: obj_container.nip,
+                   lambda obj, val: setattr(obj_container, 'nip', val)),
             # r3 holds return values
-            "retval": ("computed", 
-                      lambda obj: obj_container.gpr[3],
-                      lambda obj, val: obj_container.gpr.__setitem__(3, val)),
+            "retval": ("computed",
+                       lambda obj: obj_container.gpr[3],
+                       lambda obj, val: obj_container.gpr.__setitem__(3, val)),
         }
 
     def get_syscall_arg(self, num: int) -> Optional[int]:
@@ -1166,8 +1166,10 @@ class Riscv32PtRegsWrapper(PtRegsWrapper):
             "x31": "t6",
 
             # Alias for x0 (always zero)
-            "x0": ("computed", lambda obj: 0, lambda obj, val: None),  # x0 is hardwired to zero
-            "zero": ("computed", lambda obj: 0, lambda obj, val: None),  # x0 is hardwired to zero
+            # x0 is hardwired to zero
+            "x0": ("computed", lambda obj: 0, lambda obj, val: None),
+            # x0 is hardwired to zero
+            "zero": ("computed", lambda obj: 0, lambda obj, val: None),
 
             # Common aliases
             "pc": "epc",

--- a/tests/unit_tests/test_target/patches/tests/kffi.yaml
+++ b/tests/unit_tests/test_target/patches/tests/kffi.yaml
@@ -12,6 +12,10 @@ plugins:
         type: file_contains
         file: console.log
         string: "test printk 1 2 3 4"
+      kffi+callback:
+        type: file_contains
+        file: kffi_test.txt
+        string: "Callback called with 1, 2, 3, 4"
 
 static_files:
   /tests/kffi_test.sh:

--- a/tests/unit_tests/test_target/patches/tests/kffi.yaml
+++ b/tests/unit_tests/test_target/patches/tests/kffi.yaml
@@ -15,7 +15,7 @@ plugins:
       kffi+callback:
         type: file_contains
         file: kffi_test.txt
-        string: "Callback called with 1, 2, 3, 4"
+        string: "Callback called with expected values!"
 
 static_files:
   /tests/kffi_test.sh:


### PR DESCRIPTION
This PR introduces two new KFFI features: python callbacks and symbol lookup

The symbol lookup is a mechanism for a string to offset translation using kallsyms_lookup in the kernel.

The python callbacks are accomplished with a list of empty functions in our driver. We then allocate those by ID as a pair to python functions that request them and then set a kprobe on that callback.

In this way we can generate an address that when called in our kernel will call a specific python function.

This allows us to insert python responses to functions that would normally be implemented in C.

Further, we've added tests for this functionality.