### PR TITLE
Fix docs PDF build: drop control chars from kernel_version sentinel

### DIFF
--- a/src/penguin/penguin_config/templating.py
+++ b/src/penguin/penguin_config/templating.py
@@ -17,7 +17,10 @@ Configs that contain no ``{{ }}``/``{% %}`` are returned untouched.
 import jinja2
 
 # First-pass placeholder for the late-bound kernel_version variable.
-KERNEL_VERSION_SENTINEL = "\x00IGLOO_KERNEL_VERSION\x00"
+# Printable but improbable: a literal control character here breaks the Sphinx
+# LaTeX/PDF docs build (autodoc renders this value and pdflatex rejects control
+# chars), while this token is still effectively un-typeable in real configs.
+KERNEL_VERSION_SENTINEL = "__IGLOO_KERNEL_VERSION_SENTINEL_b3f0c1__"
 
 
 class TemplateError(Exception):


### PR DESCRIPTION
## Problem

The **Release Container** job is failing in its documentation build. `pdflatex` errors with:

```
! LaTeX Error: Unicode character (U+0090) not set up for use with LaTeX.
```

(×4, inside an autodoc-rendered code listing), which aborts the PDF build and cascades into `AssertionError: Penguin run did not complete successfully; missing .../results/latest/.ran`.

## Root cause

`penguin_config/templating.py` defined the late-bound kernel_version placeholder with raw NUL control bytes:

```python
KERNEL_VERSION_SENTINEL = "\x00IGLOO_KERNEL_VERSION\x00"
```

The bytes are harmless at runtime, but Sphinx autodoc renders this module constant's **value** into the LaTeX output, and `pdflatex` cannot typeset control characters.

## Fix

Use a printable, improbable token — still effectively un-typeable in real configs, and safe through Jinja/YAML/LaTeX:

```python
KERNEL_VERSION_SENTINEL = "__IGLOO_KERNEL_VERSION_SENTINEL_b3f0c1__"
```

Used only within `templating.py` (first-pass placeholder swapped to the resolved kernel path by `resolve_kernel_version`); kernel_version templating tests pass and flake8 is clean.