### PR TITLE
NetBinds: track service closes with debounce + transient labeling

### DIFF
--- a/pyplugins/analysis/netbinds.py
+++ b/pyplugins/analysis/netbinds.py
@@ -2,36 +2,72 @@
 NetBinds Plugin (netbinds.py) for Penguin
 =========================================
 
-This module provides the NetBinds plugin, which monitors and records all network bind events
-within the guest during emulation. It tracks both IPv4 and IPv6 binds, logs detailed information
-about each bind, and publishes 'on_bind' events for other plugins to react to new network services.
+This module provides the NetBinds plugin, which monitors and records the full
+lifecycle of network services within the guest during emulation. It tracks both
+IPv4 and IPv6 sockets, recording when they are *bound* (opened) and when they
+are *released* (closed), and publishes 'on_bind' events for other plugins to
+react to new network services.
+
+Lifecycle tracking
+-------------------
+
+Services frequently flap: a process may bind, close, and re-bind the same
+address in rapid succession (e.g. supervisord restarting a daemon, or a server
+that briefly rebinds during startup). To avoid treating every flap as a genuine
+close, NetBinds applies a *debounce period*:
+
+- When a socket is released, the close is held as *pending* rather than being
+  finalized immediately.
+- If the same socket is re-bound within ``debounce_period`` seconds, the close
+  is cancelled and the event is recorded as a *flap* (the service is considered
+  to have stayed up continuously).
+- A pending close older than ``debounce_period`` is *finalized* into a real
+  close. Finalization happens opportunistically when later events arrive, and
+  unconditionally when the plugin unloads.
+
+A socket that flaps ``transient_threshold`` or more times during the run is
+labelled *transient* in the lifecycle summary, marking it as an unstable
+service worth attention.
 
 Features
 --------
 
 - Subscribes to low-level bind/setup/release events for IPv4 and IPv6 sockets.
-- Tracks and deduplicates all bind events, including process name, IP version, socket type, IP, and port.
-- Logs bind details and summary statistics to CSV files in the output directory.
-- Publishes 'on_bind' events for other plugins (such as VPN, Nmap, FetchWeb) to consume.
-- Optionally shuts down emulation when a web service (port 80) is bound, if configured.
+- Tracks and deduplicates first-seen binds (process name, IP version, socket
+  type, IP, port), as before.
+- Logs first-seen binds and summary statistics to CSV files in the output
+  directory (``netbinds.csv``, ``netbinds_summary.csv``) -- unchanged format.
+- Logs every open/flap/transient/close transition to ``netbind_events.csv`` and
+  writes a per-socket lifecycle summary to ``netbinds_lifecycle.csv`` on unload.
+- Publishes 'on_bind' events for other plugins (such as VPN, Nmap, FetchWeb).
+- Optionally shuts down emulation when a web service (port 80) is bound.
 
 Arguments
 ---------
 
-- shutdown_on_www (bool, optional): If True, shut down emulation when a bind occurs on port 80.
+- shutdown_on_www (bool, optional): If True, shut down emulation when a bind
+  occurs on port 80.
+- debounce_period (float, optional): Seconds a close is held pending before
+  being treated as a real close. A re-bind within this window is a flap.
+  Default: 2.0.
+- transient_threshold (int, optional): Number of flaps at which a socket is
+  labelled transient. Default: 3.
 
 Plugin Interface
 ----------------
 
-- Publishes 'on_bind' events with (sock_type, ipvn, ip, port, procname) for other plugins to consume.
-- Does not subscribe to other plugin events, but listens to low-level system events.
-- Writes bind logs and summaries to files in the output directory.
+- Publishes 'on_bind' events with (sock_type, ipvn, ip, port, procname) for
+  other plugins to consume. (Semantics unchanged: fired once per first-seen
+  unique bind.)
+- Listens to low-level system bind/setup/release events.
+- Writes bind logs, a lifecycle event log, and summaries to the output dir.
 
 Overall Purpose
 ---------------
 
