### PR TITLE
Patches: template arch-derived paths in auto-generated base patch

### DIFF
--- a/docs/pyplugin_architecture.md
+++ b/docs/pyplugin_architecture.md
@@ -103,8 +103,13 @@ both at the top level and under `plugins:` is an error.
 
 Config and patch files support Jinja2 templating so values that depend on the
 architecture (or other settings) don't have to be hardcoded in multiple places.
-Available variables: `{{ arch }}`, `{{ core.<field> }}` (e.g. `{{ core.mem }}`),
+Available variables: `{{ arch }}`, the arch-derived static-layout subdirs
+`{{ arch_dir }}` and `{{ dylib_dir }}`, `{{ core.<field> }}` (e.g. `{{ core.mem }}`),
 `{{ kernel_version }}`, and anything you define in a top-level `vars:` section.
+
+Penguin's own auto-generated base patch uses this: instead of baking the arch
+subdir into host paths, it emits `{{ arch_dir }}` / `{{ dylib_dir }}` so changing
+`core.arch` reconfigures those paths automatically.
 
 ```yaml
 core:

--- a/src/penguin/arch.py
+++ b/src/penguin/arch.py
@@ -6,6 +6,31 @@ from penguin import getColoredLogger
 logger = getColoredLogger("penguin.arch")
 
 
+def get_dylib_subdir(arch_name: str) -> str:
+    """
+    Map a config arch name (e.g. "aarch64", "powerpc64le") to the subdirectory
+    under ``<static>/dylibs`` holding that arch's prebuilt dynamic libraries.
+
+    Dylibs are built/published under short, sometimes-distinct names that differ
+    from both the config arch name and the generic arch subdir, so this mapping
+    is the single source of truth for both patch generation and config templating
+    (the ``{{ dylib_dir }}`` template variable).
+    """
+    if arch_name == "aarch64":
+        return "arm64"
+    if arch_name == "intel64":
+        return "x86_64"
+    if arch_name == "loongarch64":
+        return "loongarch"
+    if arch_name == "powerpc64le":
+        return "ppc64el"
+    if "powerpc" in arch_name:
+        return arch_name.replace("powerpc", "ppc")  # dylibs use short names
+    # Fall back to the generic arch subdir (e.g. intel64 -> x86_64, mips* as-is).
+    from .utils import get_arch_subdir
+    return get_arch_subdir({"core": {"arch": arch_name}})
+
+
 @dataclasses.dataclass
 class ArchInfo:
     arch: Optional[str] = None

--- a/src/penguin/config_patchers.py
+++ b/src/penguin/config_patchers.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from penguin import getColoredLogger
-from .arch import arch_filter, arch_end
+from .arch import arch_filter, arch_end, get_dylib_subdir
 from .defaults import (
     default_init_script,
     default_lib_aliases,
@@ -422,19 +422,7 @@ class BasePatch(PatchGenerator):
 
         mock_config = {"core": {"arch": self.arch_name}}
         self.arch_dir = get_arch_subdir(mock_config)
-
-        if arch_identified == "aarch64":
-            self.dylib_dir = "arm64"
-        elif arch_identified == "intel64":
-            self.dylib_dir = "x86_64"
-        elif arch_identified == "loongarch64":
-            self.dylib_dir = "loongarch"
-        elif self.arch_name == "powerpc64le":
-            self.dylib_dir = "ppc64el"
-        elif "powerpc" in self.arch_name:
-            self.dylib_dir = self.arch_name.replace("powerpc", "ppc")  # dylibs are built with short names
-        else:
-            self.dylib_dir = self.arch_dir
+        self.dylib_dir = get_dylib_subdir(self.arch_name)
 
     def generate(self, patches: dict) -> dict:
         # Add serial device in pseudofiles
@@ -517,11 +505,14 @@ class BasePatch(PatchGenerator):
                     "host_path": os.path.join(*[STATIC_DIR, "ltrace", "*"]),
                 },
 
-                # Dynamic libraries
+                # Dynamic libraries. The arch-specific subdir is emitted as a
+                # Jinja template ({{ dylib_dir }}) and resolved at config-load
+                # time from core.arch, so changing the arch reconfigures the path
+                # instead of it being baked in here.
                 "/igloo/dylibs/*": {
                     "type": "host_file",
                     "mode": 0o755,
-                    "host_path": os.path.join(STATIC_DIR, "dylibs", self.dylib_dir or self.arch_dir, "*"),
+                    "host_path": os.path.join(STATIC_DIR, "dylibs", "{{ dylib_dir }}", "*"),
                 },
 
                 # Startup scripts
@@ -562,8 +553,9 @@ class BasePatch(PatchGenerator):
                 "mode": 0o755,
             }
         result["static_files"]["/igloo/utils/*"] = {
+            # {{ arch_dir }} is resolved at config-load time from core.arch.
             "type": "host_file",
-            "host_path": f"{STATIC_DIR}/{self.arch_dir}/*",
+            "host_path": f"{STATIC_DIR}/{{{{ arch_dir }}}}/*",
             "mode": 0o755,
         }
 

--- a/src/penguin/penguin_config/templating.py
+++ b/src/penguin/penguin_config/templating.py
@@ -69,11 +69,36 @@ def substitute(obj, ctx, env=None, where="config"):
     return obj
 
 
+def _arch_derived_vars(arch):
+    """
+    Compute arch-derived template variables for a given config arch name.
+
+    Returns a dict with ``arch_dir`` (generic static subdir) and ``dylib_dir``
+    (prebuilt-dylib subdir). Imports are lazy and failures are swallowed so the
+    templating module stays usable in self-contained contexts (e.g. schema
+    generation) where penguin.utils/arch aren't importable; in that case these
+    variables are simply absent and a template referencing them errors clearly.
+    """
+    out = {}
+    try:
+        from penguin.utils import get_arch_subdir
+        out["arch_dir"] = get_arch_subdir({"core": {"arch": arch}})
+    except Exception:
+        pass
+    try:
+        from penguin.arch import get_dylib_subdir
+        out["dylib_dir"] = get_dylib_subdir(arch)
+    except Exception:
+        pass
+    return out
+
+
 def build_context(raw_config, extra=None, env=None, where="vars"):
     """
     Build the Jinja context for a config/patch dict.
 
-    Exposes ``arch``, ``core`` (so ``{{ core.mem }}`` works), the late-bound
+    Exposes ``arch``, the arch-derived ``arch_dir`` / ``dylib_dir`` static-layout
+    subdirs, ``core`` (so ``{{ core.mem }}`` works), the late-bound
     ``kernel_version`` sentinel, anything in ``extra`` (e.g. the main config's
     context when rendering a patch), and the file's own ``vars:`` (which may
     themselves reference earlier vars / arch).
@@ -85,8 +110,10 @@ def build_context(raw_config, extra=None, env=None, where="vars"):
     core = raw_config.get("core") if isinstance(raw_config, dict) else None
     if isinstance(core, dict):
         ctx["core"] = dict(core)
-        if core.get("arch"):
-            ctx["arch"] = core["arch"]
+        arch = core.get("arch")
+        if arch:
+            ctx["arch"] = arch
+            ctx.update(_arch_derived_vars(arch))
     user_vars = raw_config.get("vars") if isinstance(raw_config, dict) else None
     if isinstance(user_vars, dict):
         for k, v in user_vars.items():

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -410,6 +410,57 @@ def test_legacy_at_placeholders_untouched():
 
 
 # --------------------------------------------------------------------------- #
+# arch-derived template variables (used by auto-generated patches)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("arch,arch_dir,dylib_dir", [
+    ("armel", "armel", "armel"),
+    ("aarch64", "aarch64", "arm64"),
+    ("intel64", "x86_64", "x86_64"),
+    ("powerpc64le", "powerpc64", "ppc64el"),
+    ("powerpc", "powerpc", "ppc"),
+    ("mipsel", "mipsel", "mipsel"),
+    ("loongarch64", "loongarch64", "loongarch"),
+])
+def test_arch_derived_context_vars(arch, arch_dir, dylib_dir):
+    ctx = templating.build_context({"core": {"arch": arch}})
+    assert ctx["arch"] == arch
+    assert ctx["arch_dir"] == arch_dir
+    assert ctx["dylib_dir"] == dylib_dir
+
+
+def test_get_dylib_subdir_matches_context():
+    from penguin.arch import get_dylib_subdir
+    assert get_dylib_subdir("aarch64") == "arm64"
+    assert get_dylib_subdir("powerpc64le") == "ppc64el"
+    assert get_dylib_subdir("mipsel") == "mipsel"
+
+
+def test_arch_dir_template_resolves_in_patch():
+    # Mirrors the generated base patch: defines core.arch and uses the derived
+    # subdir variables in host_paths.
+    patch = {
+        "core": {"arch": "aarch64"},
+        "static_files": {
+            "/igloo/dylibs/*": {"type": "host_file", "host_path": "/s/dylibs/{{ dylib_dir }}/*"},
+            "/igloo/utils/*": {"type": "host_file", "host_path": "/s/{{ arch_dir }}/*"},
+        },
+    }
+    out = templating.substitute(patch, templating.build_context(patch))
+    assert out["static_files"]["/igloo/dylibs/*"]["host_path"] == "/s/dylibs/arm64/*"
+    assert out["static_files"]["/igloo/utils/*"]["host_path"] == "/s/aarch64/*"
+
+
+def test_generated_base_patch_emits_arch_templates():
+    # The BasePatch generator should emit Jinja placeholders (not baked subdirs)
+    # for the arch-specific host_paths, so load-time templating resolves them.
+    import inspect
+    from penguin import config_patchers
+    src = inspect.getsource(config_patchers.BasePatch.generate)
+    assert "{{ dylib_dir }}" in src
+    assert "{{ arch_dir }}" in src
+
+
+# --------------------------------------------------------------------------- #
 # PR1+PR3+PR4 end-to-end through load_config (no kernel/container needed)
 # --------------------------------------------------------------------------- #
 def _make_project(tmp, config_text, plugin_dir):


### PR DESCRIPTION
Third PR in the config-reshape series. **Targets `config-reshape-core` (#818)** — it builds on that branch's Jinja templating. Independent of the plugin PR (#819); they're siblings on #818.

Puts the new templating to work in Penguin's **auto-generated patches** so architecture-dependent values are resolved from `core.arch` at load time instead of being compiled into the generated YAML. This directly addresses the original gripe that changing arch didn't update arch-derived values baked into patches.

### What changes
- **New arch-derived template variables** exposed by `templating.build_context`, derived from the file's `core.arch`:
  - `{{ arch_dir }}` — generic static subdir (e.g. `intel64`→`x86_64`, `powerpc64le`→`powerpc64`)
  - `{{ dylib_dir }}` — prebuilt-dylib subdir (e.g. `aarch64`→`arm64`, `powerpc64le`→`ppc64el`)
  - Imports are lazy/guarded so self-contained contexts (schema generation) are unaffected.
- **`arch.get_dylib_subdir()`** is now the single source of truth for the dylib mapping; `BasePatch.set_arch_info` uses it instead of an inline copy (verified equivalent for every schema-supported arch).
- **`BasePatch.generate`** emits `{{ dylib_dir }}` / `{{ arch_dir }}` in the `/igloo/dylibs/*` and `/igloo/utils/*` host paths instead of baking the subdir in. The generated `base.yaml` defines `core.arch`, so these resolve when `load_config` renders the patch.
- `core.arch` and `core.kernel` deliberately stay concrete — they're the *source* values (templating them would be circular). Serial-device major/minor (conditional ints) and kernel-module version paths (padded-version mismatch with `{{ kernel_version }}`) are intentionally left baked; noted for a possible follow-up.

### Testing
- `tests/unit_tests/test_config.py`: +10 tests (32 total, all passing on host) — derived-var values across 7 arches, `get_dylib_subdir` parity, in-patch resolution, and an assertion that the generator emits the placeholders.
- End-to-end `load_config` (a patch that defines `core.arch` and uses the derived vars) resolves to `/igloo_static/dylibs/arm64/*` and `/igloo_static/aarch64/*` as expected.