### PR TITLE
static_analyses(pseudofiles): ignore /proc/1

### DIFF
--- a/src/penguin/static_analyses.py
+++ b/src/penguin/static_analyses.py
@@ -582,7 +582,7 @@ class PseudofileFinder(StaticAnalysis):
     # Directories that we want to just ignore entirely - don't create any entries
     # within these directories. IRQs and device-tree are related to the emulated CPU
     # self and PID are related to the process itself and dynamically created
-    PROC_IGNORE = ["irq", "self", "PID", "device-tree", "net", "vmcore"]
+    PROC_IGNORE = ["1", "irq", "self", "PID", "device-tree", "net", "vmcore"]
 
     def __init__(self):
         # Load ../resources/proc_sys.txt, add each line to IGLOO_PROCFS


### PR DESCRIPTION
Since /proc/1 is guaranteed to exist when /proc is mounted, firmware can hard-code that path, causing the pseudofile finder static analysis to find it. But it is a directory, so shouldn't be considered a pseudofile.