### PR TITLE
Config: defaults, friendly errors, validate/schema CLI, Jinja2 templating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@ tests/unit_tests/test_target/config.yaml
 tests/unit_tests/test_target/nvram_state.yaml
 penguin.sif
 fw
+# Generated at build time (setuptools_scm) and by the unit-test conftest.
+src/penguin/version.txt
 db/events.*
 local_packages/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -286,6 +286,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
       ipdb \
       ipython \
       python-Levenshtein \
+      jinja2 \
       lief  \
       lxml \
       lz4 \

--- a/docs/pyplugin_architecture.md
+++ b/docs/pyplugin_architecture.md
@@ -47,6 +47,28 @@ class PluginA(Plugin):
         self.argumentA = self.get_arg("argumentA")
 ```
 
+## Meta-variable templating
+
+Config and patch files support Jinja2 templating so values that depend on the
+architecture (or other settings) don't have to be hardcoded in multiple places.
+Available variables: `{{ arch }}`, `{{ core.<field> }}` (e.g. `{{ core.mem }}`),
+`{{ kernel_version }}`, and anything you define in a top-level `vars:` section.
+
+```yaml
+core:
+  arch: mipsel
+vars:
+  webroot: /www
+static_files:
+  "{{ webroot }}/index.html":
+    type: inline_file
+    contents: "running on {{ arch }} (kernel {{ kernel_version }})"
+```
+
+`vars:` is consumed at load time and does not appear in the realized config.
+Files containing no `{{ }}`/`{% %}` are left untouched. `{{ kernel_version }}`
+is resolved after the kernel path is selected.
+
 ## Plugin File Locations and Discovery
 
 Plugins can be placed in several locations, and the plugin manager will search for them using common naming conventions. When you reference a plugin by name, the manager will look for files matching the plugin name (in CamelCase, snake_case, or lowercase) in the following locations:

--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -463,6 +463,20 @@ Shell script body dropped into /igloo/init.d to run during guest boot. Installed
 
 List of paths to patch files
 
+## `vars` Template variables
+
+|||
+|-|-|
+|__Type__|mapping from string to any or null|
+|__Default__|`null`|
+
+User-defined variables usable elsewhere via Jinja2 templating, e.g. `{{ myvar }}`. Alongside these, `{{ arch }}`, `{{ core.<field> }}`, and `{{ kernel_version }}` are available. This section is consumed at load time and does not appear in the realized config.
+
+```yaml
+libdir: /lib/{{ arch }}
+webroot: /www
+```
+
 ## `env` Environment
 
 |||
@@ -916,7 +930,7 @@ Add a file with contents specified inline in this config
 |Field|Type|Default|Title|
 |-|-|-|-|
 |`type`|`"inline_file"`||Type of file action (add inline file)|
-|`mode`|integer||Permissions of file|
+|`mode`|integer|`420`|Permissions of file|
 |`contents`|string||Contents of file|
 #### `static_files.<string>.<type=host_file>` Copy host file
 
@@ -925,7 +939,7 @@ Copy a file from the host into the guest
 |Field|Type|Default|Title|
 |-|-|-|-|
 |`type`|`"host_file"`||Type of file action (copy host file)|
-|`mode`|integer||Permissions of file|
+|`mode`|integer|`493`|Permissions of file|
 |`host_path`|string||Host path|
 #### `static_files.<string>.<type=dir>` Add directory
 
@@ -933,7 +947,7 @@ Copy a file from the host into the guest
 |Field|Type|Default|Title|
 |-|-|-|-|
 |`type`|`"dir"`||Type of file action (add directory)|
-|`mode`|integer||Permissions of directory|
+|`mode`|integer|`493`|Permissions of directory|
 #### `static_files.<string>.<type=symlink>` Add symbolic link
 
 
@@ -950,7 +964,7 @@ Copy a file from the host into the guest
 |`devtype`|`"char"` or `"block"`||Type of device file|
 |`major`|integer||Major device number|
 |`minor`|integer||Minor device number|
-|`mode`|integer||Permissions of device file|
+|`mode`|integer|`438`|Permissions of device file|
 #### `static_files.<string>.<type=delete>` Delete file
 
 

--- a/src/penguin/__main__.py
+++ b/src/penguin/__main__.py
@@ -31,6 +31,37 @@ from .utils_cli import utils as _utils_group
 logger = getColoredLogger("penguin")
 
 
+def _resolve_project_and_config(project_dir, config):
+    """
+    Normalize a (project_dir, config) pair the way `run` and `validate` expect.
+
+    Accepts a project directory or, for backwards compatibility, a path to a
+    config file inside one. Returns (project_dir, config) with both resolved to
+    existing absolute paths, raising ValueError if no config can be found.
+    """
+    if not os.path.isabs(project_dir):
+        project_dir = os.path.join(os.getcwd(), project_dir)
+
+    if os.path.isfile(project_dir) or project_dir.endswith("/config.yaml"):
+        config = project_dir
+        project_dir = os.path.dirname(config)
+
+    if not config and os.path.isdir(project_dir) and os.path.exists(
+        os.path.join(project_dir, "config.yaml")
+    ):
+        config = os.path.join(project_dir, "config.yaml")
+
+    if config is None:
+        raise ValueError(
+            f"Could not find config and none was provided. Auto-checked {project_dir} for config.yaml"
+        )
+
+    if not Path(config).exists():
+        raise ValueError(f"Config file does not exist: {config}")
+
+    return project_dir, config
+
+
 def _validate_project(proj_dir, config_path):
     if not os.path.isdir(proj_dir):
         raise RuntimeError(f"Project directory not found: {proj_dir}")
@@ -589,28 +620,10 @@ def run(ctx, project_dir, config, output, force, timeout, auto):
     """
     _startup_checks(ctx.obj['VERBOSE'])
 
-    if not os.path.isabs(project_dir):
-        current_dir = os.getcwd()
-        project_dir = os.path.join(current_dir, project_dir)
-
-    if os.path.isfile(project_dir) or project_dir.endswith("/config.yaml"):
-        config = project_dir
-        project_dir = os.path.dirname(config)
+    project_dir, config = _resolve_project_and_config(project_dir, config)
 
     if force and output and os.path.isdir(output):
         shutil.rmtree(output, ignore_errors=True)
-
-    if not config and os.path.isdir(project_dir) and os.path.exists(
-        os.path.join(project_dir, "config.yaml")
-    ):
-        config = os.path.join(project_dir, "config.yaml")
-
-    if config is None:
-        raise ValueError(f"Could not find config and none was provided. Auto-checked {project_dir} for config.yaml")
-
-    config_path = Path(config)
-    if not config_path.exists():
-        raise ValueError(f"Config file does not exist: {config}")
 
     if not os.path.isdir(os.path.join(project_dir, "base")):
         raise ValueError(
@@ -663,6 +676,34 @@ def run(ctx, project_dir, config, output, force, timeout, auto):
 
 
 @cli.command()
+@click.argument("project_dir", type=str)
+@click.option("--config", type=str, default=None, help="Path to a config file. Defaults to <project_dir>/config.yaml.")
+@verbose_option
+@click.pass_context
+def validate(ctx, project_dir, config):
+    """
+    Validate a config without running it.
+
+    Loads the config, applies patches and drop-ins, and runs full schema
+    validation. On failure, prints a located, actionable report (which file,
+    which option, what was wrong, allowed values) and exits non-zero.
+    """
+    _startup_checks(ctx.obj['VERBOSE'])
+
+    project_dir, config = _resolve_project_and_config(project_dir, config)
+
+    # load_config routes schema errors through the friendly formatter and
+    # exits non-zero itself; a clean return means the config validated.
+    cfg = load_config(project_dir, config, validate=True, verbose=ctx.obj['VERBOSE'])
+
+    click.secho("Config OK", fg="green", bold=True)
+    click.echo(f"  arch:   {cfg['core'].get('arch')}")
+    click.echo(f"  kernel: {cfg['core'].get('kernel')}")
+    plugin_names = sorted((cfg.get("plugins") or {}).keys())
+    click.echo(f"  plugins: {', '.join(plugin_names) if plugin_names else '(none)'}")
+
+
+@cli.command()
 @verbose_option
 @click.pass_context
 def shell(ctx):
@@ -703,17 +744,94 @@ def docs(ctx, filename):
     else:
         with open(full_path, "r") as f:
             lines = len(f.readlines())
+        _render_markdown_file(full_path, num_lines=lines)
 
-        try:
-            rows, _ = os.get_terminal_size()
-        except OSError:
-            rows = None
 
-        glow_args = ["glow", full_path]
-        if rows and lines > rows:
-            subprocess.run(glow_args + ["--pager"])
-        else:
-            subprocess.run(glow_args)
+def _render_markdown_file(path, num_lines=None):
+    """Render a markdown file to the terminal via glow, with a pager for long files."""
+    if not shutil.which("glow"):
+        with open(path, "r") as f:
+            click.echo(f.read())
+        return
+    if num_lines is None:
+        with open(path, "r") as f:
+            num_lines = len(f.readlines())
+    try:
+        rows, _ = os.get_terminal_size()
+    except OSError:
+        rows = None
+    glow_args = ["glow", path]
+    if rows and num_lines > rows:
+        subprocess.run(glow_args + ["--pager"])
+    else:
+        subprocess.run(glow_args)
+
+
+def _render_markdown(text):
+    """Render a markdown string to the terminal (reuses the glow file renderer)."""
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+        f.write(text)
+        tmp = f.name
+    try:
+        _render_markdown_file(tmp, num_lines=text.count("\n") + 1)
+    finally:
+        os.unlink(tmp)
+
+
+@cli.command()
+@click.argument("section", type=str, required=False)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit the raw JSON schema instead of rendered docs.")
+@verbose_option
+@click.pass_context
+def schema(ctx, section, as_json):
+    """
+    Show the config schema.
+
+    With no SECTION, lists the top-level config sections. With a dotted SECTION
+    (e.g. `core`, `pseudofiles.read`, `pseudofiles.read.const_buf`), renders that
+    part of the schema.
+    """
+    _startup_checks(ctx.obj['VERBOSE'])
+    from penguin.penguin_config import gen_docs
+    from penguin.penguin_config.gen_docs import DocsField
+
+    if not section:
+        if as_json:
+            click.echo(yaml.dump(structure_json_schema(), indent=2))
+            return
+        lines = ["# Config sections", ""]
+        for name, title in gen_docs.list_sections():
+            lines.append(f"- `{name}` — {title}")
+        lines.append("")
+        lines.append("Run `penguin schema <section>` to see details, e.g. `penguin schema core`.")
+        _render_markdown("\n".join(lines))
+        return
+
+    resolved = gen_docs.resolve_section(section)
+    if resolved is not None:
+        if as_json:
+            try:
+                click.echo(yaml.dump(resolved.model_json_schema(), indent=2))
+            except AttributeError:
+                click.echo(f"(section '{section}' is a primitive type with no sub-schema)")
+            return
+        md = gen_docs.gen_docs(
+            path=section.split("."),
+            docs_field=DocsField.from_type(resolved),
+        )
+        _render_markdown(md)
+        return
+
+    logger.error(
+        f"Unknown schema section '{section}'. "
+        f"Run `penguin schema` to list available sections."
+    )
+    sys.exit(1)
+
+
+def structure_json_schema():
+    from penguin.penguin_config import structure
+    return structure.Main.model_json_schema()
 
 
 @cli.command()

--- a/src/penguin/penguin_config/__init__.py
+++ b/src/penguin/penguin_config/__init__.py
@@ -17,10 +17,12 @@ try:
 except ImportError:
     from yamlcore import CoreLoader, CoreDumper
     import yaml
-from pydantic import BaseModel, Field, RootModel
+from pydantic import BaseModel, Field, RootModel, ValidationError
 from pydantic.config import ConfigDict
 
 import penguin
+from .errors import format_validation_error
+from . import templating
 try:
     from penguin.common import patch_config
     from penguin.dropin_compile import compile_init_c_dropin
@@ -49,9 +51,15 @@ def _jsonify_dict(d):
     }
 
 
-def _validate_config_schema(config, is_dump):
+def _validate_config_schema(config, is_dump, path=None, origin_map=None):
     """Validate config with Pydantic"""
-    validated_model = structure.Main(**config)
+    try:
+        validated_model = structure.Main(**config)
+    except ValidationError as e:
+        logger.error(
+            "\n" + format_validation_error(e, config_path=path, origin_map=origin_map)
+        )
+        sys.exit(1)
 
     if is_dump:
         validated_model.model_dump(exclude_none=True)
@@ -178,8 +186,8 @@ def _validate_config_version(config, path):
         sys.exit(1)
 
 
-def _validate_config(config, is_dump=False):
-    _validate_config_schema(config, is_dump)
+def _validate_config(config, is_dump=False, path=None, origin_map=None):
+    _validate_config_schema(config, is_dump, path=path, origin_map=origin_map)
     _validate_config_options(config)
 
 
@@ -196,6 +204,16 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
     """Load penguin config from path"""
     with open(path, "r") as f:
         config = yaml.load(f, Loader=CoreLoader)
+
+    # Render Jinja2 meta-variables ({{ arch }}, {{ core.* }}, user vars:, and the
+    # late-bound {{ kernel_version }}) per-file, before merging. main_ctx is
+    # reused so patches resolve against the main config's core/arch/vars.
+    try:
+        config, main_ctx = templating.render_config(config, where=os.path.basename(path))
+    except templating.TemplateError as e:
+        logger.error(str(e))
+        sys.exit(1)
+
     config = structure.Patch(**config)
 
     # 1. Initialize the empty map to track our provenance
@@ -208,11 +226,13 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
         if patches_dir.exists():
             patch_files += list(patches_dir.glob("*.yaml"))
         if patch_files:
-            if config.patches.root is None:
+            if config.patches is None:
+                config.patches = structure.Patches(root=[])
+            elif config.patches.root is None:
                 config.patches.root = []
             for patch_file in patch_files:
                 config.patches.root.append(str(patch_file))
-    if config.patches.root is not None:
+    if config.patches is not None and config.patches.root is not None:
         patch_list = config.patches.root
         for patch in patch_list:
             # patches are loaded relative to the main config file
@@ -220,6 +240,15 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
             if patch_relocated.exists():
                 with open(patch_relocated, "r") as f:
                     patch_data = yaml.load(f, Loader=CoreLoader)
+                try:
+                    patch_data = templating.substitute(
+                        patch_data,
+                        templating.build_context(patch_data, extra=main_ctx),
+                        where=os.path.basename(str(patch_relocated)),
+                    )
+                except templating.TemplateError as e:
+                    logger.error(str(e))
+                    sys.exit(1)
                 patch_data = structure.Patch(**patch_data)
 
                 # 2. Pass the origin map and the patch name down into the merger
@@ -235,6 +264,8 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
                 logger.error(f"patch file {patch} not found, ignoring")
 
     config = config.model_dump()
+    # `vars` is load-time metadata only; drop it so it never reaches the run.
+    config.pop("vars", None)
     if config["core"].get("guest_cmd", False) is True:
         config["static_files"]["/igloo/utils/guesthopper"] = dict(
             type="host_file",
@@ -328,9 +359,16 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
     else:
         config["core"]["kernel"] = get_kernel(config, proj_dir)
 
+    # Second templating pass: now that the kernel is resolved, fill in any
+    # {{ kernel_version }} references that were deferred in the first pass.
+    # Kernel paths look like /igloo_static/kernels/<VERSION>/<file>.
+    resolved_kpath = config["core"].get("kernel") or ""
+    kernel_version = os.path.basename(os.path.dirname(resolved_kpath)) if resolved_kpath else ""
+    config = templating.resolve_kernel_version(config, kernel_version)
+
     # when loading a patch we don't need a completely valid config
     if validate:
-        _validate_config(config)
+        _validate_config(config, path=path, origin_map=origin_map)
         _validate_config_version(config, path)
         # Not required in schema as to allow for patches, but these really are required
         if config["core"].get("arch", None) is None:

--- a/src/penguin/penguin_config/errors.py
+++ b/src/penguin/penguin_config/errors.py
@@ -1,0 +1,184 @@
+"""
+Human-friendly rendering of Pydantic ValidationErrors for Penguin configs.
+
+`structure.Main(**config)` raises a `pydantic.ValidationError` whose default
+string form is a wall of text with URLs and no indication of which config/patch
+file is at fault. `format_validation_error` turns it into a short, located,
+optionally-colorized report that names the offending option, the file that set
+it (via the patch `origin_map`), what was wrong, and the allowed values.
+"""
+
+import difflib
+import os
+import sys
+import typing
+from types import NoneType
+from typing import Union
+
+from . import structure
+
+# Keys that we never want to suggest as "did you mean" or treat as descendable.
+_UNION_TAG_KEYS = ("type", "model")
+
+
+def _supports_color(stream) -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+class _Palette:
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+
+    def _wrap(self, code, text):
+        return f"\033[{code}m{text}\033[0m" if self.enabled else text
+
+    def loc(self, t):
+        return self._wrap("1;31", t)  # bold red
+
+    def file(self, t):
+        return self._wrap("2", t)  # dim
+
+    def allowed(self, t):
+        return self._wrap("33", t)  # yellow
+
+    def ok(self, t):
+        return self._wrap("32", t)  # green
+
+
+def _unwrap_optional(type_):
+    """Collapse Optional[Optional[... T ...]] to T (mirrors gen_docs)."""
+    while (
+        typing.get_origin(type_) is Union
+        and len(typing.get_args(type_)) == 2
+        and typing.get_args(type_)[1] is NoneType
+    ):
+        type_ = typing.get_args(type_)[0]
+    return type_
+
+
+def _resolve_model_at_path(loc, root=None):
+    """
+    Walk ``root`` (default ``structure.Main``) along ``loc`` (a tuple of pydantic
+    error-location segments) and return the BaseModel class at that location, or
+    None if it can't be resolved (best effort, used only for "did you mean").
+    """
+    type_ = root if root is not None else structure.Main
+    for seg in loc:
+        type_ = _unwrap_optional(type_)
+        # RootModel newtypes / tagged unions wrap their content under "root".
+        if hasattr(type_, "model_fields") and "root" in type_.model_fields:
+            info = type_.model_fields["root"]
+            ann = info.annotation
+            if info.discriminator and typing.get_origin(ann) is Union:
+                # Tagged union: seg should be a discriminator tag value.
+                match = None
+                for variant in typing.get_args(ann):
+                    disc = variant.model_fields.get(info.discriminator)
+                    if disc is None:
+                        continue
+                    vals = typing.get_args(disc.annotation)
+                    if vals and vals[0] == seg:
+                        match = variant
+                        break
+                if match is None:
+                    return None
+                type_ = match
+                continue
+            type_ = _unwrap_optional(ann)
+            # Re-process this same segment against the unwrapped type.
+
+        type_ = _unwrap_optional(type_)
+        if hasattr(type_, "model_fields"):
+            field = type_.model_fields.get(seg)
+            if field is None:
+                return None
+            type_ = field.annotation
+        elif typing.get_origin(type_) is dict:
+            # dict[K, V]: a path segment is a key; descend into V.
+            type_ = typing.get_args(type_)[1]
+        else:
+            return None
+    type_ = _unwrap_optional(type_)
+    return type_ if hasattr(type_, "model_fields") else None
+
+
+def _field_names(model):
+    try:
+        return [k for k in model.model_fields.keys() if k != "root"]
+    except AttributeError:
+        return []
+
+
+def _did_you_mean(key, candidates):
+    matches = difflib.get_close_matches(str(key), candidates, n=1)
+    return matches[0] if matches else None
+
+
+def _describe(err, pal, root=None):
+    """Return a one-line description of a single pydantic error dict."""
+    etype = err["type"]
+    ctx = err.get("ctx", {})
+    loc = err["loc"]
+    last = loc[-1] if loc else ""
+
+    if etype == "literal_error":
+        return f"invalid value; allowed: {pal.allowed(ctx.get('expected', '?'))}"
+    if etype in ("union_tag_invalid", "union_tag_not_found"):
+        disc = ctx.get("discriminator", "type")
+        tag = ctx.get("tag")
+        allowed = ctx.get("expected_tags", "?")
+        if tag is not None:
+            return f"unknown {disc} {tag!r}; allowed: {pal.allowed(allowed)}"
+        return f"missing {disc}; allowed: {pal.allowed(allowed)}"
+    if etype == "extra_forbidden":
+        parent = _resolve_model_at_path(loc[:-1], root=root)
+        msg = f"unknown option {str(last)!r}"
+        if parent is not None:
+            suggestion = _did_you_mean(last, _field_names(parent))
+            if suggestion:
+                msg += f" (did you mean {pal.allowed(suggestion)}?)"
+        return msg
+    if etype == "missing":
+        return f"required option {str(last)!r} is missing"
+    return err.get("msg", etype)
+
+
+def format_validation_error(
+    exc, *, config_path=None, origin_map=None, root_model=None,
+    header="Config validation failed:",
+):
+    """
+    Render a pydantic ``ValidationError`` into a friendly multi-line report.
+
+    ``config_path`` is the main config file (used as a fallback source).
+    ``origin_map`` is the {dotted.path: source_file} map produced by
+    ``patch_config`` during load, used to name which file set each option.
+    ``root_model`` is the model the error paths are relative to (defaults to
+    ``structure.Main``); pass a plugin's ``Args`` model for plugin-arg errors.
+    """
+    pal = _Palette(_supports_color(sys.stderr))
+    origin_map = origin_map or {}
+
+    lines = [header]
+    for err in exc.errors(include_url=False):
+        loc = err["loc"]
+        dotted = ".".join(str(p) for p in loc)
+        # The origin map keys are dotted paths without union-tag segments;
+        # drop tag segments (type/model values) when looking up the source.
+        origin_key = ".".join(
+            str(p) for p in loc if p not in _UNION_TAG_KEYS
+        )
+        source = origin_map.get(origin_key) or origin_map.get(dotted)
+        if source and source != "base_config":
+            source = os.path.basename(source)
+        elif source == "base_config" and config_path:
+            source = os.path.basename(config_path)
+        elif config_path:
+            source = os.path.basename(config_path)
+
+        head = pal.loc(dotted) if dotted else pal.loc("<root>")
+        where = f" [{pal.file(source)}]" if source else ""
+        lines.append(f"  - {head}{where}: {_describe(err, pal, root=root_model)}")
+    return "\n".join(lines)

--- a/src/penguin/penguin_config/gen_docs.py
+++ b/src/penguin/penguin_config/gen_docs.py
@@ -59,6 +59,10 @@ def gen_docs_type_name(t):
         return " or ".join([gen_docs_literal_arg(a) for a in args])
     elif og in (list, tuple):
         return "list of " + gen_docs_type_name(args[0])
+    elif og is dict:
+        return f"mapping from {gen_docs_type_name(args[0])} to {gen_docs_type_name(args[1])}"
+    elif t is Any:
+        return "any"
     elif t is int:
         return "integer"
     elif t is str:
@@ -296,6 +300,69 @@ def gen_docs(path=[], docs_field=DocsField.from_type(structure.Main)):
         # There is no more recursion to do for this field, so just generate docs for it.
         out += gen_docs_field(path, docs_field)
 
+    return out
+
+
+def _advance_section(type_, seg):
+    """
+    Move one user-facing step into the schema by `seg`, transparently skipping
+    non-consuming wrappers (Optional, RootModel newtypes, and dict values).
+
+    Returns the resolved sub-type, or None if `seg` doesn't resolve.
+    """
+    while True:
+        # Collapse Optional[... T ...] to T
+        while (
+            typing.get_origin(type_) is Union
+            and len(typing.get_args(type_)) == 2
+            and typing.get_args(type_)[1] is NoneType
+        ):
+            type_ = typing.get_args(type_)[0]
+
+        if hasattr(type_, "model_fields") and "root" in type_.model_fields:
+            info = type_.model_fields["root"]
+            ann = info.annotation
+            if info.discriminator and typing.get_origin(ann) is Union:
+                # Tagged union: `seg` should name a discriminator value.
+                for variant in typing.get_args(ann):
+                    disc = variant.model_fields.get(info.discriminator)
+                    vals = typing.get_args(disc.annotation) if disc else ()
+                    if vals and vals[0] == seg:
+                        return variant
+                return None
+            type_ = ann  # newtype: unwrap and retry the same segment
+            continue
+
+        if hasattr(type_, "model_fields"):
+            field = type_.model_fields.get(seg)
+            return field.annotation if field is not None else None
+
+        if typing.get_origin(type_) is dict:
+            type_ = typing.get_args(type_)[1]  # descend into the value type
+            continue
+
+        return None
+
+
+def resolve_section(dotted):
+    """
+    Resolve a dotted config-section path (e.g. "core", "pseudofiles.read",
+    "pseudofiles.read.const_buf") to the type at that location, or None.
+    """
+    type_ = structure.Main
+    for seg in [s for s in dotted.split(".") if s]:
+        type_ = _advance_section(type_, seg)
+        if type_ is None:
+            return None
+    return type_
+
+
+def list_sections():
+    """Return [(name, title)] for the top-level config sections."""
+    out = []
+    for name, info in structure.Main.model_fields.items():
+        df = DocsField.from_field(info)
+        out.append((name, df.title or name))
     return out
 
 

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Dict, List, Literal, Optional, Union, ClassVar
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union, ClassVar
 from pydantic import BaseModel, Field, RootModel
 from pydantic.config import ConfigDict
 from pydantic_partial import PartialModelMixin, create_partial_model
@@ -701,7 +701,7 @@ StaticFileAction = _union(
             title="Add inline file",
             description="Add a file with contents specified inline in this config",
             fields=(
-                ("mode", int, Field(title="Permissions of file")),
+                ("mode", int, Field(0o644, title="Permissions of file")),
                 ("contents", str, Field(title="Contents of file")),
             ),
         ),
@@ -710,7 +710,7 @@ StaticFileAction = _union(
             title="Copy host file",
             description="Copy a file from the host into the guest",
             fields=(
-                ("mode", int, Field(title="Permissions of file")),
+                ("mode", int, Field(0o755, title="Permissions of file")),
                 ("host_path", str, Field(title="Host path")),
             ),
         ),
@@ -718,7 +718,7 @@ StaticFileAction = _union(
             discrim_val="dir",
             title="Add directory",
             description=None,
-            fields=(("mode", int, Field(title="Permissions of directory")),),
+            fields=(("mode", int, Field(0o755, title="Permissions of directory")),),
         ),
         dict(
             discrim_val="symlink",
@@ -741,7 +741,7 @@ StaticFileAction = _union(
                 (
                     "mode",
                     int,
-                    Field(title="Permissions of device file"),
+                    Field(0o666, title="Permissions of device file"),
                 ),
             ),
         ),
@@ -905,6 +905,20 @@ class Main(PartialModelMixin, BaseModel):
 
     core: Core
     patches: Optional[Patches] = None
+    vars: Annotated[
+        Optional[dict[str, Any]],
+        Field(
+            None,
+            title="Template variables",
+            description=" ".join((
+                "User-defined variables usable elsewhere via Jinja2 templating,",
+                "e.g. `{{ myvar }}`. Alongside these, `{{ arch }}`, `{{ core.<field> }}`,",
+                "and `{{ kernel_version }}` are available. This section is consumed at",
+                "load time and does not appear in the realized config.",
+            )),
+            examples=[dict(webroot="/www", libdir="/lib/{{ arch }}")],
+        ),
+    ] = None
     env: Env
     pseudofiles: Pseudofiles
     nvram: NVRAM

--- a/src/penguin/penguin_config/templating.py
+++ b/src/penguin/penguin_config/templating.py
@@ -1,0 +1,117 @@
+"""
+Jinja2 "meta variable" templating for Penguin configs.
+
+Lets a config or patch reference values like ``{{ arch }}`` / ``{{ core.arch }}``,
+any other ``core.*`` scalar, user-defined ``vars:``, and ``{{ kernel_version }}``
+so that changing one value (e.g. ``core.arch``) flows everywhere it is used.
+
+Substitution runs per-file on the parsed YAML dict, before patch merging:
+each file resolves against the main config's ``core``/``arch`` plus its own and
+the main config's ``vars``. ``kernel_version`` is special — the real kernel path
+is only resolved late, so first-pass rendering replaces ``{{ kernel_version }}``
+with a sentinel that ``resolve_kernel_version`` substitutes once it is known.
+
+Configs that contain no ``{{ }}``/``{% %}`` are returned untouched.
+"""
+
+import jinja2
+
+# First-pass placeholder for the late-bound kernel_version variable.
+KERNEL_VERSION_SENTINEL = "\x00IGLOO_KERNEL_VERSION\x00"
+
+
+class TemplateError(Exception):
+    """Raised when a config template references an undefined var or is malformed."""
+
+
+def _env():
+    return jinja2.Environment(
+        undefined=jinja2.StrictUndefined,
+        autoescape=False,
+        keep_trailing_newline=True,
+    )
+
+
+def _looks_templated(s):
+    return "{{" in s or "{%" in s or "{#" in s
+
+
+def _render_str(s, ctx, env, where):
+    if not _looks_templated(s):
+        return s
+    try:
+        return env.from_string(s).render(**ctx)
+    except jinja2.UndefinedError as e:
+        defined = sorted(k for k in ctx if not k.startswith("_"))
+        raise TemplateError(
+            f"undefined template variable in {where}: {e}; defined vars: {defined}"
+        )
+    except jinja2.TemplateSyntaxError as e:
+        raise TemplateError(f"template syntax error in {where}: {e}")
+
+
+def substitute(obj, ctx, env=None, where="config"):
+    """Recursively render every string leaf of ``obj`` with the Jinja context."""
+    env = env or _env()
+    if isinstance(obj, str):
+        return _render_str(obj, ctx, env, where)
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            nk = _render_str(k, ctx, env, where) if isinstance(k, str) else k
+            out[nk] = substitute(v, ctx, env, where)
+        return out
+    if isinstance(obj, list):
+        return [substitute(v, ctx, env, where) for v in obj]
+    return obj
+
+
+def build_context(raw_config, extra=None, env=None, where="vars"):
+    """
+    Build the Jinja context for a config/patch dict.
+
+    Exposes ``arch``, ``core`` (so ``{{ core.mem }}`` works), the late-bound
+    ``kernel_version`` sentinel, anything in ``extra`` (e.g. the main config's
+    context when rendering a patch), and the file's own ``vars:`` (which may
+    themselves reference earlier vars / arch).
+    """
+    env = env or _env()
+    ctx = {"kernel_version": KERNEL_VERSION_SENTINEL}
+    if extra:
+        ctx.update(extra)
+    core = raw_config.get("core") if isinstance(raw_config, dict) else None
+    if isinstance(core, dict):
+        ctx["core"] = dict(core)
+        if core.get("arch"):
+            ctx["arch"] = core["arch"]
+    user_vars = raw_config.get("vars") if isinstance(raw_config, dict) else None
+    if isinstance(user_vars, dict):
+        for k, v in user_vars.items():
+            ctx[k] = substitute(v, ctx, env, where)
+    return ctx
+
+
+def render_config(raw_config, extra=None, env=None, where="config"):
+    """
+    Render a raw config/patch dict in place-equivalent fashion, returning the
+    rendered dict and the context used (so callers can reuse it for patches).
+    """
+    env = env or _env()
+    ctx = build_context(raw_config, extra=extra, env=env)
+    return substitute(raw_config, ctx, env, where), ctx
+
+
+def resolve_kernel_version(obj, kernel_version):
+    """Second pass: replace the kernel_version sentinel with the resolved value."""
+    kv = str(kernel_version) if kernel_version is not None else ""
+    if isinstance(obj, str):
+        return obj.replace(KERNEL_VERSION_SENTINEL, kv)
+    if isinstance(obj, dict):
+        return {
+            (k.replace(KERNEL_VERSION_SENTINEL, kv) if isinstance(k, str) else k):
+                resolve_kernel_version(v, kv)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [resolve_kernel_version(v, kv) for v in obj]
+    return obj

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -28,6 +28,7 @@ include_package_data = True
 install_requires =
     pyyaml
     jsonschema
+    jinja2
 
 [options.entry_points]
 console_scripts =

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -3,3 +3,16 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+# `penguin/__init__.py` reads version.txt at import time. It is generated during
+# the container build; when running these unit tests from a source checkout it
+# may be absent. Create a dev placeholder so `import penguin` works either way.
+_version_file = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../src/penguin/version.txt")
+)
+if not os.path.exists(_version_file):
+    try:
+        with open(_version_file, "w") as _f:
+            _f.write("0.0.0+dev\n")
+    except OSError:
+        pass

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -1,0 +1,246 @@
+"""
+Unit tests for the Penguin config layer (penguin.penguin_config).
+
+These cover the schema reshape infrastructure:
+  * static_files mode defaults
+  * friendly Pydantic validation error rendering
+  * `penguin schema` section resolution / docs generation
+  * Jinja2 meta-variable templating
+
+Everything here runs without a rootfs, kernel, or container.
+"""
+
+import tarfile
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import penguin.penguin_config as pc
+from penguin.penguin_config import structure
+from penguin.penguin_config import gen_docs, templating
+from penguin.penguin_config.errors import format_validation_error
+from pydantic import ValidationError
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def base_config(**overrides):
+    """A minimal config dict that validates against structure.Main."""
+    cfg = dict(
+        core=dict(version=2, arch="armel"),
+        env={},
+        pseudofiles={},
+        nvram={},
+        lib_inject={},
+        static_files={},
+        plugins={},
+    )
+    cfg.update(overrides)
+    return cfg
+
+
+def _error_for(cfg):
+    try:
+        structure.Main(**cfg)
+    except ValidationError as e:
+        return e
+    raise AssertionError("expected ValidationError")
+
+
+# --------------------------------------------------------------------------- #
+# static_files mode defaults
+# --------------------------------------------------------------------------- #
+def test_inline_file_mode_defaults_to_644():
+    cfg = base_config(static_files={"/x": dict(type="inline_file", contents="hi")})
+    m = structure.Main(**cfg).model_dump()
+    assert m["static_files"]["/x"]["mode"] == 0o644
+
+
+def test_host_file_and_dir_mode_default_to_755():
+    cfg = base_config(static_files={
+        "/h": dict(type="host_file", host_path="/tmp/h"),
+        "/d": dict(type="dir"),
+    })
+    m = structure.Main(**cfg).model_dump()
+    assert m["static_files"]["/h"]["mode"] == 0o755
+    assert m["static_files"]["/d"]["mode"] == 0o755
+
+
+def test_dev_mode_defaults_to_666():
+    cfg = base_config(static_files={
+        "/dev/x": dict(type="dev", devtype="char", major=1, minor=2),
+    })
+    m = structure.Main(**cfg).model_dump()
+    assert m["static_files"]["/dev/x"]["mode"] == 0o666
+
+
+def test_explicit_mode_is_preserved():
+    cfg = base_config(static_files={"/x": dict(type="inline_file", contents="hi", mode=0o600)})
+    m = structure.Main(**cfg).model_dump()
+    assert m["static_files"]["/x"]["mode"] == 0o600
+
+
+# --------------------------------------------------------------------------- #
+# friendly validation errors
+# --------------------------------------------------------------------------- #
+def test_friendly_error_bad_literal_lists_allowed_values():
+    cfg = base_config(core=dict(version=2, arch="sparc"))
+    msg = format_validation_error(_error_for(cfg))
+    assert "core.arch" in msg
+    assert "allowed:" in msg
+    assert "armel" in msg and "mipsel" in msg
+
+
+def test_friendly_error_unknown_union_tag_lists_tags():
+    cfg = base_config(static_files={"/x": dict(type="bogus")})
+    msg = format_validation_error(_error_for(cfg))
+    assert "static_files./x" in msg
+    assert "inline_file" in msg and "symlink" in msg
+
+
+def test_friendly_error_typo_suggests_field():
+    cfg = base_config()
+    cfg["core"]["kernal"] = "/x"  # typo of kernel
+    msg = format_validation_error(_error_for(cfg))
+    assert "unknown option 'kernal'" in msg
+    assert "did you mean kernel" in msg
+
+
+def test_friendly_error_missing_required_section():
+    cfg = base_config()
+    del cfg["env"]
+    msg = format_validation_error(_error_for(cfg))
+    assert "required option 'env' is missing" in msg
+
+
+def test_friendly_error_records_source_file_from_origin_map():
+    cfg = base_config(core=dict(version=2, arch="sparc"))
+    origin = {"core.arch": "/proj/patch_foo.yaml"}
+    msg = format_validation_error(_error_for(cfg), origin_map=origin)
+    assert "patch_foo.yaml" in msg
+
+
+# --------------------------------------------------------------------------- #
+# schema section resolution + docs generation
+# --------------------------------------------------------------------------- #
+def test_list_sections_contains_known_sections():
+    names = [n for n, _ in gen_docs.list_sections()]
+    for expected in ("core", "env", "static_files", "plugins", "vars"):
+        assert expected in names
+
+
+def test_resolve_section_core():
+    assert gen_docs.resolve_section("core") is structure.Core
+
+
+def test_resolve_section_into_union_variant():
+    variant = gen_docs.resolve_section("pseudofiles.read.const_buf")
+    assert variant is not None
+    assert "val" in variant.model_fields
+
+
+def test_resolve_section_unknown_returns_none():
+    assert gen_docs.resolve_section("does.not.exist") is None
+
+
+def test_gen_docs_runs_without_error():
+    # Exercises dict/Any handling added for the `vars` section.
+    out = gen_docs.gen_docs()
+    assert "Template variables" in out
+    assert isinstance(out, str) and len(out) > 0
+
+
+# --------------------------------------------------------------------------- #
+# Jinja2 templating
+# --------------------------------------------------------------------------- #
+def test_substitute_arch_and_core_fields():
+    raw = {"core": {"arch": "mipsel", "mem": "1G"}, "x": "a={{ arch }} m={{ core.mem }}"}
+    out, _ = templating.render_config(raw)
+    assert out["x"] == "a=mipsel m=1G"
+
+
+def test_substitute_user_vars_including_nested():
+    raw = {
+        "core": {"arch": "mipsel"},
+        "vars": {"webroot": "/www", "libdir": "/lib/{{ arch }}"},
+        "x": "{{ webroot }} {{ libdir }}",
+    }
+    out, _ = templating.render_config(raw)
+    assert out["x"] == "/www /lib/mipsel"
+
+
+def test_substitute_renders_dict_keys():
+    raw = {"core": {"arch": "x"}, "vars": {"d": "/www"}, "sf": {"{{ d }}/index": 1}}
+    out, _ = templating.render_config(raw)
+    assert "/www/index" in out["sf"]
+
+
+def test_kernel_version_two_pass():
+    raw = {"core": {"arch": "mipsel"}, "p": "/k/{{ kernel_version }}/x"}
+    rendered, _ = templating.render_config(raw)
+    assert "{{ kernel_version }}" not in rendered["p"]
+    final = templating.resolve_kernel_version(rendered, "6.13")
+    assert final["p"] == "/k/6.13/x"
+
+
+def test_undefined_variable_raises():
+    with pytest.raises(templating.TemplateError):
+        templating.render_config({"core": {"arch": "x"}, "y": "{{ nope }}"})
+
+
+def test_no_template_config_is_untouched():
+    raw = {"core": {"arch": "armel"}, "static_files": {"/a": {"type": "dir"}}}
+    out, _ = templating.render_config(raw)
+    assert out == raw
+
+
+def test_legacy_at_placeholders_untouched():
+    # @ARCH@-style placeholders (substituted by the test harness) must survive.
+    raw = {"core": {"arch": "armel"}, "k": "/kernels/@ARCH@/vmlinux.@ARCH@"}
+    out, _ = templating.render_config(raw)
+    assert out["k"] == "/kernels/@ARCH@/vmlinux.@ARCH@"
+
+
+# --------------------------------------------------------------------------- #
+# end-to-end through load_config (no kernel/container needed)
+# --------------------------------------------------------------------------- #
+def test_load_config_templating_and_defaults():
+    with tempfile.TemporaryDirectory() as tmp:
+        proj = Path(tmp, "proj")
+        (proj / "base").mkdir(parents=True)
+        with tarfile.open(proj / "base" / "fs.tar.gz", "w"):
+            pass
+        (proj / "config.yaml").write_text(textwrap.dedent("""
+            core:
+              arch: mipsel
+              version: 2
+            vars:
+              webroot: /www
+            env: {}
+            pseudofiles: {}
+            nvram: {}
+            lib_inject: {}
+            static_files:
+              "{{ webroot }}/index.html":
+                type: inline_file
+                contents: "arch={{ arch }} kver={{ kernel_version }}"
+            plugins: {}
+        """))
+
+        cfg = pc.load_config(
+            str(proj), str(proj / "config.yaml"),
+            validate=True,
+            resolved_kernel="/igloo_static/kernels/6.13/zImage.mipsel",
+        )
+
+    sf = cfg["static_files"]["/www/index.html"]
+    assert sf["contents"] == "arch=mipsel kver=6.13"  # templated key + value + 2nd pass
+    assert sf["mode"] == 0o644                          # default applied
+    assert "vars" not in cfg                            # metadata stripped
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
First of two stacked PRs reshaping the config layer. **Fully backwards-compatible** — existing configs load unchanged.

This PR (the infrastructure half):

### Better defaults
- `static_files` actions no longer require `mode`: `inline_file`→`0o644`, `host_file`/`dir`→`0o755`, `dev`→`0o666`. Explicit `mode` is preserved.

### Friendly validation errors
- New `penguin_config/errors.py` renders Pydantic `ValidationError`s into a located, colorized report: the offending option, the **source file** (via the patch `origin_map`), allowed values for bad literals/union tags, and *did-you-mean* suggestions for unknown keys — replacing the raw traceback.

### New CLI commands
- `penguin validate <project>` — full config validation (patches, drop-ins, schema) without a run.
- `penguin schema [section]` — lists top-level sections, or renders any dotted section (e.g. `core`, `pseudofiles.read.const_buf`) using the existing `gen_docs` machinery.

### Jinja2 meta-variable templating
- Configs and patches can use `{{ arch }}`, `{{ core.<field> }}`, a top-level `vars:` section, and the late-bound `{{ kernel_version }}`. Rendered per-file before patch merge; `vars` is stripped from the realized config; files without `{{ }}` are byte-identical. `jinja2` added to `setup.cfg` + Dockerfile.

### Misc
- `gen_docs` gains `resolve_section`/`list_sections` and `dict`/`Any` type rendering; `docs/schema_doc.md` regenerated.
- `conftest.py` creates a dev `version.txt` so `tests/unit_tests` run from a source checkout.
- New `tests/unit_tests/test_config.py` (22 tests) covering defaults, error rendering, schema resolution, and templating.

### Testing
- `tests/unit_tests/test_config.py`: 22 passing on host. Recommend running `tests/comprehensive/test.sh` in-container before merge.

**Stacked:** the follow-up PR (plugin `Args` declarations + first-class plugin syntax + documenting 17 plugins) targets this branch.