### PR TITLE
Fix release build: don't assert emulation success for --docs-only runs

### DIFF
--- a/tests/unit_tests/test_target/test.py
+++ b/tests/unit_tests/test_target/test.py
@@ -46,6 +46,28 @@ def penguin_run(config, image, name=None):
         sys.exit(1)
 
 
+def assert_docs_built():
+    """Validate a --docs-only run.
+
+    The doc_generator plugin builds the docs and then calls ``os._exit(0)``,
+    so a docs build intentionally never boots the guest and never produces a
+    ``.ran`` file or verifier output. Assert the documentation artifacts were
+    produced instead (this also still catches a broken docs/PDF build).
+    """
+    latest = TEST_DIR / "results" / "latest"
+    html_index = latest / "sphinx" / "html" / "index.html"
+    pdfs = list((latest / "sphinx" / "latex").glob("*.pdf"))
+
+    if not html_index.exists():
+        raise AssertionError(
+            f"Docs build did not produce HTML output; missing {html_index}"
+        )
+    if not pdfs:
+        raise AssertionError(
+            f"Docs build did not produce a PDF in {latest / 'sphinx' / 'latex'}"
+        )
+
+
 def assert_penguin_run_succeeded():
     latest = TEST_DIR / "results" / "latest"
     ran_file = latest / ".ran"
@@ -153,7 +175,12 @@ def run_test(kernel, arch, image, test_file=None, docs_only=False, execution_mod
             logger.info(f"Placed preset nvram_state.yaml from {state_preset.name}")
 
     penguin_run(new_config, image, name)
-    assert_penguin_run_succeeded()
+    if docs_only:
+        # A docs-only run builds documentation and exits without emulating,
+        # so assert the docs artifacts rather than a successful penguin run.
+        assert_docs_built()
+    else:
+        assert_penguin_run_succeeded()
     logger.info("Test completed")
 
 


### PR DESCRIPTION
## Problem

The `Release Container` workflow is still failing after the docs/PDF fix (#825), now with:

```
AssertionError: Penguin run did not complete successfully; missing .../results/latest/.ran
```

…even though the emulation exits `rc=0` and the docs build successfully.

## Root cause (not a config-PR regression)

`publish.yaml` runs `test.py --docs-only`, which enables the `doc_generator` plugin. `SphinxGenerator.__init__` builds the HTML/PDF docs and then calls `os._exit(0)` (doc_generator.py:62) — so a docs build **intentionally** never boots the guest and never writes `.ran` or `verifier.xml`.

A recently-added `assert_penguin_run_succeeded()` (checks `.ran` + `verifier.xml`) is called after **every** `run_test()`, including the docs-only run, so the docs build can never pass it. The earlier pdflatex `U+0090` crash masked this (it died before `os._exit`); once #825 made the docs build succeed, the bad assertion surfaced.

Confirmed via history: the last green release (`07402357`) predates `assert_penguin_run_succeeded()`, and `os._exit(0)` was already present then — i.e. this is a test-harness bug, independent of the config-reshape PRs.

## Fix

- Gate `assert_penguin_run_succeeded()` to non-docs runs.
- Add `assert_docs_built()` for `--docs-only` runs: asserts the Sphinx HTML (`index.html`) and a PDF were produced. This keeps a meaningful regression guard — a broken docs/PDF build (like the `U+0090` one) would still fail here.

`flake8` clean; file parses.