### PR TITLE
fix(config): log error when patch in config is not found

### DIFF
--- a/src/penguin/penguin_config/__init__.py
+++ b/src/penguin/penguin_config/__init__.py
@@ -230,6 +230,8 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
                     origin_map=origin_map,           # Pass the state map
                     verbose=verbose
                 )
+            else:
+                logger.error(f"patch file {patch} not found, ignoring")
 
     config = config.model_dump()
     if config["core"].get("guest_cmd", False) is True:


### PR DESCRIPTION
Previously, if a patch file in the `patches` section of the config was not found, it would be silently ignored. Now it shows an error. It also just prints the error without exiting PENGUIN to avoid breaking old configs.