### PR TITLE
lib_inject.d drop-in

### DIFF
--- a/pyplugins/interventions/nvram2.py
+++ b/pyplugins/interventions/nvram2.py
@@ -45,7 +45,20 @@ log = "nvram.csv"
 # access: 0 = miss get, 1 = hit get, 2 = set, 3 = clear
 
 
-def add_lib_inject_for_abi(config, abi, cache_dir):
+def _lib_inject_dropin_files(proj_dir):
+    """Return (sorted .c paths, sorted .h paths) under proj_dir/lib_inject.d/."""
+    if not proj_dir:
+        return [], []
+    d = Path(proj_dir) / "lib_inject.d"
+    if not d.is_dir():
+        return [], []
+    visible = [p for p in d.iterdir() if p.is_file() and not p.name.startswith(".")]
+    c_files = sorted(p for p in visible if p.suffix == ".c")
+    h_files = sorted(p for p in visible if p.suffix == ".h")
+    return c_files, h_files
+
+
+def add_lib_inject_for_abi(config, abi, cache_dir, proj_dir=None):
     """Compile lib_inject for the ABI and put it in /igloo, using cache_dir for caching"""
 
     arch = config["core"]["arch"]
@@ -59,6 +72,11 @@ def add_lib_inject_for_abi(config, abi, cache_dir):
 
     cache_dir = Path(cache_dir)
     os.makedirs(cache_dir, exist_ok=True)
+
+    dropin_c, dropin_h = _lib_inject_dropin_files(proj_dir)
+    dropin_include = []
+    if dropin_c or dropin_h:
+        dropin_include = ["-I", str(Path(proj_dir) / "lib_inject.d")]
 
     hash_options = "-Wl,--hash-style=both" if "mips" not in arch else ""
 
@@ -76,8 +94,14 @@ def add_lib_inject_for_abi(config, abi, cache_dir):
             "-isystem",
             headers_dir,
             f"-DCONFIG_{libnvram_arch_name.upper()}=1",
+        ]
+        + dropin_include
+        + [
             "/igloo_static/libnvram/nvram.c",
             "/igloo_static/guest-utils/ltrace/inject_ltrace.c",
+        ]
+        + [str(p) for p in dropin_c]
+        + [
             "--language",
             "c",
             "-",
@@ -103,9 +127,17 @@ def add_lib_inject_for_abi(config, abi, cache_dir):
                     source_files_content.append(f.read())
             except Exception:
                 pass  # Ignore files that can't be read
+    dropin_signature = []
+    for p in dropin_c + dropin_h:
+        try:
+            dropin_signature.append((p.name, p.read_bytes()))
+        except Exception:
+            pass
 
-    hash_input = str((arch, abi, aliases, lib_inject.get("extra", ""), args)).encode()
+    hash_input = str((arch, abi, aliases, lib_inject.get("extra", ""), args, [n for n, _ in dropin_signature])).encode()
     for content in source_files_content:
+        hash_input += content
+    for _, content in dropin_signature:
         hash_input += content
     cache_key = hashlib.sha256(hash_input).hexdigest()
     cache_path = cache_dir / f"lib_inject_{arch}_{abi}_{cache_key}.so"
@@ -134,13 +166,13 @@ def add_lib_inject_for_abi(config, abi, cache_dir):
     )
 
 
-def add_lib_inject_all_abis(conf, cache_dir):
+def add_lib_inject_all_abis(conf, cache_dir, proj_dir=None):
     """Add lib_inject for all supported ABIs to /igloo"""
 
     arch = conf["core"]["arch"]
     arch_info = ARCH_ABI_INFO[arch]
     for abi in arch_info["abis"].keys():
-        add_lib_inject_for_abi(conf, abi, cache_dir)
+        add_lib_inject_for_abi(conf, abi, cache_dir, proj_dir=proj_dir)
 
     # This isn't covered by the automatic symlink-adding code,
     # so do it manually here.
