### PR TITLE
Fixup vpn logic

### DIFF
--- a/pyplugins/actuation/vpn.py
+++ b/pyplugins/actuation/vpn.py
@@ -308,7 +308,7 @@ class VPN(Plugin):
         elif guest_port < 1024 and not self.has_perms:
             host_port = self._find_free_port(guest_port)
             reason = f"{guest_port} is privileged and user cannot bind"
-        elif guest_port in self.mapped_ports or not self._is_port_available(guest_port):
+        elif not self._is_port_available(guest_port):
             host_port = self._find_free_port(guest_port)
             reason = f"{guest_port} is already in use"
 
@@ -484,8 +484,7 @@ class VPN(Plugin):
         # If we couldn't bind to ANY of them, we assume we can't
         return False
 
-    @staticmethod
-    def _is_port_available(port: int) -> bool:
+    def _is_port_available(self, port: int) -> bool:
         """
         Check if a port is available for binding.
 
@@ -494,6 +493,9 @@ class VPN(Plugin):
         Returns:
             bool: True if port is available for binding, False otherwise.
         """
+        # First check our mapped ports
+        if port in self.mapped_ports:
+            return False
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:


### PR DESCRIPTION
The logic around our port mapping is ever so slightly broken. I was seeing results such as:

```
13:26:39 plugins.vpn INFO            process binds tcp 0.0.0.0:1900     reach it at 192.168.11.2:1900    
13:26:39 plugins.vpn INFO            process binds tcp 127.0.0.1:1900   reach it at 192.168.11.2:1900    1900 is already in use
13:26:39 plugins.vpn INFO            process binds udp 0.0.0.0:1900     reach it at 192.168.11.2:1900    1900 is already in use
13:26:39 plugins.vpn INFO            process binds udp 127.0.0.1:1900   reach it at 192.168.11.2:1900    1900 is already in use
```
The issue here being that when we find a free port we don't check that we haven't already mapped that on a previous run.

This exposes a race condition from the vpn actually claiming that port and another process grabbing it.

I've fixed this by adjusting `_is_port_available` to also check if a port is mapped.

This makes it so that ports are unavailable when they're claimed not just when the system tells us that vpn has claimed it.

It's probably a bit more efficient as well.