-The NetBinds plugin provides a comprehensive record of all network services started by the guest,
-enabling automation, analysis, and integration with other actuation plugins.
+The NetBinds plugin provides a comprehensive record of the network services
+started -- and stopped -- by the guest, enabling automation, analysis, and
+integration with other actuation plugins.
 """
 
 import socket
@@ -44,12 +80,26 @@ from penguin import plugins, Plugin, PluginArgs
 
 BINDS_FILE = "netbinds.csv"
 SUMMARY_BINDS_FILE = "netbinds_summary.csv"
+EVENTS_FILE = "netbind_events.csv"
+LIFECYCLE_FILE = "netbinds_lifecycle.csv"
+
+DEFAULT_DEBOUNCE_PERIOD = 2.0
+DEFAULT_TRANSIENT_THRESHOLD = 3
 
 
 class NetBinds(Plugin):
     class Args(PluginArgs):
         shutdown_on_www: bool = Field(
             default=False, description="If true, shut down emulation when a bind occurs on port 80."
+        )
+        debounce_period: float = Field(
+            default=DEFAULT_DEBOUNCE_PERIOD,
+            description="Seconds a close is held pending before being treated as a real close. "
+            "A re-bind within this window is recorded as a flap, not a close.",
+        )
+        transient_threshold: int = Field(
+            default=DEFAULT_TRANSIENT_THRESHOLD,
+            description="Number of flaps at which a socket is labelled transient.",
         )
 
     def __init__(self) -> None:
@@ -59,10 +109,18 @@ class NetBinds(Plugin):
         self.outdir = self.get_arg("outdir")
         self.seen_binds = set()
         self.start_time = time.time()
-        self.bind_list = []
         self.shutdown_on_www = self.get_arg_bool("shutdown_on_www")
 
-        # The NetBinds.on_bind PPP callback happens on every bind.
+        debounce = self.get_arg("debounce_period")
+        self.debounce_period = float(debounce) if debounce is not None else DEFAULT_DEBOUNCE_PERIOD
+        threshold = self.get_arg("transient_threshold")
+        self.transient_threshold = int(threshold) if threshold is not None else DEFAULT_TRANSIENT_THRESHOLD
+
+        # Per-socket lifecycle state, keyed by (ipvn, sock_type, normalized_ip, port).
+        # This is the source of truth for currently-active binds (see give_list).
+        self.sockets = {}
+
+        # The NetBinds.on_bind PPP callback happens on every first-seen bind.
         # Don't be confused by the vpn on_bind callback that happens
         # after the VPN bridges a connection. This one has the better name
         # but that one is more of a pain to change.
@@ -74,6 +132,9 @@ class NetBinds(Plugin):
 
         with open(join(self.outdir, SUMMARY_BINDS_FILE), "w") as f:
             f.write("n_procs,n_sockets,bound_www,time\n")
+
+        with open(join(self.outdir, EVENTS_FILE), "w") as f:
+            f.write("event,procname,ipvn,domain,guest_ip,guest_port,pid,time\n")
 
         plugins.subscribe(plugins.Events, "igloo_ipv4_bind", self.on_ipv4_bind)
         plugins.subscribe(plugins.Events, "igloo_ipv6_bind", self.on_ipv6_bind)
@@ -144,7 +205,7 @@ class NetBinds(Plugin):
 
     def on_ipv4_release(self, cpu, ip_port, is_stream) -> None:
         """
-        Handle IPv4 socket release event, remove bind from tracking.
+        Handle IPv4 socket release event, record a (debounced) close.
 
         Args:
             cpu: The CPU core where the event occurred.
@@ -152,24 +213,24 @@ class NetBinds(Plugin):
             is_stream: Boolean indicating if this was a stream (TCP) socket.
         """
         sock_type = "tcp" if is_stream else "udp"
-        ip, port = ip_port.split(':')
+        ip, port = ip_port.rsplit(':', 1)
         if int(port) != 0:
-            self.remove_bind(ip, port, sock_type)
+            self.record_close(4, sock_type, ip, int(port))
 
     def on_ipv6_release(self, cpu, ip_port, is_stream) -> None:
         """
