### PR TITLE
qemu_compat: size target_long/target_ulong to guest word size

### DIFF
--- a/pyplugins/compat/qemu_compat.py
+++ b/pyplugins/compat/qemu_compat.py
@@ -17,8 +17,6 @@ SHUTDOWN_CAUSE_HOST_QMP_QUIT = 2
 
 MINIMAL_CDEF = """
 typedef _Bool bool;
-typedef int64_t target_long;
-typedef uint64_t target_ulong;
 typedef uint64_t vaddr;
 typedef struct CPUState CPUState;
 typedef struct MachineState MachineState;
@@ -371,9 +369,16 @@ class QemuCompat:
         )
         self.ffi = cffi.FFI()
         cdef_source = self.header_path.read_text() if self.header_path else MINIMAL_CDEF
+        # target_long/target_ulong must match the *guest* word size so that
+        # ffi.cast("target_long", x) sign-extends correctly (e.g. a 32-bit
+        # guest's 0xFFFFFFFF fd argument casts to -1). PANDA sized these per
+        # guest arch; hard-coding int64_t silently broke negative-value /
+        # `== -1` checks on 32-bit targets (see rv130 libc_addr regression).
+        target_long_t = "int64_t" if self.bits == 64 else "int32_t"
+        target_ulong_t = "uint64_t" if self.bits == 64 else "uint32_t"
         for declaration in (
-            "typedef int64_t target_long;",
-            "typedef uint64_t target_ulong;",
+            f"typedef {target_long_t} target_long;",
+            f"typedef {target_ulong_t} target_ulong;",
             "int main(int argc, char **argv);",
             "void bql_lock_impl(const char *file, int line);",
             "bool bql_locked(void);",


### PR DESCRIPTION
## Summary

Fixes a PANDA→QEMU migration regression on **32-bit guests**.

`pyplugins/compat/qemu_compat.py` hard-coded the cffi typedefs:
```c
typedef int64_t  target_long;
typedef uint64_t target_ulong;
```
regardless of guest architecture. Under PANDA these matched the guest word size, so on a 32-bit guest `ffi.cast("target_long", 0xFFFFFFFF)` evaluated to `-1`. With `int64_t` it stays `4294967295`, silently breaking **every signed / negative-value check on 32-bit guests**, e.g.:
- `fd == -1` anonymous-mmap detection,
- penguin's own `rw_logger.py` (`signed_fd`) and `syscalls_logger.py` (retval) negative-return handling.

## Fix

Size the typedefs from the already-computed `self.bits`: `int32_t`/`uint32_t` for 32-bit guests, `int64_t`/`uint64_t` for 64-bit. These typedefs are **not used in any cffi struct layout** (only for value casts), so narrowing is safe for memory reads. Also dropped the hard-coded int64 typedefs from `MINIMAL_CDEF` so the dynamic injection doesn't produce a duplicate typedef.

## How it was found

Mining the `rehosting/rehostings` nightly regression CI: **cisco/rv130 `libc_mapping`** had been failing every weeknight since **2026-05-18** (12/13 tests passing — only this one red). That test forces libc's reservation mmap to `0x357fb000` via a `sys_mmap_pgoff` arg rewrite guarded by `if fd == -1`; the guard stopped matching after the migration. The regression boundary (last-good penguin `b946b8c` → first-bad `a3518da`) is exactly where QEMU 0.0.2 replaced PANDA.

## Verification

Built the image against `penguin:latest`, mounted this patched file, ran `penguin repro`:
- before: `libc_mapping_httpd.txt` = `0xb6cf2000` (kernel default), `libc_mapping` ❌
- after:  `libc_mapping_httpd.txt` = `0x357fb000` (forced), verifier `failures=0 tests=13` ✅

No cffi/typedef build errors across the armel guest.