@@ -152,7 +184,7 @@ def add_lib_inject_all_abis(conf, cache_dir):
     )
 
 
-def prep_config(conf, cache_dir):
+def prep_config(conf, cache_dir, proj_dir=None):
     config_files = conf["static_files"] if "static_files" in conf else {}
     config_nvram = conf["nvram"] if "nvram" in conf else {}
 
@@ -176,7 +208,7 @@ def prep_config(conf, cache_dir):
             "mode": 0o644,
         }
 
-    add_lib_inject_all_abis(conf, cache_dir)
+    add_lib_inject_all_abis(conf, cache_dir, proj_dir=proj_dir)
 
 
 class Nvram2(Plugin):
@@ -217,7 +249,7 @@ class Nvram2(Plugin):
         self.logger.info(f"logging nvram accesses: {self.logging_enabled}")
         cache_dir = Path(proj_dir).resolve() / "qcows" / "cache" if proj_dir else Path(os.path.dirname(os.path.abspath(__file__))).resolve() / "qcows" / "cache"
         os.makedirs(cache_dir, exist_ok=True)
-        prep_config(config, cache_dir)
+        prep_config(config, cache_dir, proj_dir=proj_dir)
         # Even at debug level, logging every nvram get/clear can be very verbose.
         # As such, we only debug log nvram sets
 

--- a/pyplugins/interventions/nvram2.py
+++ b/pyplugins/interventions/nvram2.py
@@ -183,6 +183,21 @@ def add_lib_inject_all_abis(conf, cache_dir, proj_dir=None):
         target=f"/igloo/lib_inject_{arch_info['default_abi']}.so",
     )
 
+    # Binaries in /igloo/utils (e.g. test_nvram) are compiled with the dynamic
+    # linker path /igloo/dylibs/ld-musl-<penguin-arch>.so.1.  The actual loader
+    # file mounted under /igloo/dylibs/ uses the musl arch name, which differs
+    # for several arches (armel→arm, mipseb→mips, mips64eb→mips64).  Add a
+    # symlink so LD_PRELOAD works with these binaries in minimal rootfs envs.
+    default_abi = arch_info["default_abi"]
+    musl_arch = arch_info["abis"][default_abi]["musl_arch_name"]
+    canonical_loader = f"ld-musl-{arch}.so.1"
+    musl_loader = f"ld-musl-{musl_arch}.so.1"
+    if canonical_loader != musl_loader:
+        conf["static_files"][f"/igloo/dylibs/{canonical_loader}"] = dict(
+            type="symlink",
+            target=musl_loader,
+        )
+
 
 def prep_config(conf, cache_dir, proj_dir=None):
     config_files = conf["static_files"] if "static_files" in conf else {}

--- a/pyplugins/interventions/nvram2.py
+++ b/pyplugins/interventions/nvram2.py
@@ -185,18 +185,32 @@ def add_lib_inject_all_abis(conf, cache_dir, proj_dir=None):
 
     # Binaries in /igloo/utils (e.g. test_nvram) are compiled with the dynamic
     # linker path /igloo/dylibs/ld-musl-<penguin-arch>.so.1.  The actual loader
-    # file mounted under /igloo/dylibs/ uses the musl arch name, which differs
+    # file mounted under /igloo/dylibs/ uses the musl loader name, which differs
     # for several arches (armel→arm, mipseb→mips, mips64eb→mips64).  Add a
     # symlink so LD_PRELOAD works with these binaries in minimal rootfs envs.
