### PR TITLE
Dockerfile: make use of local packages clear in version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -574,7 +574,7 @@ RUN used_pkgs="" ; \
             tar xzf /tmp/local_packages/igloo_driver.tar.gz -C /igloo_static; \
             used_pkgs="${used_pkgs},igloo_driver"; \
         fi; \
-        if [ ! -z "$used_pkgs" ]; then \
+        if [ -n "$used_pkgs" ]; then \
             used_pkgs=$(echo "$used_pkgs" | sed 's/^,//'); \
             echo "$(cat /pkg/penguin/version.txt)+localpackages=${used_pkgs}" > /pkg/penguin/version.txt; \
         fi; \


### PR DESCRIPTION
When developing penguin with changes in related projects we often place updated packages in the `local_packages` folder.

This is helpful for development, but it can be easy to forget or misunderstand which packages you've replaced in your image when testing.

This PR changes our dockerfile so that it is clear which packages have been modified locally in the version string for penguin.

For example, a penguin version pulled from dockerhub might have a version that looks like: 

`penguin v2.2.40`

A locally built image on a branch might look like: 

`penguin v2.2.40.dev7+gaee16a2f8.d20251024`

In that same environment if you were to provide a kernel in `local_packages` you would see:

`penguin v2.2.40.dev7+gaee16a2f8.d20251024+localpackages=kernels`

If you modified the driver as well you would see:

`penguin v2.2.40.dev7+gaee16a2f8.d20251024+localpackages=kernels,igloo_driver`

and so on for additional packages if packages have been modified.
