### PR TITLE
core: add log_file option for penguin logger

### DIFF
--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -224,6 +224,19 @@ false
 true
 ```
 
+### `core.log_file` Penguin log file
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+If set, write penguin/plugin logger output to this file (relative paths resolve under the results dir).
+
+```yaml
+penguin.log
+```
+
 ### `core.immutable` Enable immutable mode
 
 |||

--- a/pyplugins/core/core.py
+++ b/pyplugins/core/core.py
@@ -33,11 +33,12 @@ The Core plugin ensures the emulation environment is correctly set up, manages s
 procedures, and records essential information for reproducibility and debugging.
 """
 
+import logging
 import os
 import signal
 import threading
 import time
-from penguin import Plugin, yaml, plugins
+from penguin import Plugin, yaml, plugins, common
 from penguin.defaults import vnc_password
 
 
@@ -68,6 +69,17 @@ class Core(Plugin):
         conf = self.get_arg("conf")
 
         telnet_port = self.get_arg("telnet_port")
+        log_file = conf["core"].get("log_file")
+        if log_file:
+            if not os.path.isabs(log_file):
+                log_file = os.path.join(self.outdir, log_file)
+            fh = logging.FileHandler(log_file)
+            fh.setFormatter(common.PathHighlightingFormatter(
+                fmt="%(asctime)s %(name)s %(levelname)s %(message)s",
+                datefmt="%H:%M:%S",
+            ))
+            common.redirect_logs_to(fh)
+            self.logger.info(f"Penguin logs redirected to {log_file}")
 
         # Essential plugins are always loaded with core
         essential_plugins = [

--- a/pyplugins/core/core.py
+++ b/pyplugins/core/core.py
@@ -71,18 +71,21 @@ class Core(Plugin):
         telnet_port = self.get_arg("telnet_port")
         log_file = conf["core"].get("log_file")
         if log_file:
-            if not os.path.isabs(log_file):
-                log_file = os.path.join(self.outdir, log_file)
-            log_dir = os.path.dirname(log_file)
-            if log_dir:
-                os.makedirs(log_dir, exist_ok=True)
-            fh = logging.FileHandler(log_file)
-            fh.setFormatter(common.PathHighlightingFormatter(
-                fmt="%(asctime)s %(name)s %(levelname)s %(message)s",
-                datefmt="%H:%M:%S",
-            ))
-            common.redirect_logs_to(fh)
-            self.logger.info(f"Penguin logs redirected to {log_file}")
+            try:
+                if not os.path.isabs(log_file):
+                    log_file = os.path.join(self.outdir, log_file)
+                log_dir = os.path.dirname(log_file)
+                if log_dir:
+                    os.makedirs(log_dir, exist_ok=True)
+                fh = logging.FileHandler(log_file)
+                fh.setFormatter(common.PathHighlightingFormatter(
+                    fmt="%(asctime)s %(name)s %(levelname)s %(message)s",
+                    datefmt="%H:%M:%S",
+                ))
+                common.redirect_logs_to(fh)
+                self.logger.info(f"Penguin logs redirected to {log_file}")
+            except Exception as e:
+                self.logger.error(f"Error during setup of log file. core.log_file: {log_file}\n{e}")
 
         # Essential plugins are always loaded with core
         essential_plugins = [

--- a/pyplugins/core/core.py
+++ b/pyplugins/core/core.py
@@ -73,6 +73,9 @@ class Core(Plugin):
         if log_file:
             if not os.path.isabs(log_file):
                 log_file = os.path.join(self.outdir, log_file)
+            log_dir = os.path.dirname(log_file)
+            if log_dir:
+                os.makedirs(log_dir, exist_ok=True)
             fh = logging.FileHandler(log_file)
             fh.setFormatter(common.PathHighlightingFormatter(
                 fmt="%(asctime)s %(name)s %(levelname)s %(message)s",

--- a/src/penguin/common.py
+++ b/src/penguin/common.py
@@ -11,7 +11,7 @@ _redirect_handler: logging.Handler | None = None
 
 def redirect_logs_to(handler: logging.Handler) -> None:
     """
-    Replace stderr StreamHandlers with `handler` for all current and future
+    Replace StreamHandlers with `handler` for all current and future
     penguin/plugins/config loggers.
     """
     global _redirect_handler

--- a/src/penguin/common.py
+++ b/src/penguin/common.py
@@ -6,6 +6,28 @@ import yaml
 from os.path import join, isfile, basename
 from yamlcore import CoreDumper, CoreLoader
 
+_redirect_handler: logging.Handler | None = None
+
+
+def redirect_logs_to(handler: logging.Handler) -> None:
+    """
+    Replace stderr StreamHandlers with `handler` for all current and future
+    penguin/plugins/config loggers.
+    """
+    global _redirect_handler
+    _redirect_handler = handler
+    for name, lg in list(logging.Logger.manager.loggerDict.items()):
+        if not isinstance(lg, logging.Logger):
+            continue
+        if not (name == "penguin" or name.startswith("penguin.")
+                or name == "plugins" or name.startswith("plugins.")
+                or name == "config"):
+            continue
+        # Strict type check: drop plain StreamHandler, keep FileHandler/NullHandler/etc.
+        lg.handlers = [h for h in lg.handlers if type(h) is not logging.StreamHandler]
+        if handler not in lg.handlers:
+            lg.addHandler(handler)
+
 
 # Hex integers
 def int_to_hex_representer(dumper, data):
@@ -217,12 +239,21 @@ def getColoredLogger(name):
 
     # Check if the logger already has handlers to prevent duplicate logs
     if not logger.handlers:
-        # Create and configure a stream handler
-        handler = logging.StreamHandler()
-        logger.setLevel(level)
-        handler.setLevel(level)  # Set the handler level
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
+        if _redirect_handler is not None:
+            # Logs are being redirected: skip the default stderr StreamHandler.
+            logger.setLevel(level)
+            logger.addHandler(_redirect_handler)
+        else:
+            # Default: stderr.
+            handler = logging.StreamHandler()
+            logger.setLevel(level)
+            handler.setLevel(level)
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+    elif _redirect_handler is not None and _redirect_handler not in logger.handlers:
+        # Redirect was set after this logger was already created — swap.
+        logger.handlers = [h for h in logger.handlers if type(h) is not logging.StreamHandler]
+        logger.addHandler(_redirect_handler)
 
     # Prevent log messages from propagating to parent loggers (i.e., penguin.manager should not also log for penguin)
     logger.propagate = False

--- a/src/penguin/common.py
+++ b/src/penguin/common.py
@@ -15,6 +15,8 @@ def redirect_logs_to(handler: logging.Handler) -> None:
     penguin/plugins/config loggers.
     """
     global _redirect_handler
+    handler._penguin_redirect = True  # marker for custom_set_level — exclude from per-logger level propagation
+    handler.setLevel(logging.NOTSET)
     _redirect_handler = handler
     for name, lg in list(logging.Logger.manager.loggerDict.items()):
         if not isinstance(lg, logging.Logger):
@@ -266,6 +268,8 @@ def getColoredLogger(name):
             # Call the original method, not the monkeypatched one
             original_set_level(level)
             for handler in logger.handlers:
+                if getattr(handler, '_penguin_redirect', False):
+                    continue
                 handler.setLevel(level)
 
         logger.custom_set_level = custom_set_level

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -198,10 +198,10 @@ class Core(PartialModelMixin, BaseModel):
     log_file: Annotated[
       Optional[str],
       Field(
-          None,
-          title="Penguin log file",
-          description="If set, write penguin/plugin logger output to this file (relative paths resolve under the results dir).",
-          examples=["penguin.log"],
+            None,
+            title="Penguin log file",
+            description="If set, write penguin/plugin logger output to this file (relative paths resolve under the results dir).",
+            examples=["penguin.log"],
       ),
     ]
     immutable: Annotated[

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -195,6 +195,15 @@ class Core(PartialModelMixin, BaseModel):
             examples=[False, True],
         ),
     ]
+    log_file: Annotated[
+      Optional[str],
+      Field(
+          None,
+          title="Penguin log file",
+          description="If set, write penguin/plugin logger output to this file (relative paths resolve under the results dir).",
+          examples=["penguin.log"],
+      ),
+    ]
     immutable: Annotated[
         bool,
         Field(


### PR DESCRIPTION
This PR adds an option, `log_file`, to `core` to move penguin logger from stderr (which gets promoted to stdout because `docker -it`) to a file.

Example usage:
```yaml
core:
    log_file: penguin.log
```
Gives:
```bash
$ tail -f ./projects/FIRMWARE/results/latest/penguin.log 
08:47:38 plugins.vpn INFO             nmbd binds udp 0.0.0.0:138      reach it at 192.168.3.2:138      
08:47:38 plugins.vpn INFO         lighttpd binds tcp 192.168.0.100:443 reach it at 192.168.3.2:1443     443 is already in use
08:47:38 plugins.vpn INFO         dropbear binds tcp 192.168.0.100:22 reach it at 192.168.3.2:1022     22 is already in use
08:47:38 plugins.vpn INFO             nmbd binds udp 192.168.0.100:138 reach it at 192.168.3.2:1138     138 is already in use
08:47:38 plugins.vpn INFO            snmpd binds udp 192.168.0.100:161 reach it at 192.168.3.2:1161     161 is already in use
08:47:38 plugins.vpn INFO         lighttpd binds tcp 192.168.0.100:80 reach it at 192.168.3.2:1080     80 is already in use
```

Note: we still output all the ANSI codes so that things like `tail`, `less -R` etc... look nice. If that's annoying we can add an option later to output plain text.