-        Handle IPv6 socket release event, remove bind from tracking.
+        Handle IPv6 socket release event, record a (debounced) close.
 
         Args:
             cpu: The CPU core where the event occurred.
-            ip_port: The IP:port string of the released socket.
+            ip_port: The IP:port string of the released socket, e.g. "[::1]:80".
             is_stream: Boolean indicating if this was a stream (TCP) socket.
         """
         sock_type = "tcp" if is_stream else "udp"
-        ip_part, port = ip_port.rsplit(']:')
+        ip_part, port = ip_port.rsplit(']:', 1)
         if int(port) != 0:
             ip = ip_part.lstrip('[')
-            self.remove_bind(ip, port, sock_type)
+            self.record_close(6, sock_type, ip, int(port))
 
     def on_bind(self, cpu, procname, is_ipv4, is_stream, port_pid, sin_addr) -> None:
         """
@@ -214,6 +275,11 @@ class NetBinds(Plugin):
                     sin_addr = struct.pack("<IIII", *(struct.unpack(">IIII", sin_addr)))
                 ip = f"[{socket.inet_ntop(socket.AF_INET6, sin_addr)}]"
 
+        # Update the socket lifecycle on every bind, including repeats, so we
+        # can observe (and debounce) flapping services. This runs before the
+        # seen_binds dedup gate below, which only governs the legacy CSV/event.
+        self.record_open(now, time_delta, procname, ipvn, sock_type, ip, port, pid)
+
         # Only report each bind once, if it's identical
         # VPN / stats will just get confused if we report the same bind twice
         if (procname, ipvn, sock_type, ip, port) in self.seen_binds:
@@ -223,8 +289,6 @@ class NetBinds(Plugin):
         # Log details to disk
         self.report_bind_info(time_delta, procname, ipvn, sock_type, ip, port, pid)
 
-        self.track_bind(procname, ipvn, sock_type, ip, port, pid, time_delta)
-
         # Trigger our callback
         plugins.publish(self, "on_bind", sock_type, ipvn, ip, port, procname)
 
@@ -233,48 +297,149 @@ class NetBinds(Plugin):
             self.logger.info("Shutting down emulation due to bind on port 80")
             self.panda.end_analysis()
 
-    def track_bind(self, procname, ipvn, sock_type, ip, port, pid, time) -> None:
-        """
-        Track a bind event in the internal list for later analysis.
+    @staticmethod
+    def _norm_ip(ip) -> str:
+        """Normalize an IP for keying: strip IPv6 brackets so bind ('[::1]')
+        and release ('::1') refer to the same socket."""
+        return ip.strip("[]")
 
-        Args:
-            procname: The name of the process that performed the bind.
-            ipvn: The IP version (4 or 6) of the bind.
-            sock_type: The type of socket (TCP or UDP).
-            ip: The IP address being bound.
-            port: The port number being bound.
-            time: The time since emulation start when the bind occurred.
-        """
-        add_dict = {
-            "Process Name": procname,
-            "IPvN": ipvn,
-            "Socket Type": sock_type,
-            "IP": ip,
-            "Port": port,
-            "PID": pid,
-            "Time": time
-        }
-        self.bind_list.append(add_dict)
+    def _socket_key(self, ipvn, sock_type, ip, port):
+        """Build the lifecycle dict key for a socket."""
+        return (ipvn, sock_type, self._norm_ip(ip), int(port))
 
