### PR TITLE
Net errors

### DIFF
--- a/pyplugins/apis/net.py
+++ b/pyplugins/apis/net.py
@@ -201,6 +201,9 @@ class Netdevs(Plugin):
             return 0
 
         for name in names:
+            if len(name) > 15:
+                self.logger.error(f"Netdev name '{name}' exceeds 15 character limit and will be ignored")
+                continue
             buf = name.encode("latin-1", errors="ignore") + b"\0"
             result = yield PortalCmd(hop.HYPER_OP_REGISTER_NETDEV, 0, len(buf), None, buf)
             is_up = yield from self.set_netdev_state(name, True)
@@ -214,7 +217,7 @@ class Netdevs(Plugin):
                         self.logger.error(f"Failed to register or look up '{name}'")
                         return
                 else:
-                    self.logger.error(f"Failed to register netdev '{name}' (kernel returned 0)")
+                    self.logger.info(f"Failed to register netdev '{name}' (kernel returned 0)")
                     return
             self._netdev_structs[name] = result
             yield from self._net_setup(name, result)


### PR DESCRIPTION
This PR does the following:
- ignores (and gives an error) if netdev names exceed 15 characters
- Tones down failed to register netdev as these could just be already registered