### PR TITLE
doc_generator: update pengutils name

### DIFF
--- a/pyplugins/docgen/doc_generator.py
+++ b/pyplugins/docgen/doc_generator.py
@@ -33,7 +33,7 @@ class SphinxGenerator(Plugin):
         self.module_specs = {
             "pyplugins": Path("/pyplugins"),
             "penguin": Path("/pkg/penguin"),
-            "events": Path("/db/events"),
+            "pengutils": Path("/pengutils/pengutils"),
         }
 
         # Prepare directories


### PR DESCRIPTION
This PR fixes an issue with a hardcoded path to the renamed pengutils library.