-    def remove_bind(self, ip, port, sock_type) -> None:
-        """
-        Remove a bind from the internal tracking list.
+    def _log_event(self, event, rec, time_delta) -> None:
+        """Append one lifecycle transition to the event log."""
+        with open(join(self.outdir, EVENTS_FILE), "a") as f:
+            f.write(
+                f"{event},{rec['procname']},{rec['ipvn']},{rec['sock_type']},"
+                f"{rec['ip']},{rec['port']},{rec['pid']},{time_delta:.3f}\n"
+            )
 
-        Args:
-            ip: The IP address of the bind to remove.
-            port: The port number of the bind to remove.
-            sock_type: The type of socket (TCP or UDP) of the bind to remove.
+    def _sweep_pending_closes(self, now) -> None:
+        """Finalize any pending closes that have outlived the debounce period."""
+        for rec in self.sockets.values():
+            if rec["pending_close"] is not None and (now - rec["pending_close"]) > self.debounce_period:
+                self._finalize_close(rec)
+
+    def _finalize_close(self, rec) -> None:
+        """Turn a pending close into a real close, accounting for uptime."""
+        close_delta = rec["pending_close_delta"]
+        rec["state"] = "closed"
+        rec["close_count"] += 1
+        rec["last_close"] = close_delta
+        if rec["last_open"] is not None:
+            rec["total_uptime"] += max(0.0, close_delta - rec["last_open"])
+        rec["pending_close"] = None
+        rec["pending_close_delta"] = None
+        self._log_event("close", rec, close_delta)
+
+    def record_open(self, now, time_delta, procname, ipvn, sock_type, ip, port, pid) -> None:
         """
-        self.bind_list[:] = [bind for bind in self.bind_list if not (bind["IP"] == ip and bind["Port"] == int(port) and bind["Socket Type"] == sock_type)]
+        Record a bind (open) in the socket lifecycle, applying debounce so a
+        re-bind shortly after a close is treated as a flap rather than a new
+        service.
+        """
+        self._sweep_pending_closes(now)
+        key = self._socket_key(ipvn, sock_type, ip, port)
+        rec = self.sockets.get(key)
+
+        if rec is None:
+            self.sockets[key] = {
+                "procname": procname,
+                "pid": pid,
+                "ipvn": ipvn,
+                "sock_type": sock_type,
+                "ip": ip,
+                "port": port,
+                "state": "open",
+                "open_count": 1,
+                "close_count": 0,
+                "flap_count": 0,
+                "first_open": time_delta,
+                "last_open": time_delta,
+                "last_close": None,
+                "pending_close": None,
+                "pending_close_delta": None,
+                "total_uptime": 0.0,
+                "transient": False,
+            }
+            self._log_event("open", self.sockets[key], time_delta)
+            return
+
+        # Refresh identity from the latest binder.
+        rec["procname"] = procname
+        rec["pid"] = pid
+        rec["ip"] = ip
+
+        if rec["pending_close"] is not None:
+            # Re-bound within the debounce window -> a flap. The close never
+            # really happened; the service is considered continuously up.
+            rec["pending_close"] = None
+            rec["pending_close_delta"] = None
+            rec["flap_count"] += 1
+            rec["open_count"] += 1
+            rec["state"] = "open"
+            self._log_event("flap", rec, time_delta)
+            if rec["flap_count"] >= self.transient_threshold and not rec["transient"]:
+                rec["transient"] = True
+                self.logger.info(
+                    f"Service {sock_type}/{ip}:{port} ({procname}) marked transient "
+                    f"after {rec['flap_count']} flaps"
+                )
+                # Record the transition to transient as its own lifecycle event so
+                # it is observable incrementally (the per-socket summary is only
+                # written at unload).
+                self._log_event("transient", rec, time_delta)
+        elif rec["state"] == "closed":
+            # Genuine re-open after a finalized close (outside the debounce
+            # window) -- a spaced restart, not rapid flapping.
+            rec["open_count"] += 1
+            rec["last_open"] = time_delta
+            rec["state"] = "open"
+            self._log_event("open", rec, time_delta)
+        # else: already open and not pending close -> duplicate bind, no change.
+
+    def record_close(self, ipvn, sock_type, ip, port) -> None:
+        """
+        Record a release (close) in the socket lifecycle. The close is held
+        pending until the debounce period elapses (see _sweep_pending_closes
+        and uninit), so a quick re-bind can cancel it as a flap.
+        """
+        now = time.time()
+        time_delta = now - self.start_time
+        self._sweep_pending_closes(now)
+
+        key = self._socket_key(ipvn, sock_type, ip, port)
+        rec = self.sockets.get(key)
+        if rec is None or rec["state"] != "open":
+            # Release for a socket we never saw bound, or already closed/pending.
+            return
+        rec["pending_close"] = now
+        rec["pending_close_delta"] = time_delta
 
     def give_list(self):
         """
