### PR TITLE
Fix #839: pseudofile from_plugin read/write adapters collide on self._func

### DIFF
--- a/pyplugins/hyperfile/models/read.py
+++ b/pyplugins/hyperfile/models/read.py
@@ -307,11 +307,11 @@ class ReadExternalVFS:
     """
 
     def __init__(self, *, read_plugin: str = None, read_function: str = "read", **kwargs):
-        self._func = getattr(getattr(plugins, read_plugin), read_function)
+        self._read_func = getattr(getattr(plugins, read_plugin), read_function)
         super().__init__(**kwargs)
 
     def read(self, ptregs: PtRegsWrapper, file: FilePtr, user_buf: CharPtr, size: SizeT, loff: LoffTPtr):
-        res = self._func(ptregs, file, user_buf, size, loff)
+        res = self._read_func(ptregs, file, user_buf, size, loff)
         if inspect.isgenerator(res):
             yield from res
 
@@ -323,7 +323,7 @@ class ReadExternalLegacy:
     """
 
     def __init__(self, *, read_plugin: str = None, read_function: str = "read", **kwargs):
-        self._func = getattr(getattr(plugins, read_plugin), read_function)
+        self._read_func = getattr(getattr(plugins, read_plugin), read_function)
         self._legacy_kwargs = kwargs.copy()  # Capture extra args for 'details'
         super().__init__(**kwargs)
 
@@ -336,7 +336,7 @@ class ReadExternalLegacy:
         # self.full_path comes from BaseFile via composition
         filename = getattr(self, "full_path", "unknown")
 
-        res = self._func(self, filename, user_buf, size_val, offset, details=self._legacy_kwargs)
+        res = self._read_func(self, filename, user_buf, size_val, offset, details=self._legacy_kwargs)
 
         if inspect.isgenerator(res):
             val = yield from res

--- a/pyplugins/hyperfile/models/write.py
+++ b/pyplugins/hyperfile/models/write.py
@@ -192,11 +192,11 @@ class WriteExternalVFS:
     """Modern VFS Write Adapter"""
 
     def __init__(self, *, write_plugin: str = None, write_function: str = "write", **kwargs):
-        self._func = getattr(getattr(plugins, write_plugin), write_function)
+        self._write_func = getattr(getattr(plugins, write_plugin), write_function)
         super().__init__(**kwargs)
 
     def write(self, ptregs: PtRegsWrapper, file: FilePtr, user_buf: CharPtr, size: SizeT, loff: LoffTPtr):
-        res = self._func(ptregs, file, user_buf, size, loff)
+        res = self._write_func(ptregs, file, user_buf, size, loff)
         if inspect.isgenerator(res):
             yield from res
 
@@ -205,7 +205,7 @@ class WriteExternalLegacy:
     """Legacy Write Adapter"""
 
     def __init__(self, *, write_plugin: str = None, write_function: str = "write", **kwargs):
-        self._func = getattr(getattr(plugins, write_plugin), write_function)
+        self._write_func = getattr(getattr(plugins, write_plugin), write_function)
         self._legacy_kwargs = kwargs.copy()
         super().__init__(**kwargs)
 
@@ -215,7 +215,7 @@ class WriteExternalLegacy:
         buf = yield from plugins.mem.read(user_buf, size_val, fmt="bytes")
         offset = yield from plugins.kffi.deref(loff)
 
-        res = self._func(self, getattr(self, "full_path", "unknown"), user_buf, size_val, offset, buf, self._legacy_kwargs)
+        res = self._write_func(self, getattr(self, "full_path", "unknown"), user_buf, size_val, offset, buf, self._legacy_kwargs)
 
         if inspect.isgenerator(res):
             result = yield from res

