### PR TITLE
project dir drop-ins for init.d, source.d, plugins.d

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   REGISTRY: ${{ secrets.REHOSTING_ARC_REGISTRY || 'harbor.harbor.svc.cluster.local' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -199,16 +199,9 @@ WORKDIR /source
 RUN wget -q https://raw.githubusercontent.com/panda-re/libhc/main/hypercall.h
 RUN make all
 
-# Stage per-arch *minimum* musl sysroots so the runtime image can cross-compile
-# small C drop-ins with the existing clang-20 (no full toolchain needed).
-# Per arch we copy: crt*.o + Scrt1.o, libc.{a,so}, ld-musl-*, musl stub libs
-# (libm/libpthread/libdl/librt/libresolv/libutil/libcrypt/libxnet/libssp_nonshared),
-# libgcc.a + libgcc_eh.a + libgcc_s.so* (linker script + .so.1), and the GCC
-# crtbegin/crtend variants. include/ is wired up by symlink in the final stage
-# pointing at /igloo_static/musl-headers/<musl_arch>/ to avoid ~22M/arch dupes.
-# Total: ~127 MB across 11 arches. loongarch64 SKIPPED — its toolchain is a
-# glibc cross with a different sysroot layout (target/usr/lib64), so it would
-# need a separate code path; revisit when a drop-in actually targets it.
+# Stage per-arch link-time sysroot skeletons for project init.d/*.c drop-ins.
+# Runtime libc support comes from /igloo/dylibs, which is already shipped in
+# each rehosting, so only startup objects need to be copied from toolchains.
 RUN set -eux; mkdir -p /sysroots; \
     stage() { \
         local penguin_arch="$1" triple_dir="$2" triple="$3"; \
@@ -216,16 +209,12 @@ RUN set -eux; mkdir -p /sysroots; \
         local gccbase="/opt/cross/${triple_dir}/lib/gcc/${triple}"; \
         local dst="/sysroots/${penguin_arch}/lib"; \
         mkdir -p "$dst"; \
-        for f in crt1.o crti.o crtn.o Scrt1.o rcrt1.o gcrt1.o \
-                 libc.a libc.so \
-                 libm.a libpthread.a libdl.a librt.a libresolv.a libutil.a libcrypt.a libxnet.a \
-                 libssp_nonshared.a libgcc_s.so libgcc_s.so.1; do \
+        for f in crt1.o crti.o crtn.o Scrt1.o rcrt1.o; do \
             [ -e "$src/lib/$f" ] && cp -P "$src/lib/$f" "$dst/" || true; \
         done; \
-        for f in "$src/lib"/ld-musl-*; do [ -e "$f" ] && cp -P "$f" "$dst/" || true; done; \
         if [ -d "$gccbase" ]; then \
             local gccver="$(ls "$gccbase" | head -1)"; \
-            for f in libgcc.a libgcc_eh.a crtbegin.o crtbeginS.o crtbeginT.o crtend.o crtendS.o; do \
+            for f in crtbegin.o crtbeginS.o crtbeginT.o crtend.o crtendS.o; do \
                 [ -e "$gccbase/$gccver/$f" ] && cp -P "$gccbase/$gccver/$f" "$dst/" || true; \
             done; \
         fi; \
@@ -501,19 +490,30 @@ COPY --from=downloader /tmp/ltrace /igloo_static/ltrace
 
 # Copy source and binaries from host
 COPY --from=cross_builder /source/out /igloo_static/
-# Minimum per-arch musl sysroots for compiling per-project drop-in C files
-# with the existing clang-20 (no big toolchain needed). Each arch's include/
-# is symlinked into /igloo_static/musl-headers/<musl_arch>/include to avoid
-# duplicating ~22 MB of headers per arch (saves ~240 MB total).
+# Tiny per-arch musl sysroots for compiling per-project init.d/*.c files.
+# Headers and dynamic libc/libgcc are symlinked to existing /igloo_static
+# assets, keeping this layer under 1 MB instead of copying libc.a/libgcc.a.
 COPY --from=cross_builder /sysroots /igloo_static/sysroots
 RUN set -eux; \
-    for pair in armel=arm aarch64=aarch64 powerpc=powerpc powerpc64=powerpc64 \
-                powerpc64le=powerpc64 riscv64=riscv64 mipsel=mips mipseb=mips \
-                mips64el=mips64 mips64eb=mips64 intel64=x86_64; do \
-        arch="${pair%=*}"; musl_arch="${pair#*=}"; \
+    stage() { \
+        arch="$1"; musl_arch="$2"; dylib_arch="$3"; \
         ln -sfn /igloo_static/musl-headers/$musl_arch/include /igloo_static/sysroots/$arch/include; \
         ln -sfn ../include /igloo_static/sysroots/$arch/usr/include; \
-    done
+        ln -sfn /igloo_static/dylibs/$dylib_arch/libc.so /igloo_static/sysroots/$arch/lib/libc.so; \
+        ln -sfn /igloo_static/dylibs/$dylib_arch/libgcc_s.so.1 /igloo_static/sysroots/$arch/lib/libgcc_s.so.1; \
+        ln -sfn libgcc_s.so.1 /igloo_static/sysroots/$arch/lib/libgcc_s.so; \
+    }; \
+    stage armel       arm       armel; \
+    stage aarch64     aarch64   arm64; \
+    stage powerpc     powerpc   ppc; \
+    stage powerpc64   powerpc64 ppc64; \
+    stage powerpc64le powerpc64 ppc64el; \
+    stage riscv64     riscv64   riscv64; \
+    stage mipsel      mips      mipsel; \
+    stage mipseb      mips      mipseb; \
+    stage mips64el    mips64    mips64el; \
+    stage mips64eb    mips64    mips64eb; \
+    stage intel64     x86_64    x86_64
 COPY guest-utils /igloo_static/guest-utils
 COPY --from=rust_builder /root/vhost-device/target/x86_64-unknown-linux-gnu/release/vhost-device-vsock /usr/local/bin/vhost-device-vsock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -199,6 +199,52 @@ WORKDIR /source
 RUN wget -q https://raw.githubusercontent.com/panda-re/libhc/main/hypercall.h
 RUN make all
 
+# Stage per-arch *minimum* musl sysroots so the runtime image can cross-compile
+# small C drop-ins with the existing clang-20 (no full toolchain needed).
+# Per arch we copy: crt*.o + Scrt1.o, libc.{a,so}, ld-musl-*, musl stub libs
+# (libm/libpthread/libdl/librt/libresolv/libutil/libcrypt/libxnet/libssp_nonshared),
+# libgcc.a + libgcc_eh.a + libgcc_s.so* (linker script + .so.1), and the GCC
+# crtbegin/crtend variants. include/ is wired up by symlink in the final stage
+# pointing at /igloo_static/musl-headers/<musl_arch>/ to avoid ~22M/arch dupes.
+# Total: ~127 MB across 11 arches. loongarch64 SKIPPED — its toolchain is a
+# glibc cross with a different sysroot layout (target/usr/lib64), so it would
+# need a separate code path; revisit when a drop-in actually targets it.
+RUN set -eux; mkdir -p /sysroots; \
+    stage() { \
+        local penguin_arch="$1" triple_dir="$2" triple="$3"; \
+        local src="/opt/cross/${triple_dir}/${triple}"; \
+        local gccbase="/opt/cross/${triple_dir}/lib/gcc/${triple}"; \
+        local dst="/sysroots/${penguin_arch}/lib"; \
+        mkdir -p "$dst"; \
+        for f in crt1.o crti.o crtn.o Scrt1.o rcrt1.o gcrt1.o \
+                 libc.a libc.so \
+                 libm.a libpthread.a libdl.a librt.a libresolv.a libutil.a libcrypt.a libxnet.a \
+                 libssp_nonshared.a libgcc_s.so libgcc_s.so.1; do \
+            [ -e "$src/lib/$f" ] && cp -P "$src/lib/$f" "$dst/" || true; \
+        done; \
+        for f in "$src/lib"/ld-musl-*; do [ -e "$f" ] && cp -P "$f" "$dst/" || true; done; \
+        if [ -d "$gccbase" ]; then \
+            local gccver="$(ls "$gccbase" | head -1)"; \
+            for f in libgcc.a libgcc_eh.a crtbegin.o crtbeginS.o crtbeginT.o crtend.o crtendS.o; do \
+                [ -e "$gccbase/$gccver/$f" ] && cp -P "$gccbase/$gccver/$f" "$dst/" || true; \
+            done; \
+        fi; \
+        mkdir -p "/sysroots/${penguin_arch}/usr"; \
+        ln -sfn ../lib "/sysroots/${penguin_arch}/usr/lib"; \
+    }; \
+    stage armel       arm-linux-musleabi-cross     arm-linux-musleabi; \
+    stage aarch64     aarch64-linux-musl-cross     aarch64-linux-musl; \
+    stage powerpc     powerpc-linux-musl-cross     powerpc-linux-musl; \
+    stage powerpc64   powerpc64-linux-musl-cross   powerpc64-linux-musl; \
+    stage powerpc64le powerpc64le-linux-musl-cross powerpc64le-linux-musl; \
+    stage riscv64     riscv64-linux-musl-cross     riscv64-linux-musl; \
+    stage mipsel      mipsel-linux-musl            mipsel-linux-musl; \
+    stage mipseb      mipseb-linux-musl            mipseb-linux-musl; \
+    stage mips64el    mips64el-linux-musl-cross    mips64el-linux-musl; \
+    stage mips64eb    mips64-linux-musl-cross      mips64-linux-musl; \
+    stage intel64     x86_64-linux-musl-cross      x86_64-linux-musl; \
+    du -sh /sysroots/* | sort -h; du -sh /sysroots
+
 #### NMAP BUILDER: Build nmap ####
 FROM base_mirrored AS nmap_builder
 ENV DEBIAN_FRONTEND=noninteractive
@@ -455,6 +501,19 @@ COPY --from=downloader /tmp/ltrace /igloo_static/ltrace
 
 # Copy source and binaries from host
 COPY --from=cross_builder /source/out /igloo_static/
+# Minimum per-arch musl sysroots for compiling per-project drop-in C files
+# with the existing clang-20 (no big toolchain needed). Each arch's include/
+# is symlinked into /igloo_static/musl-headers/<musl_arch>/include to avoid
+# duplicating ~22 MB of headers per arch (saves ~240 MB total).
+COPY --from=cross_builder /sysroots /igloo_static/sysroots
+RUN set -eux; \
+    for pair in armel=arm aarch64=aarch64 powerpc=powerpc powerpc64=powerpc64 \
+                powerpc64le=powerpc64 riscv64=riscv64 mipsel=mips mipseb=mips \
+                mips64el=mips64 mips64eb=mips64 intel64=x86_64; do \
+        arch="${pair%=*}"; musl_arch="${pair#*=}"; \
+        ln -sfn /igloo_static/musl-headers/$musl_arch/include /igloo_static/sysroots/$arch/include; \
+        ln -sfn ../include /igloo_static/sysroots/$arch/usr/include; \
+    done
 COPY guest-utils /igloo_static/guest-utils
 COPY --from=rust_builder /root/vhost-device/target/x86_64-unknown-linux-gnu/release/vhost-device-vsock /usr/local/bin/vhost-device-vsock
 

--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -420,6 +420,23 @@ false
 true
 ```
 
+### `core.startup_script` Inline guest startup script
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Shell script body dropped into /igloo/init.d to run during guest boot. Installed under a name that sorts after other init.d entries so it runs last. A '#!/igloo/utils/sh' shebang is prepended automatically.
+
+```yaml
+'ip link set eth0 up
+
+  udhcpc -i eth0
+
+  '
+```
+
 ## `patches` Patches
 
 |||

--- a/src/penguin/__main__.py
+++ b/src/penguin/__main__.py
@@ -293,6 +293,13 @@ def _do_package(project_dir, output_path):
     if os.path.exists(static_dir):
         _add_file("static")
 
+    # Bundle drop-in directories wholesale so .c/.h sources and disabled
+    # plugins travel with the project even when nothing references them
+    # directly via static_files.
+    for dropin in ("init.d", "source.d", "plugins.d"):
+        if os.path.exists(os.path.join(project_dir_abs, dropin)):
+            _add_file(dropin)
+
     # Add explicit file references from the VALIDATED config
     core = config.get("core", {})
     _add_file(core.get("fs"))

--- a/src/penguin/config_patchers.py
+++ b/src/penguin/config_patchers.py
@@ -429,6 +429,8 @@ class BasePatch(PatchGenerator):
             self.dylib_dir = "x86_64"
         elif arch_identified == "loongarch64":
             self.dylib_dir = "loongarch"
+        elif self.arch_name == "powerpc64le":
+            self.dylib_dir = "ppc64el"
         elif "powerpc" in self.arch_name:
             self.dylib_dir = self.arch_name.replace("powerpc", "ppc")  # dylibs are built with short names
         else:

--- a/src/penguin/dropin_compile.py
+++ b/src/penguin/dropin_compile.py
@@ -1,0 +1,138 @@
+import glob
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+import penguin
+from penguin.abi_info import ARCH_ABI_INFO
+from penguin.defaults import static_dir as STATIC_DIR
+
+
+logger = penguin.getColoredLogger("dropin_compile")
+
+
+DYLIB_DIRS = {
+    "aarch64": "arm64",
+    "intel64": "x86_64",
+    "loongarch64": "loongarch",
+    "powerpc": "ppc",
+    "powerpc64": "ppc64",
+    "powerpc64le": "ppc64el",
+}
+
+
+def _default_abi_info(arch: str) -> Dict[str, Any]:
+    arch_info = ARCH_ABI_INFO[arch]
+    abi = arch_info["default_abi"]
+    abi_info = arch_info["abis"][abi]
+    return {
+        "abi": abi,
+        "target_triple": abi_info.get("target_triple") or arch_info["target_triple"],
+        "m_flags": abi_info["m_flags"],
+    }
+
+
+def _dylib_dir(arch: str) -> str:
+    return DYLIB_DIRS.get(arch, arch)
+
+
+def _loader_name(arch: str) -> str:
+    dylib_dir = _dylib_dir(arch)
+    matches = glob.glob(os.path.join(STATIC_DIR, "dylibs", dylib_dir, "ld-musl-*.so.1"))
+    if not matches:
+        raise FileNotFoundError(
+            f"no musl loader found for {arch} in {os.path.join(STATIC_DIR, 'dylibs', dylib_dir)}"
+        )
+    return os.path.basename(matches[0])
+
+
+def _source_signature(init_dir: Path) -> str:
+    digest = hashlib.sha256()
+    paths = [
+        path
+        for pattern in ("*.c", "*.h")
+        for path in init_dir.glob(pattern)
+        if path.is_file()
+    ]
+    for path in sorted(paths):
+        digest.update(path.name.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def compile_init_c_dropin(proj_dir: str, init_dir: str, source_path: str, config: Dict[str, Any]) -> str:
+    """Compile an init.d/*.c drop-in and return its project-local binary path."""
+    arch = config["core"]["arch"]
+    if arch not in ARCH_ABI_INFO:
+        raise ValueError(f"cannot compile C drop-in {source_path}: unsupported architecture {arch}")
+
+    sysroot = Path(STATIC_DIR) / "sysroots" / arch
+    if not sysroot.is_dir():
+        raise FileNotFoundError(
+            f"cannot compile C drop-in {source_path}: missing {sysroot}. "
+            "Rebuild the penguin container with drop-in sysroot support."
+        )
+
+    init_path = Path(init_dir)
+    source = Path(source_path)
+    output_dir = Path(proj_dir) / ".dropin_build" / arch
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output = output_dir / source.stem
+    stamp = output.with_name(output.name + ".sha256")
+    source_signature = _source_signature(init_path)
+
+    if output.exists() and stamp.exists() and stamp.read_text() == source_signature:
+        return str(output)
+
+    abi_info = _default_abi_info(arch)
+    loader = _loader_name(arch)
+    lib_dir = sysroot / "lib"
+    startup = [lib_dir / name for name in ("Scrt1.o", "crti.o", "crtbeginS.o")]
+    finish = [lib_dir / name for name in ("crtendS.o", "crtn.o")]
+    missing = [str(path) for path in startup + finish if not path.exists()]
+    if missing:
+        raise FileNotFoundError(
+            f"cannot compile C drop-in {source_path}: missing startup files: {', '.join(missing)}"
+        )
+
+    cmd = [
+        "clang-20",
+        "--target=" + abi_info["target_triple"],
+        "--sysroot=" + str(sysroot),
+        "-fuse-ld=lld",
+        "-Oz",
+        "-nostdlib",
+        "-pie",
+        "-I",
+        str(init_path),
+        "-Wl,--dynamic-linker,/igloo/dylibs/" + loader,
+        "-Wl,-rpath,/igloo/dylibs",
+        "-Wl,--strip-all",
+    ]
+    cmd += [
+        f"-m{key.replace('_', '-')}={value}"
+        for key, value in abi_info["m_flags"].items()
+    ]
+    cmd += [str(path) for path in startup]
+    tmp_output = output.with_name(output.name + ".tmp")
+    cmd += [str(source), "-L" + str(lib_dir), "-lc", "-lgcc_s"]
+    cmd += [str(path) for path in finish]
+    cmd += ["-o", str(tmp_output)]
+
+    logger.info(f"Compiling C drop-in {source_path} for {arch}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        if result.stdout:
+            logger.error(result.stdout)
+        if result.stderr:
+            logger.error(result.stderr)
+        raise RuntimeError(f"failed to compile C drop-in {source_path}")
+
+    tmp_output.chmod(0o755)
+    os.replace(tmp_output, output)
+    stamp.write_text(source_signature)
+    return str(output)

--- a/src/penguin/penguin_config/__init__.py
+++ b/src/penguin/penguin_config/__init__.py
@@ -278,6 +278,20 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
                 "mode": 0o755,
             }
 
+    startup_script = config["core"].get("startup_script")
+    if startup_script:
+        guest_path = "/igloo/init.d/zz_startup_script"
+        if guest_path in config["static_files"]:
+            logger.warning(
+                f"core.startup_script is overriding existing static_files entry "
+                f"{guest_path} (previously set by a patch, base config, or drop-in)"
+            )
+        config["static_files"][guest_path] = {
+            "type": "inline_file",
+            "contents": "#!/igloo/utils/sh\n" + startup_script,
+            "mode": 0o755,
+        }
+
     plugins_dir = os.path.join(proj_dir, "plugins.d")
     if os.path.isdir(plugins_dir):
         if not isinstance(config.get("plugins"), dict):

--- a/src/penguin/penguin_config/__init__.py
+++ b/src/penguin/penguin_config/__init__.py
@@ -245,6 +245,61 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
             contents="RUST_LOG=info /igloo/utils/guesthopper --shell /igloo/utils/sh &",
             mode=0o755,
         )
+
+    # Project drop-ins are applied after patches so the user's per-project
+    # files always win over inherited base configs and patch layers.
+    for dropin_dir in ("init.d", "source.d"):
+        host_dir = os.path.join(proj_dir, dropin_dir)
+        if not os.path.isdir(host_dir):
+            continue
+        for filename in sorted(os.listdir(host_dir)):
+            if filename.startswith("."):
+                continue
+            host_path = os.path.join(host_dir, filename)
+            if not os.path.isfile(host_path):
+                continue
+            guest_path = f"/igloo/{dropin_dir}/{filename}"
+            if guest_path in config["static_files"]:
+                logger.warning(
+                    f"drop-in {host_path} is overriding existing static_files entry "
+                    f"{guest_path} (previously set by a patch or base config)"
+                )
+            config["static_files"][guest_path] = {
+                "type": "host_file",
+                "host_path": host_path,
+                "mode": 0o755,
+            }
+
+    plugins_dir = os.path.join(proj_dir, "plugins.d")
+    if os.path.isdir(plugins_dir):
+        if not isinstance(config.get("plugins"), dict):
+            config["plugins"] = {}
+        for filename in sorted(os.listdir(plugins_dir)):
+            if not filename.endswith(".py"):
+                continue
+            host_path = os.path.join(plugins_dir, filename)
+            if not os.path.isfile(host_path):
+                continue
+            plugin_name = filename[:-3]
+            sidecar = os.path.join(plugins_dir, f"{plugin_name}.yaml")
+            args: Dict[str, Any] = {}
+            if os.path.isfile(sidecar):
+                with open(sidecar, "r") as f:
+                    loaded = yaml.load(f, Loader=CoreLoader)
+                if isinstance(loaded, dict):
+                    args = loaded
+                else:
+                    logger.debug(
+                        f"plugins.d sidecar {sidecar} is not a dict (got {type(loaded).__name__}); "
+                        f"using empty args for plugin {plugin_name}"
+                    )
+            if plugin_name in config["plugins"]:
+                logger.warning(
+                    f"drop-in plugin {host_path} is overriding existing plugins entry "
+                    f"'{plugin_name}' (previously set by a patch or base config)"
+                )
+            config["plugins"][plugin_name] = args
+
     # Use pre-resolved kernel if provided, otherwise resolve it
     if resolved_kernel:
         config["core"]["kernel"] = resolved_kernel

--- a/src/penguin/penguin_config/__init__.py
+++ b/src/penguin/penguin_config/__init__.py
@@ -23,6 +23,7 @@ from pydantic.config import ConfigDict
 import penguin
 try:
     from penguin.common import patch_config
+    from penguin.dropin_compile import compile_init_c_dropin
     from penguin.utils import construct_empty_fs
     from penguin.utils import get_kernel
 except ImportError:
@@ -258,7 +259,14 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
             host_path = os.path.join(host_dir, filename)
             if not os.path.isfile(host_path):
                 continue
-            guest_path = f"/igloo/{dropin_dir}/{filename}"
+            if dropin_dir == "init.d" and filename.endswith(".h"):
+                continue
+            if dropin_dir == "init.d" and filename.endswith(".c"):
+                static_host_path = compile_init_c_dropin(proj_dir, host_dir, host_path, config)
+                guest_path = f"/igloo/{dropin_dir}/{Path(filename).stem}"
+            else:
+                static_host_path = host_path
+                guest_path = f"/igloo/{dropin_dir}/{filename}"
             if guest_path in config["static_files"]:
                 logger.warning(
                     f"drop-in {host_path} is overriding existing static_files entry "
@@ -266,7 +274,7 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
                 )
             config["static_files"][guest_path] = {
                 "type": "host_file",
-                "host_path": host_path,
+                "host_path": static_host_path,
                 "mode": 0o755,
             }
 

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -301,6 +301,19 @@ class Core(PartialModelMixin, BaseModel):
             examples=[False, True],
         ),
     ]
+    startup_script: Annotated[
+        Optional[str],
+        Field(
+            None,
+            title="Inline guest startup script",
+            description=" ".join((
+                "Shell script body dropped into /igloo/init.d to run during guest boot.",
+                "Installed under a name that sorts after other init.d entries so it runs last.",
+                "A '#!/igloo/utils/sh' shebang is prepended automatically.",
+            )),
+            examples=["ip link set eth0 up\nudhcpc -i eth0\n"],
+        ),
+    ]
 
 
 EnvVal = _newtype(

--- a/src/penguin/plugin_manager.py
+++ b/src/penguin/plugin_manager.py
@@ -334,6 +334,8 @@ def gen_search_locations(plugin_name: str, proj_dir: str,
         join(proj_dir, plugin_name + ".py"),
         join(proj_dir, "plugins", plugin_name),
         join(proj_dir, "plugins", plugin_name + ".py"),
+        join(proj_dir, "plugins.d", plugin_name),
+        join(proj_dir, "plugins.d", plugin_name + ".py"),
     ]
     return search_locations
 

--- a/tests/unit_tests/basic_target/init.d/dropin_c.c
+++ b/tests/unit_tests/basic_target/init.d/dropin_c.c
@@ -1,0 +1,19 @@
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <dropin_c_util.h>
+
+int main(void) {
+    const char *message = dropin_c_message();
+    int fd = open("/igloo/shared/dropin_c_ran", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        return 1;
+    }
+    if (write(fd, message, strlen(message)) < 0) {
+        close(fd);
+        return 2;
+    }
+    close(fd);
+    return 0;
+}

--- a/tests/unit_tests/basic_target/init.d/dropin_c_util.h
+++ b/tests/unit_tests/basic_target/init.d/dropin_c_util.h
@@ -1,0 +1,8 @@
+#ifndef DROPIN_C_UTIL_H
+#define DROPIN_C_UTIL_H
+
+static inline const char *dropin_c_message(void) {
+    return "dropin-c-ran-from-header\n";
+}
+
+#endif

--- a/tests/unit_tests/basic_target/test.py
+++ b/tests/unit_tests/basic_target/test.py
@@ -3,6 +3,7 @@ import logging
 import os
 from pathlib import Path
 import click
+import shutil
 import subprocess
 import yaml
 
@@ -20,6 +21,14 @@ proj_dir = Path(__file__).resolve().parent
 
 FS_DIR = Path(proj_dir, "fs")
 FS_DIR.mkdir(exist_ok=True)
+
+DROPIN_C_TEST_ARCHES = {
+    'armel', 'aarch64',
+    'mipsel', 'mipseb', 'mips64el', 'mips64eb',
+    'riscv64',
+    'x86_64',
+    'powerpc', 'powerpc64',
+}
 
 
 def run_cmd(cmd, **kwargs):
@@ -75,19 +84,54 @@ def penguin_run(config, image):
         raise e
 
 
+def assert_dropin_c_result(project_dir):
+    marker = project_dir / "results" / "latest" / "shared" / "dropin_c_ran"
+    if not marker.exists():
+        raise AssertionError(f"C drop-in marker file not found: {marker}")
+    contents = marker.read_text()
+    expected = "dropin-c-ran-from-header"
+    if expected not in contents:
+        raise AssertionError(
+            f"C drop-in marker had unexpected contents: {contents!r}"
+        )
+
+    core_config_path = project_dir / "results" / "latest" / "core_config.yaml"
+    with open(core_config_path, "r") as file:
+        core_config = yaml.safe_load(file)
+
+    static_files = core_config["static_files"]
+    if "/igloo/init.d/dropin_c" not in static_files:
+        raise AssertionError("compiled C drop-in missing from core_config.yaml")
+    if "/igloo/init.d/dropin_c.c" in static_files:
+        raise AssertionError("C source should not be installed as an init.d file")
+    if "/igloo/init.d/dropin_c_util.h" in static_files:
+        raise AssertionError("C header should not be installed as an init.d file")
+
+    host_path = static_files["/igloo/init.d/dropin_c"]["host_path"]
+    if ".dropin_build" not in host_path or not host_path.endswith("/dropin_c"):
+        raise AssertionError(f"C drop-in did not point at compiled cache: {host_path}")
+
+
 def run_test(kernel, arch, image):
     id = subprocess.check_output(
         f"docker create {image}", shell=True).decode().strip()
     run_cmd(
         f"docker cp -L {id}:/igloo_static/utils.bin/busybox.{arch} {FS_DIR}/busybox", shell=True)
     run_cmd(f"docker rm -v {id}", shell=True)
+    (FS_DIR / "bin").mkdir(exist_ok=True)
     run_cmd(f"tar -czvf {TEST_DIR}/empty_fs.tar.gz -C {FS_DIR} .", shell=True)
 
     # init
     penguin_init(f"{TEST_DIR}/empty_fs.tar.gz", image)
 
-    base_config = str(Path(proj_dir, "projects/empty_fs/config.yaml"))
-    config = str(Path(proj_dir, "projects/empty_fs/config.yaml"))
+    project_path = Path(proj_dir, "projects/empty_fs")
+    if arch in DROPIN_C_TEST_ARCHES:
+        shutil.copytree(TEST_DIR / "init.d", project_path / "init.d", dirs_exist_ok=True)
+    else:
+        logger.info(f"Skipping C drop-in test fixture for unsupported arch {arch}")
+
+    base_config = str(project_path / "config.yaml")
+    config = str(project_path / "config.yaml")
     run_cmd(
         f"cp {proj_dir}/patch.yaml {proj_dir}/projects/empty_fs/patch.yaml", shell=True)
 
@@ -101,6 +145,9 @@ def run_test(kernel, arch, image):
         yaml.dump(bconfig, file, sort_keys=False)
 
     penguin_run(config, image)
+
+    if arch in DROPIN_C_TEST_ARCHES:
+        assert_dropin_c_result(project_path)
 
     logger.info("Test completed")
 


### PR DESCRIPTION
This PR adds support for automatically importing init.d, source.d, since those are static_files we usually treat the same way (i.g., "pull in this file, make it executable, etc...). 

It also adds a plugins.d for importing pyplugins. This makes us avoid having to do the pattern of:
```
plugins:
   foo: {}
```
and autoloads plugins in plugins.d
It also supports a yaml sidecar for passing in plugin args.

If you drop a .c file into init.d it will be compiled and that binary will be executed on startup

and added a core.startup_script to more ergonomically handle "run these commands before guest init":
```
core:
      startup_script: |
           echo hello world!
```