-        Return the current list of tracked binds.
+        Return the list of currently-active binds (open, or closed-but-pending
+        within the debounce window).
 
         Returns:
-            list: A list of dictionaries, each representing a tracked bind.
+            list: A list of dictionaries, each representing an active bind.
         """
-        return self.bind_list
+        active = []
+        for rec in self.sockets.values():
+            if rec["state"] == "open":
+                active.append({
+                    "Process Name": rec["procname"],
+                    "IPvN": rec["ipvn"],
+                    "Socket Type": rec["sock_type"],
+                    "IP": rec["ip"],
+                    "Port": rec["port"],
+                    "PID": rec["pid"],
+                    "Time": rec["first_open"],
+                    "State": "transient" if rec["transient"] else "open",
+                    "Flaps": rec["flap_count"],
+                })
+        return active
 
     def report_bind_info(self, time_delta, procname, ipvn, sock_type, ip, port, pid) -> None:
         """
@@ -310,3 +475,36 @@ class NetBinds(Plugin):
         # Report summary stats
         with open(join(self.outdir, SUMMARY_BINDS_FILE), "a") as f:
             f.write(f"{n_procs},{n_sockets},{bound_www},{time_delta:.3f}\n")
+
+    def uninit(self) -> None:
+        """
+        Finalize the socket lifecycle on unload and write the lifecycle summary.
+
+        Any pending closes are finalized at their real (pending) close time, and
+        any sockets still open at shutdown have their uptime closed out at the
+        end of the run.
+        """
+        now = time.time()
+        final_delta = now - self.start_time
+
+        for rec in self.sockets.values():
+            if rec["pending_close"] is not None:
+                # A close that never got a re-bind: it was real.
+                self._finalize_close(rec)
+            elif rec["state"] == "open" and rec["last_open"] is not None:
+                # Still up at shutdown: count uptime through end of run.
+                rec["total_uptime"] += max(0.0, final_delta - rec["last_open"])
+
+        with open(join(self.outdir, LIFECYCLE_FILE), "w") as f:
+            f.write(
+                "procname,ipvn,domain,guest_ip,guest_port,pid,state,transient,"
+                "open_count,close_count,flap_count,first_open,last_close,total_uptime\n"
+            )
+            for rec in self.sockets.values():
+                last_close = "" if rec["last_close"] is None else f"{rec['last_close']:.3f}"
+                f.write(
+                    f"{rec['procname']},{rec['ipvn']},{rec['sock_type']},{rec['ip']},"
+                    f"{rec['port']},{rec['pid']},{rec['state']},{rec['transient']},"
+                    f"{rec['open_count']},{rec['close_count']},{rec['flap_count']},"
+                    f"{rec['first_open']:.3f},{last_close},{rec['total_uptime']:.3f}\n"
+                )

--- a/tests/unit_tests/test_target/base_config.yaml
+++ b/tests/unit_tests/test_target/base_config.yaml
@@ -27,6 +27,7 @@ patches:
   - ./patches/tests/portalcall.yaml
   - ./patches/tests/net_missing.yaml
   - ./patches/tests/netbinds.yaml
+  - ./patches/tests/netbinds_lifecycle.yaml
   - ./patches/tests/netdevs.yaml
   - ./patches/tests/netdev_auto_register.yaml
   - ./patches/tests/netdev_names.yaml

--- a/tests/unit_tests/test_target/patches/tests/netbinds.yaml
+++ b/tests/unit_tests/test_target/patches/tests/netbinds.yaml
@@ -28,7 +28,50 @@ static_files:
       # start server
       /igloo/utils/busybox httpd -f -p 8000 -h / &
       sleep 1