-    default_abi = arch_info["default_abi"]
-    musl_arch = arch_info["abis"][default_abi]["musl_arch_name"]
+    #
+    # We detect the actual loader name by globbing the dylibs directory rather
+    # than deriving it from musl_arch_name, because musl_arch_name reflects the
+    # headers directory (shared between endianness variants) not the loader
+    # filename (which encodes endianness: ld-musl-mipsel.so.1 ≠ ld-musl-mips.so.1).
+    _dylib_dir_overrides = {
+        "aarch64": "arm64",
+        "intel64": "x86_64",
+        "loongarch64": "loongarch",
+        "powerpc": "ppc",
+        "powerpc64": "ppc64",
+        "powerpc64le": "ppc64el",
+    }
+    dylib_dir = _dylib_dir_overrides.get(arch, arch)
     canonical_loader = f"ld-musl-{arch}.so.1"
-    musl_loader = f"ld-musl-{musl_arch}.so.1"
-    if canonical_loader != musl_loader:
-        conf["static_files"][f"/igloo/dylibs/{canonical_loader}"] = dict(
-            type="symlink",
-            target=musl_loader,
-        )
+    actual_loaders = glob.glob(f"/igloo_static/dylibs/{dylib_dir}/ld-musl-*.so.1")
+    if actual_loaders:
+        actual_loader = os.path.basename(sorted(actual_loaders)[0])
+        if canonical_loader != actual_loader:
+            conf["static_files"][f"/igloo/dylibs/{canonical_loader}"] = dict(
+                type="symlink",
+                target=actual_loader,
+            )
 
 
 def prep_config(conf, cache_dir, proj_dir=None):

--- a/tests/unit_tests/basic_target/init.d/load_libinject.sh
+++ b/tests/unit_tests/basic_target/init.d/load_libinject.sh
@@ -1,5 +1,0 @@
-#!/igloo/utils/sh
-# Force lib_inject.so to load by invoking a dynamic /igloo/utils binary with
-# LD_PRELOAD set. The constructor inside lib_inject.d/dropin_lib.c then writes
-# its marker file. We don't care about the binary's exit status.
-LD_PRELOAD=/igloo/dylibs/lib_inject.so /igloo/utils/test_nvram get __unused_libinject_loader__ >/dev/null 2>&1 || /busybox true

--- a/tests/unit_tests/basic_target/init.d/load_libinject.sh
+++ b/tests/unit_tests/basic_target/init.d/load_libinject.sh
@@ -1,0 +1,5 @@
+#!/igloo/utils/sh
+# Force lib_inject.so to load by invoking a dynamic /igloo/utils binary with
+# LD_PRELOAD set. The constructor inside lib_inject.d/dropin_lib.c then writes
+# its marker file. We don't care about the binary's exit status.
+LD_PRELOAD=/igloo/dylibs/lib_inject.so /igloo/utils/test_nvram get __unused_libinject_loader__ >/dev/null 2>&1 || /busybox true

--- a/tests/unit_tests/basic_target/lib_inject.d/dropin_lib.c
+++ b/tests/unit_tests/basic_target/lib_inject.d/dropin_lib.c
@@ -1,0 +1,21 @@
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "dropin_lib_util.h"
+
+const char *dropin_lib_marker = DROPIN_LIB_MARKER_STRING;
+
+int dropin_lib_answer(void) {
+    return 42;
+}
+
+static void __attribute__((constructor)) dropin_lib_init(void) {
+    int fd = open("/igloo/shared/lib_inject_dropin_ran", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        return;
+    }
+    const char *msg = DROPIN_LIB_MARKER_STRING "\n";
+    write(fd, msg, strlen(msg));
+    close(fd);
+}

--- a/tests/unit_tests/basic_target/lib_inject.d/dropin_lib_util.h
+++ b/tests/unit_tests/basic_target/lib_inject.d/dropin_lib_util.h
@@ -1,0 +1,6 @@
+#ifndef DROPIN_LIB_UTIL_H
+#define DROPIN_LIB_UTIL_H
+
+#define DROPIN_LIB_MARKER_STRING "libinject-dropin-marker-from-header"
+
+#endif

