### PR TITLE
fix arch name for x86_64 telnet

### DIFF
--- a/src/penguin/config_patchers.py
+++ b/src/penguin/config_patchers.py
@@ -439,7 +439,7 @@ class BasePatch(PatchGenerator):
         # This is because arm uses ttyAMA (major 204) and mips uses ttyS (major 4).
         # XXX: For mips we use major 4, minor 65. For arm we use major 204, minor 65.
         # For powerpc: major 229, minor 1 (hvc1)
-        if 'mips' in self.arch_name or self.arch_name == "x86_64":
+        if 'mips' in self.arch_name or self.arch_name == "intel64":
             igloo_serial_major = 4
             igloo_serial_minor = 65
         elif self.arch_name in ['armel', 'aarch64']:


### PR DESCRIPTION
Our telnet for x86_64 was previously broken because it used the wrong major/minor dev node.

The logic was ever so slightly off because while the intention of

```python
        if 'mips' in self.arch_name or self.arch_name == "x86_64":
            igloo_serial_major = 4
            igloo_serial_minor = 65
```
is correct the name of the architecture at this point is actually `intel64` not `x86_64`.