-      /igloo/utils/netcat_udp_echo.sh &
+      # Watchdog the UDP echo server. On MIPS, micropython's getaddrinfo() (used
+      # to resolve the listen address) intermittently hangs or segfaults when
+      # another micropython process calls getaddrinfo() at the same time. If the
+      # server gets stuck before binding 4444, the host-side udp_echo check never
+      # sees the bind and fails. So: launch it, and if it has not bound 4444
+      # (0x115C in /proc/net/udp) within a few seconds, kill it and relaunch. A
+      # clean crash/exit also just falls through to a relaunch. The host retries
+      # the echo for ~10s once it sees the bind, ample for this recovery.
+      ( set +e
+        while /igloo/utils/busybox true; do
+          /igloo/utils/netcat_udp_echo.sh &
+          np=$!
+          bound=0
+          i=0
+          while [ $i -lt 4 ]; do
+            if /igloo/utils/busybox grep -qi ":115C" /proc/net/udp 2>/dev/null; then
+              bound=1
+              break
+            fi
+            /igloo/utils/busybox sleep 1
+            i=$((i + 1))
+          done
+          if [ $bound -eq 1 ]; then
+            wait $np
+          else
+            /igloo/utils/busybox kill $np 2>/dev/null
+          fi
+          /igloo/utils/busybox sleep 1
+        done ) &
+
+      # Block here until the echo server has actually bound 4444 before letting
+      # run_tests.sh advance to the next test. That next test also calls
+      # micropython getaddrinfo(), and a concurrent getaddrinfo() is exactly what
+      # makes the server hang/crash on MIPS -- so resolving the server's address
+      # while nothing else competes is what keeps it reliable. Bounded so a
+      # genuinely stuck server can't wedge the whole suite.
+      j=0
+      while [ $j -lt 20 ]; do
+        if /igloo/utils/busybox grep -qi ":115C" /proc/net/udp 2>/dev/null; then
+          break
+        fi
+        /igloo/utils/busybox sleep 1
+        j=$((j + 1))
+      done
       # echo "tests pass"
       exit 0
     mode: 73
@@ -52,7 +95,9 @@ static_files:
       try:
           while True:
               try:
-                  data, addr = sock.recvfrom(65535)
+                  # Tiny control messages -- a small buffer avoids needlessly
+                  # allocating 64 KiB per recv on memory-tight MIPS guests.
+                  data, addr = sock.recvfrom(2048)
               except Exception:   # e.g., EINTR on some ports
                   continue
               try:

--- a/tests/unit_tests/test_target/patches/tests/netbinds_lifecycle.yaml
+++ b/tests/unit_tests/test_target/patches/tests/netbinds_lifecycle.yaml
@@ -1,0 +1,65 @@
+# Exercises NetBinds' socket lifecycle tracking: debounce, flap detection, the
+# transient label, and close finalization. A large debounce_period means every
+# quick re-bind during the run lands inside the window and is counted as a flap
+# (independent of emulation speed), and a low transient_threshold makes two
+# flaps enough to mark a service transient.
+plugins:
+  netbinds:
+    debounce_period: 3600
+    transient_threshold: 2
+  verifier:
+    conditions:
+      # Re-binding 8401 within the debounce window is recorded as a flap.
+      netbinds_lifecycle+flap:
+        type: file_contains
+        file: netbind_events.csv
+        strings:
+          - "flap,"
+          - ",8401,"
+      # Two flaps cross transient_threshold and emit a transient event.
+      netbinds_lifecycle+transient:
+        type: file_contains
+        file: netbind_events.csv
+        strings:
+          - "transient,"
+          - ",8401,"
+      # The cleanly-closed 8402 listener is finalized as closed at unload.
+      netbinds_lifecycle+closed:
+        type: file_contains
+        file: netbinds_lifecycle.csv
+        strings:
+          - ",8402,"
+          - "closed"
+static_files:
+  # A single process drives the lifecycle by explicitly binding/listening and
+  # closing sockets, so each close() reliably emits a release hypercall and the
+  # next bind() re-binds immediately. This is deterministic regardless of
+  # emulation speed -- unlike killing a background daemon, where the port may
+  # not be released before the next bind ("Address in use"). listen() puts the
+  # socket in TCP_LISTEN so the release fires even with a listener-only guard.
+  /tests/netbinds_lifecycle.sh:
+    type: inline_file
+    contents: |
+      #!/igloo/utils/micropython
+      import usocket as socket
+
+      def cycle(port, times):
+          for _ in range(times):
+              s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+              try:
+                  s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+              except Exception:
+                  pass
+              ai = socket.getaddrinfo("0.0.0.0", port, 0, socket.SOCK_STREAM)[0]
+              s.bind(ai[-1])
+              s.listen(1)
+              s.close()
+
+      # Flapping service: bind/close 8401 three times. With the large
+      # debounce_period each re-bind lands inside the window and is a flap;
+      # reaching transient_threshold (2) marks the service transient.
+      cycle(8401, 3)
+
+      # Cleanly-closed service: bind 8402 once, then close it for good.
+      cycle(8402, 1)
+    mode: 73


