### PR TITLE
plugin_manager: get_arg_bool operator precedence

### DIFF
--- a/src/penguin/plugin_manager.py
+++ b/src/penguin/plugin_manager.py
@@ -213,7 +213,7 @@ class Plugin:
         """
         if arg_name not in self.args:
             return False
-        if x := interpret_bool(self.args[arg_name]) is not None:
+        if (x := interpret_bool(self.args[arg_name])) is not None:
             return x
 
         raise ValueError(f"Unsupported arg type: {type(self.args[arg_name])}")
@@ -896,7 +896,7 @@ class IGLOOPluginManager:
         """
         if arg_name not in self.args:
             return False
-        if x := interpret_bool(self.args[arg_name]) is not None:
+        if (x := interpret_bool(self.args[arg_name])) is not None:
             return x
 
         raise ValueError(f"Unsupported arg type: {type(self.args[arg_name])}")


### PR DESCRIPTION
Similar to https://github.com/rehosting/penguin/commit/15e3874045020d78486c1fe163cdb77a4aabc540, this fixes `get_arg_bool`.  Before this commit, you'd see debug output from plugins even without running `penguin` with `--verbose` 