--- a/tests/unit_tests/basic_target/patch.yaml
+++ b/tests/unit_tests/basic_target/patch.yaml
@@ -21,5 +21,9 @@ static_files:
       set -e
       /busybox mkdir -p /igloo/shared/tests/ran.sh/
       /busybox ls -la > /igloo/shared/tests/ran.sh/stdout 2> /igloo/shared/tests/ran.sh/stderr
+      # Force lib_inject.so to load so the lib_inject.d/ constructor fires.
+      # basic_target has no rootfs libc.so, so the lib_inject.core patch does
+      # not auto-set LD_PRELOAD — we trigger it here against a dynamic binary.
+      LD_PRELOAD=/igloo/dylibs/lib_inject.so /igloo/utils/test_nvram get __unused_libinject_loader__ >/dev/null 2>&1 || /busybox true
       /busybox echo "ran" > /igloo/shared/ran
       return 1

--- a/tests/unit_tests/basic_target/patch.yaml
+++ b/tests/unit_tests/basic_target/patch.yaml
@@ -24,6 +24,9 @@ static_files:
       # Force lib_inject.so to load so the lib_inject.d/ constructor fires.
       # basic_target has no rootfs libc.so, so the lib_inject.core patch does
       # not auto-set LD_PRELOAD — we trigger it here against a dynamic binary.
-      LD_PRELOAD=/igloo/dylibs/lib_inject.so /igloo/utils/test_nvram get __unused_libinject_loader__ >/dev/null 2>&1 || /busybox true
+      /busybox echo "[lib_inject.d test] invoking test_nvram with LD_PRELOAD"
+      LD_PRELOAD=/igloo/dylibs/lib_inject.so /igloo/utils/test_nvram get __unused_libinject_loader__ && rc=0 || rc=$?
+      /busybox echo "[lib_inject.d test] test_nvram exit=$rc"
+      /busybox ls -la /igloo/shared/lib_inject_dropin_ran 2>&1 || /busybox echo "[lib_inject.d test] marker file missing"
       /busybox echo "ran" > /igloo/shared/ran
       return 1

--- a/tests/unit_tests/basic_target/test.py
+++ b/tests/unit_tests/basic_target/test.py
@@ -84,6 +84,21 @@ def penguin_run(config, image):
         raise e
 
 
+def assert_lib_inject_dropin_result(project_dir, arch):
+    cache_dir = project_dir / "qcows" / "cache"
+    matches = sorted(cache_dir.glob(f"lib_inject_{arch}_*.so"))
+    if not matches:
+        raise AssertionError(
+            f"no cached lib_inject build found for {arch} under {cache_dir}"
+        )
+    marker = b"libinject-dropin-marker-from-header"
+    if not any(marker in path.read_bytes() for path in matches):
+        raise AssertionError(
+            f"lib_inject.d marker {marker!r} missing from cached lib_inject .so files: "
+            f"{[p.name for p in matches]}"
+        )
+
+
 def assert_dropin_c_result(project_dir):
     marker = project_dir / "results" / "latest" / "shared" / "dropin_c_ran"
     if not marker.exists():
@@ -129,6 +144,7 @@ def run_test(kernel, arch, image):
         shutil.copytree(TEST_DIR / "init.d", project_path / "init.d", dirs_exist_ok=True)
     else:
         logger.info(f"Skipping C drop-in test fixture for unsupported arch {arch}")
+    shutil.copytree(TEST_DIR / "lib_inject.d", project_path / "lib_inject.d", dirs_exist_ok=True)
 
     base_config = str(project_path / "config.yaml")
     config = str(project_path / "config.yaml")
@@ -148,6 +164,8 @@ def run_test(kernel, arch, image):
 
     if arch in DROPIN_C_TEST_ARCHES:
         assert_dropin_c_result(project_path)
+
+    assert_lib_inject_dropin_result(project_path, arch)
 
     logger.info("Test completed")
 