### PR DESCRIPTION
## Summary

Penguin tracks when guest services **bind** ports but not when they **close** — releases mutated an in-memory list that was never written out, so closes were invisible. Some firmware also opens/closes the same port in rapid succession. This adds a debounced socket lifecycle to NetBinds, plus the bug fixes and test-harness revival needed to exercise it.

### Feature — `pyplugins/analysis/netbinds.py`
- Per-socket lifecycle state machine keyed on `(ipvn, sock_type, ip, port)` recording open/close/reopen with timestamps.
- **Debounce** (`debounce_period`, default 2.0s): a release is held *pending*; a re-bind within the window is a **flap**, not a close. Pending closes finalize on later events and at `uninit`.
- **Transient labeling** (`transient_threshold`, default 3): flap count >= threshold => `transient`.
- New outputs `netbind_events.csv` (open/flap/close log) and `netbinds_lifecycle.csv` (per-socket summary). Existing `netbinds.csv` / `netbinds_summary.csv` and the `on_bind` PPP event are unchanged.
- Fixes two latent bugs: `seen_binds` permanently suppressing re-binds, and IPv6 keys never matching releases (bracket normalization).

Pairs with rehosting/igloo_driver#75 (guest hook only emits TCP releases for listening sockets).

### Drive-by fixes — explore was broken (uncaught due to bit-rotted suite)
- `common.py`: `int_to_hex_representer` passed a raw int to `represent_scalar` for values > 10, crashing every config dump with yamlcore (e.g. modes 73/493).
- `graph_search.py`: single-threaded `Worker(...)` omitted the `timeout` arg.
- `utils.py`: `get_mitigation_providers` only caught `ValueError`; a missing flat plugin file raises `FileNotFoundError`.

### Test + harness
- `tests/comprehensive/netbinds/` — stable / flapping-transient / cleanly-closed listeners + `assert_netbinds`.
- Revived the comprehensive harness against current penguin: `makeImage.sh` -> `penguin explore`, modern project layout (`base/` + `static/InitFinder.yaml`), `PENGUIN_IMAGE` override, conditional TTY, forward `n_iters`.

## Validation
- Host lifecycle logic: full unit simulation (debounce, flap->transient, clean close, IPv6) passes.
- Builds into the image (local-packages); the netbinds plugin loads and writes its new CSVs in the real runtime.
- **Not yet end-to-end in-guest**: capturing real bind/release hypercalls is blocked by a kernel/driver vermagic mismatch in the available `linux_builder` artifacts and synthetic-config boot bit-rot (`/igloo/init` shebang vs current preinit flow). Follow-up: rebuild a matched kernel+driver and finish reviving the harness.

> Draft: the three drive-by fixes are independent of the feature and can be split into their own PR on request.