### PR TITLE
Add early guest compatibility boot hook

### DIFF
--- a/src/penguin/penguin_run.py
+++ b/src/penguin/penguin_run.py
@@ -244,6 +244,16 @@ def run_config(
         " clocksource=jiffies nohz_full nohz=off no_timer_check"  # Improve determinism?
     )
 
+    if pkversion < (6, 13):
+        append += (
+            " systemd.unified_cgroup_hierarchy=0"
+            " systemd.legacy_systemd_cgroup_controller=1"
+            " IGLOO_CGROUP_MODE=v1"
+            " IGLOO_IPTABLES_BACKEND=legacy"
+        )
+    else:
+        append += " IGLOO_CGROUP_MODE=v2 IGLOO_IPTABLES_BACKEND=nft"
+
     # acpi=off blocks x86 secondary-CPU enumeration via MADT; only safe on
     # single-CPU old kernels where PANDA needs it for determinism.
     if pkversion < (6, 13) and conf["core"].get("smp", 1) <= 1:
@@ -492,7 +502,17 @@ def run_config(
     # Find the argument after '-append' in the list and re-render it based on updated env
     append_idx = panda.panda_args.index("-append") + 1
 
-    priority_env = ("igloo_init", "CID", "PROJ_NAME", "SHARED_DIR", "ROOT_SHELL", "WWW", "STRACE")
+    priority_env = (
+        "igloo_init",
+        "CID",
+        "PROJ_NAME",
+        "SHARED_DIR",
+        "ROOT_SHELL",
+        "WWW",
+        "STRACE",
+        "IGLOO_CGROUP_MODE",
+        "IGLOO_IPTABLES_BACKEND",
+    )
     env_items = []
     seen_env = set()
     for key in priority_env:

--- a/src/resources/source.d/45_guest_compat.sh
+++ b/src/resources/source.d/45_guest_compat.sh
@@ -1,0 +1,82 @@
+OUT=/igloo/shared/diagnostics
+
+set_backend_with_update_alternatives() {
+  name="$1"
+  target="$2"
+
+  if command -v update-alternatives >/dev/null 2>&1; then
+    if update-alternatives --query "$name" 2>/dev/null | /igloo/utils/busybox grep -Fq "Alternative: $target"; then
+      update-alternatives --set "$name" "$target"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+set_backend_with_alternatives() {
+  name="$1"
+  target="$2"
+
+  if command -v alternatives >/dev/null 2>&1; then
+    alternatives --set "$name" "$target" >/dev/null 2>&1
+    return $?
+  fi
+
+  return 1
+}
+
+set_backend_with_symlink() {
+  link_path="$1"
+  target="$2"
+
+  if [ -L "$link_path" ] && [ -e "$target" ]; then
+    /igloo/utils/busybox ln -sf "$target" "$link_path"
+    return 0
+  fi
+
+  return 1
+}
+
+set_iptables_backend() {
+  if [ "$1" = "legacy" ]; then
+    set_backend_with_update_alternatives iptables /usr/sbin/iptables-legacy \
+      || set_backend_with_alternatives iptables /usr/sbin/iptables-legacy \
+      || set_backend_with_symlink /usr/sbin/iptables /usr/sbin/iptables-legacy
+    set_backend_with_update_alternatives ip6tables /usr/sbin/ip6tables-legacy \
+      || set_backend_with_alternatives ip6tables /usr/sbin/ip6tables-legacy \
+      || set_backend_with_symlink /usr/sbin/ip6tables /usr/sbin/ip6tables-legacy
+    set_backend_with_update_alternatives arptables /usr/sbin/arptables-legacy \
+      || set_backend_with_alternatives arptables /usr/sbin/arptables-legacy \
+      || set_backend_with_symlink /usr/sbin/arptables /usr/sbin/arptables-legacy
+    set_backend_with_update_alternatives ebtables /usr/sbin/ebtables-legacy \
+      || set_backend_with_alternatives ebtables /usr/sbin/ebtables-legacy \
+      || set_backend_with_symlink /usr/sbin/ebtables /usr/sbin/ebtables-legacy
+  fi
+}
+
+mkdir -p "$OUT"
+
+if [ ! -z "${IGLOO_IPTABLES_BACKEND}" ]; then
+  set_iptables_backend "$IGLOO_IPTABLES_BACKEND"
+fi
+
+{
+  echo "timestamp=$(date -Is)"
+  echo "kernel=$(/igloo/utils/busybox uname -r)"
+  echo "cgroup_mode=${IGLOO_CGROUP_MODE:-unset}"
+  echo "iptables_backend=${IGLOO_IPTABLES_BACKEND:-unset}"
+} > "$OUT/compat_mode.txt"
+
+if command -v iptables >/dev/null 2>&1; then
+  iptables --version > "$OUT/iptables_version.txt" 2>&1 || true
+fi
+
+if command -v ip6tables >/dev/null 2>&1; then
+  ip6tables --version > "$OUT/ip6tables_version.txt" 2>&1 || true
+fi
+
+if command -v update-alternatives >/dev/null 2>&1; then
+  update-alternatives --query iptables > "$OUT/iptables_alternatives.txt" 2>&1 || true
+  update-alternatives --query ip6tables >> "$OUT/iptables_alternatives.txt" 2>&1 || true
+fi


### PR DESCRIPTION
## Summary
- add a built-in /igloo/source.d guest compatibility hook that runs before the guest init system
- default older kernels to cgroup v1 plus legacy iptables, while keeping newer kernels on the nftables/v2 path
- keep the compatibility selection in the kernel cmdline so the guest hook stays init-system agnostic

## Validation
- validated Debian 10 + systemd + Docker on Penguin 4.10 under KVM: Docker starts with legacy iptables and cgroup v1 compatibility flags
- validated Debian 10 + systemd + Docker on Penguin 6.13 under KVM: compatibility hook records nftables/v2 mode and dockerd remains healthy on the modern path

## Notes
- this intentionally replaces the scratch-only systemd-unit approach with a generic early boot path
- no linux_builder change is included because the working fix did not depend on a kernel config update