--- a/pyplugins/testing/from_plugin_test.py
+++ b/pyplugins/testing/from_plugin_test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Regression test plugin for issue #839.
+
+A single pseudofile node configured with BOTH a `from_plugin` read and a
+`from_plugin` write must dispatch each operation to the correct handler. The
+bug was that the read/write external adapters shared one `self._func`
+instance attribute, so the read silently invoked the write function.
+
+This plugin exposes distinguishable VFS-style `read`/`write` handlers. The
+signatures contain neither `details`/`filename` (read) nor `buf` (write), so
+`_detect_plugin_style` resolves them to `ReadExternalVFS` / `WriteExternalVFS`
+— exactly the colliding path. The guest does a write-then-read round-trip and
+expects the read handler's marker back; with the bug present, the read is
+misrouted to the write handler (which never fills `user_buf`) and the marker
+is absent.
+"""
+from penguin import plugins, Plugin
+
+# Distinctive payload the read handler returns. If a read is misrouted to the
+# write handler this marker is never written to the user buffer.
+READ_MARKER = b"READ_HANDLER\n"
+
+
+class FromPluginTest(Plugin):
+    def __init__(self):
+        # Bytes most recently seen by the write handler (proves write ran).
+        self._last_write = b""
+
+    def read(self, ptregs, file, user_buf, size, loff):
+        size_val = int(size)
+        offset = yield from plugins.kffi.deref(loff)
+        data = READ_MARKER
+
+        if size_val <= 0 or offset >= len(data):
+            ptregs.retval = 0
+            return
+
+        chunk = min(size_val, len(data) - offset)
+        yield from plugins.mem.write(user_buf, data[offset:offset + chunk])
+        yield from plugins.mem.write(loff, offset + chunk)
+        ptregs.retval = chunk
+
+    def write(self, ptregs, file, user_buf, size, loff):
+        size_val = int(size)
+        # Bypass the smart dispatcher by requesting raw bytes.
+        self._last_write = yield from plugins.mem.read(user_buf, size_val, fmt="bytes")
+        self.logger.info(f"from_plugin_test write handler got {self._last_write!r}")
+        # Deliberately do NOT touch user_buf — so a misrouted read returns nothing.
+        ptregs.retval = size_val

--- a/tests/unit_tests/test_target/base_config.yaml
+++ b/tests/unit_tests/test_target/base_config.yaml
@@ -43,6 +43,7 @@ patches:
   - ./patches/tests/native_mmap.yaml
   - ./patches/tests/pseudofile_readdir.yaml
   - ./patches/tests/pseudofile_sysfs.yaml
+  - ./patches/tests/pseudofile_from_plugin.yaml
   - ./patches/tests/shared_dir.yaml
   # - ./patches/tests/syscall.yaml
   - ./patches/tests/indiv_debug.yaml

--- a/tests/unit_tests/test_target/patches/tests/pseudofile_from_plugin.yaml
+++ b/tests/unit_tests/test_target/patches/tests/pseudofile_from_plugin.yaml
@@ -1,0 +1,51 @@
+plugins:
+  from_plugin_test: {}
+  verifier:
+    conditions:
+      from_plugin_rw+console:
+        type: file_contains
+        file: console.log
+        string: "/tests/pseudofile_from_plugin.sh PASS"
+      from_plugin_rw+stdout:
+        type: file_contains
+        file: shared/tests/pseudofile_from_plugin.sh/stdout
+        string: "pseudofile_from_plugin PASS"
+
+# Regression test for issue #839: a single node with BOTH a from_plugin read
+# and a from_plugin write must dispatch each operation to the correct handler.
+pseudofiles:
+  /dev/from_plugin_rw:
+    read:
+      model: from_plugin
+      plugin: from_plugin_test
+      function: read
+    write:
+      model: from_plugin
+      plugin: from_plugin_test
+      function: write
+
+static_files:
+  /tests/pseudofile_from_plugin.sh:
+    type: inline_file
+    mode: 73
+    contents: |
+      #!/igloo/utils/sh
+      set -ux
+      bb="/igloo/utils/busybox"
+      dev="/dev/from_plugin_rw"
+
+      # Exercise the write handler first (the handler that "won" the shared
+      # attribute before the fix). This must NOT corrupt the read path.
+      $bb printf "PING" > "$dev"
+
+      # Read it back. The read handler returns a distinctive marker. With the
+      # #839 bug the read is misrouted to the write handler, which never fills
+      # the user buffer, so the marker is absent and this check fails.
+      out=$($bb cat "$dev")
+      if [ "$out" != "READ_HANDLER" ]; then
+        echo "Error: read dispatched to wrong handler (got '$out', want 'READ_HANDLER')"
+        exit 1
+      fi
+
+      echo "pseudofile_from_plugin PASS"
+      exit 0


### PR DESCRIPTION
## Summary

Fixes #839. When a pseudofile/device node is configured with **more than one** `from_plugin` model (e.g. both `read` and `write`), the external adapter mixins collide: `ReadExternalVFS`/`ReadExternalLegacy` and `WriteExternalVFS`/`WriteExternalLegacy` each stored their resolved plugin callback in the **same** instance attribute `self._func`.

These adapters are mixed into one dynamically-built device class (`_create_dynamic_class`, `pyplugins/hyperfile/pseudofiles.py`) and their `__init__`s run cooperatively via `super()`, so the **last one in the MRO wins** and overwrites `self._func`. As a result a `from_plugin` **read** silently dispatched to the **write** handler.

## Fix

Give the read and write adapters domain-specific attribute names so they no longer clobber each other:

- `ReadExternalVFS` / `ReadExternalLegacy` → `self._read_func`
- `WriteExternalVFS` / `WriteExternalLegacy` → `self._write_func`

Minimal, host-side change — no driver/image change required.

Scope note: `from_plugin` **ioctl** does not go through the MRO (it uses separate `IoctlPluginVFS`/`IoctlPluginLegacy` handler objects in `handlers_map`), and `WriteFromPlugin` is never returned by `_resolve_mixin`, so neither is part of the collision and both are intentionally left unchanged.

## Regression test (runs in CI)

`from_plugin` previously had **zero** test coverage. Added a test that runs in the `test_target` CI suite across all arches/kernels:

- `pyplugins/testing/from_plugin_test.py` — a test pyplugin with distinguishable VFS-style `read`/`write` handlers (the read writes a `READ_HANDLER` marker; the write never touches `user_buf`).
- `tests/unit_tests/test_target/patches/tests/pseudofile_from_plugin.yaml` — configures `/dev/from_plugin_rw` with both `from_plugin` read and write, and a guest write-then-read round-trip asserting the read returns the read handler's marker. With the bug present the read is misrouted to the write handler and the marker is absent → test fails.
- Registered the patch in `base_config.yaml`.