--- a/tests/unit_tests/basic_target/test.py
+++ b/tests/unit_tests/basic_target/test.py
@@ -86,16 +86,27 @@ def penguin_run(config, image):
 
 def assert_lib_inject_dropin_result(project_dir, arch):
     cache_dir = project_dir / "qcows" / "cache"
-    matches = sorted(cache_dir.glob(f"lib_inject_{arch}_*.so"))
+    matches = sorted(cache_dir.glob("lib_inject_*.so"))
     if not matches:
         raise AssertionError(
-            f"no cached lib_inject build found for {arch} under {cache_dir}"
+            f"no cached lib_inject build found under {cache_dir}"
         )
-    marker = b"libinject-dropin-marker-from-header"
-    if not any(marker in path.read_bytes() for path in matches):
+    marker_bytes = b"libinject-dropin-marker-from-header"
+    if not any(marker_bytes in path.read_bytes() for path in matches):
         raise AssertionError(
-            f"lib_inject.d marker {marker!r} missing from cached lib_inject .so files: "
+            f"lib_inject.d marker {marker_bytes!r} missing from cached lib_inject .so files: "
             f"{[p.name for p in matches]}"
+        )
+
+    runtime_marker = project_dir / "results" / "latest" / "shared" / "lib_inject_dropin_ran"
+    if not runtime_marker.exists():
+        raise AssertionError(
+            f"lib_inject.d constructor marker not written in guest: {runtime_marker}"
+        )
+    contents = runtime_marker.read_text()
+    if "libinject-dropin-marker-from-header" not in contents:
+        raise AssertionError(
+            f"lib_inject.d constructor marker had unexpected contents: {contents!r}"
         )
 
 

--- a/tests/unit_tests/basic_target/test.py
+++ b/tests/unit_tests/basic_target/test.py
@@ -84,13 +84,11 @@ def penguin_run(config, image):
         raise e
 
 
-def assert_lib_inject_dropin_result(project_dir, arch):
+def assert_lib_inject_dropin_result(project_dir):
     cache_dir = project_dir / "qcows" / "cache"
     matches = sorted(cache_dir.glob("lib_inject_*.so"))
     if not matches:
-        raise AssertionError(
-            f"no cached lib_inject build found under {cache_dir}"
-        )
+        raise AssertionError(f"no cached lib_inject build found under {cache_dir}")
     marker_bytes = b"libinject-dropin-marker-from-header"
     if not any(marker_bytes in path.read_bytes() for path in matches):
         raise AssertionError(
@@ -191,7 +189,7 @@ def run_test(kernel, arch, image):
     if arch in DROPIN_C_TEST_ARCHES:
         assert_dropin_c_result(project_path)
 
-    assert_lib_inject_dropin_result(project_path, arch)
+    assert_lib_inject_dropin_result(project_path)
 
     logger.info("Test completed")
 

--- a/tests/unit_tests/basic_target/test.py
+++ b/tests/unit_tests/basic_target/test.py
@@ -100,6 +100,21 @@ def assert_lib_inject_dropin_result(project_dir, arch):
 
     runtime_marker = project_dir / "results" / "latest" / "shared" / "lib_inject_dropin_ran"
     if not runtime_marker.exists():
+        latest = project_dir / "results" / "latest"
+        shared = latest / "shared"
+        console = latest / "console.log"
+        logger.error(f"--- shared/ listing ({shared}) ---")
+        if shared.is_dir():
+            for entry in sorted(shared.iterdir()):
+                logger.error(f"  {entry.name}")
+        else:
+            logger.error("  (missing)")
+        logger.error("--- console.log tail ---")
+        if console.exists():
+            for line in console.read_text(errors="replace").splitlines()[-80:]:
+                logger.error(line)
+        else:
+            logger.error("(no console.log)")
         raise AssertionError(
             f"lib_inject.d constructor marker not written in guest: {runtime_marker}"
         )


### PR DESCRIPTION
An ergonomic alternative to `lib_inject.extra`, you can now drop .c files into lib_inject.d have them be added to lib_inject