### PR TITLE
portal: bound pseudofile installs per interrupt window

### DIFF
--- a/pyplugins/hyper/portal.py
+++ b/pyplugins/hyper/portal.py
@@ -51,6 +51,12 @@ kffi = plugins.kffi
 # Global singleton for a no-operation command
 _NONE_CMD = None
 
+# Max pseudofile installs (devfs/procfs/sysctl/sysfs) dispatched across all
+# plugins in a single portal interrupt window. Kept comfortably below the point
+# where the install burst corrupts guest kernel memory (empirically ~50+ at
+# once breaks MIPS targets like fwr8102; this leaves wide margin).
+PORTAL_INSTALL_BUDGET_PER_WINDOW = 32
+
 
 class PortalCmd:
     """
@@ -180,6 +186,16 @@ class Portal(Plugin):
         # Generic interrupts mechanism
         self._interrupt_handlers = {}  # plugin_name -> handler_function
         self._pending_interrupts = set()  # Set of plugin names with pending work
+
+        # Global per-interrupt-window budget for pseudofile installs. Draining
+        # every plugin's full pending list in one window floods the portal's
+        # shared-memory path during early boot (e.g. fwr8102 installs 100+
+        # /dev,/proc nodes at once), which corrupts kernel memory on some
+        # targets (MIPS do_ade). Install handlers consult take_install_budget()
+        # and re-queue their remainder so the combined installs per window stay
+        # bounded and the guest runs between batches.
+        self._install_budget_max = PORTAL_INSTALL_BUDGET_PER_WINDOW
+        self._install_budget = self._install_budget_max
         plugins.hypercall.hypercall(iconsts.IGLOO_HYPER_REGISTER_MEM_REGION)(
             self._register_cpu_memregion)
         plugins.hypercall.hypercall(iconsts.IGLOO_HYPER_ENABLE_PORTAL_INTERRUPT)(
@@ -215,6 +231,9 @@ class Portal(Plugin):
         interrupts = self._pending_interrupts.copy()
         self._pending_interrupts.clear()
         self._portal_clear_interrupt()
+        # Refill the per-window install budget. Install handlers decrement it
+        # via take_install_budget() and re-queue their remainder if it runs out.
+        self._install_budget = self._install_budget_max
         for plugin_name in list(interrupts):
             if plugin_name in self._interrupt_handlers:
                 handler_fn = self._interrupt_handlers[plugin_name]
@@ -242,6 +261,20 @@ class Portal(Plugin):
         if plugin_name in self._pending_interrupts:
             self.logger.debug(
                 f"Plugin {plugin_name} already had pending interrupts")
+
+    def take_install_budget(self) -> bool:
+        """
+        Consume one unit of the per-interrupt-window pseudofile-install budget.
+
+        Returns True if budget remained (and one unit was consumed), False if
+        the window's budget is exhausted. Install interrupt handlers should call
+        this before each install and, when it returns False, stop and re-queue
+        their interrupt so the remainder is processed in a later window.
+        """
+        if self._install_budget <= 0:
+            return False
+        self._install_budget -= 1
+        return True
 
     def queue_interrupt(self, plugin_name: str) -> bool:
         """

--- a/pyplugins/hyperfile/devfs.py
+++ b/pyplugins/hyperfile/devfs.py
@@ -245,9 +245,12 @@ class Devfs(Plugin):
         if not self._pending_devfs:
             return False
 
-        pending = self._pending_devfs[:]
-        self._pending_devfs.clear()
-        while pending:
-            devfs = pending.pop(0)
+        # Honor the portal's per-window install budget so a large batch of
+        # device installs is spread across interrupt windows instead of
+        # flooding the portal in one go (see portal.take_install_budget).
+        while self._pending_devfs and plugins.portal.take_install_budget():
+            devfs = self._pending_devfs.pop(0)
             yield from self._register_devfs([devfs])
+        if self._pending_devfs:
+            plugins.portal.queue_interrupt("devfs")
         return False

--- a/pyplugins/hyperfile/procfs.py
+++ b/pyplugins/hyperfile/procfs.py
@@ -238,9 +238,10 @@ class Proc(Plugin):
         if not self._pending_procs:
             return False
 
