### PR TITLE
core: add 32-bit compatibility handling for ioctl in Devfs and Procfs classes

### DIFF
--- a/pyplugins/apis/osi.py
+++ b/pyplugins/apis/osi.py
@@ -239,7 +239,7 @@ class OSI(Plugin):
             if not mappings_bytes:
                 self.logger.debug("No mapping data received")
                 if not all_mappings:  # If this was our first request
-                    return [], 0
+                    return MappingsWrapper([])
                 break
 
             orh_struct = kffi.from_buffer("osi_result_header", mappings_bytes)

--- a/pyplugins/hyperfile/devfs.py
+++ b/pyplugins/hyperfile/devfs.py
@@ -17,6 +17,7 @@ class Devfs(Plugin):
 
         plugins.portal.register_interrupt_handler(
             "devfs", self._hyperdevfs_interrupt_handler)
+        self._is_32bit = self.panda.bits == 32
 
     def _get_overridden_methods(self, devfs_file: DevFile) -> Dict[str, callable]:
         base = DevFile
@@ -35,6 +36,13 @@ class Devfs(Plugin):
                 and meth.__code__ is not base_meth.__code__
             ):
                 overridden[name] = meth
+        '''
+        compat_ioctl runs on 64-bit systems in a 32-bit context
+        We auto-register it for 64-bit systems if they don't override it
+        '''
+        if not self._is_32bit:
+            if "ioctl" in overridden and "compat_ioctl" not in overridden:
+                overridden["compat_ioctl"] = overridden["ioctl"]
         return overridden
 
     def _make_ops_struct(self, devfs_file: DevFile):

--- a/pyplugins/hyperfile/procfs.py
+++ b/pyplugins/hyperfile/procfs.py
@@ -35,7 +35,7 @@ class Proc(Plugin):
                 and meth.__code__ is not base_meth.__code__
             ):
                 overridden[name] = meth
-        
+
         '''
         compat_ioctl runs on 64-bit systems in a 32-bit context
         We auto-register it for 64-bit systems if they don't override it

--- a/pyplugins/hyperfile/procfs.py
+++ b/pyplugins/hyperfile/procfs.py
@@ -14,6 +14,7 @@ class Proc(Plugin):
         self._proc_dirs: Dict[str, int] = {}  # path -> dir id
         plugins.portal.register_interrupt_handler(
             "procfs", self._proc_interrupt_handler)
+        self._is_32bit = self.panda.bits == 32
 
     def _get_overridden_methods(self, proc_file: ProcFile) -> Dict[str, callable]:
         """
@@ -34,6 +35,14 @@ class Proc(Plugin):
                 and meth.__code__ is not base_meth.__code__
             ):
                 overridden[name] = meth
+        
+        '''
+        compat_ioctl runs on 64-bit systems in a 32-bit context
+        We auto-register it for 64-bit systems if they don't override it
+        '''
+        if not self._is_32bit:
+            if "ioctl" in overridden and "compat_ioctl" not in overridden:
+                overridden["compat_ioctl"] = overridden["ioctl"]
         return overridden
 
     def _make_fops_struct(self, proc_file: ProcFile):


### PR DESCRIPTION
We automatically handle 32-bit `compat_ioctl` registration for 64-bit guests

Also fix osi get_mappings bug.