-        pending = self._pending_procs[:]
-        while pending:
-            proc = pending.pop(0)
+        # Honor the portal's per-window install budget (see portal docstring).
+        while self._pending_procs and plugins.portal.take_install_budget():
+            proc = self._pending_procs.pop(0)
             yield from self._register_procs([proc])
-            self._pending_procs.remove(proc)
+        if self._pending_procs:
+            plugins.portal.queue_interrupt("procfs")
         return False

--- a/pyplugins/hyperfile/sysctl.py
+++ b/pyplugins/hyperfile/sysctl.py
@@ -166,9 +166,10 @@ class Sysctl(Plugin):
         if not self._pending_sysctls:
             return False
 
-        pending = self._pending_sysctls[:]
-        while pending:
-            sysctl_node = pending.pop(0)
+        # Honor the portal's per-window install budget (see portal docstring).
+        while self._pending_sysctls and plugins.portal.take_install_budget():
+            sysctl_node = self._pending_sysctls.pop(0)
             yield from self._register_sysctls([sysctl_node])
-            self._pending_sysctls.remove(sysctl_node)
+        if self._pending_sysctls:
+            plugins.portal.queue_interrupt("sysctl")
         return False

--- a/pyplugins/hyperfile/sysfs.py
+++ b/pyplugins/hyperfile/sysfs.py
@@ -169,9 +169,10 @@ class Sysfs(Plugin):
         if not self._pending_sysfs:
             return False
 
-        pending = self._pending_sysfs[:]
-        self._pending_sysfs.clear()
-        while pending:
-            sysfs = pending.pop(0)
+        # Honor the portal's per-window install budget (see portal docstring).
+        while self._pending_sysfs and plugins.portal.take_install_budget():
+            sysfs = self._pending_sysfs.pop(0)
             yield from self._register_sysfs([sysfs])
+        if self._pending_sysfs:
+            plugins.portal.queue_interrupt("sysfs")
         return False


### PR DESCRIPTION
## Summary

Fixes an intermittent early-boot crash on targets that model many pseudofiles (surfaced by the rehostings nightly: **flyingvoice/fwr8102**, MIPS).

The pseudofile install interrupt handlers (`devfs`/`procfs`/`sysctl`/`sysfs`) each **drain their entire pending list in one portal interrupt window**, and `portal._portal_interrupt` drains every plugin's queue per window. So the guest's first interrupt check-in fires a burst of 100+ install hypercalls back-to-back through the portal's shared-memory path. On fwr8102 (~105 static `/dev`,`/proc` models) this corrupts guest kernel memory and the kernel dies with an `Unhandled kernel unaligned access` (`do_ade`, garbage task comm/PID) at ~4.6s, before userspace — so **0/9 services** bind and the nightly fails. It's intermittent because the corruption depends on boot timing.

## Root cause (bisected by install count)

Cutting fwr8102's `pseudofiles.dynamic.yaml`:

| pseudofiles installed | result |
|---|---|
| 3 | boots, **9/9 pass** |
| first 52 | boots, **9/9 pass** |
| last 53 | boots, **9/9 pass** |
| all 105 | **crash (4/4)** |

Neither half crashes alone — only the union does. So it's the **volume/rate** of installs flooding the portal, not any single bad entry. (Independently ruled out: the per-device net sysctl mutation, interface presence, and the `target_long` fix in #827.)

## Fix

A global **per-interrupt-window install budget** in the portal:
- `portal._install_budget` is refilled to `PORTAL_INSTALL_BUDGET_PER_WINDOW` (32) at the start of each `_portal_interrupt`.
- Install handlers call `take_install_budget()` before each install; when it returns `False` they stop and `queue_interrupt(...)` to finish in a later window.

This bounds the *combined* installs across all four domains per window and lets the guest run between batches, so the burst never reaches the corrupting threshold. 32 leaves wide margin below the empirical break point (>52 at once).

## Verification

Built fwr8102 against `penguin:latest`, mounted the patched plugins, `penguin repro`:
- **before:** full 105 installs → `do_ade` crash, 0/9 services (4/4 runs).
- **after:** full 105 installs → full boot, **9/9 pass, 12 service binds, 2/2 runs**.

## Note

This is the rate-limiting mitigation. The deeper driver-side fragility (the portal path corrupting under a large burst) is left as a separate follow-up; with installs bounded it is no longer reached in practice.