### PR TITLE
feat(snapshot): VM savevm/loadvm snapshot support

### DIFF
--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -182,6 +182,103 @@ lighttpd: 9999
 |__Default__|`null`|
 
 
+### `core.snapshot` Snapshot configuration
+
+|||
+|-|-|
+|__Default__|`null`|
+
+VM snapshot (savevm/loadvm) configuration.
+
+    Snapshotting is *active* whenever ``save_at`` or ``boot_from`` is set — there
+    is no separate enable flag. When active, the guest runs on a persistent
+    qcow2 overlay (rather than the throwaway immutable overlay) so an internal VM
+    snapshot can be saved and later restored. Saving a snapshot at a chosen point
+    lets a later run boot directly from that state instead of re-booting the
+    firmware.
+    
+
+#### `core.snapshot.backend` Snapshot backend
+
+|||
+|-|-|
+|__Type__|`"internal"` or `"file"`|
+|__Default__|`internal`|
+
+'internal' stores the snapshot inside the qcow2 overlay (savevm/loadvm). 'file' (not yet implemented) writes a standalone migration file bundle.
+
+```yaml
+internal
+```
+
+```yaml
+file
+```
+
+#### `core.snapshot.tag` Snapshot tag
+
+|||
+|-|-|
+|__Type__|string|
+|__Default__|`boot`|
+
+Name of the internal VM snapshot to save and/or restore.
+
+```yaml
+boot
+```
+
+```yaml
+post_init
+```
+
+#### `core.snapshot.save_at` When to save the snapshot
+
+|||
+|-|-|
+|__Type__|`"readiness"` or `"manual"` or null|
+|__Default__|`null`|
+
+'readiness' saves once the guest reaches steady state; 'manual' arms the Snapshot plugin to save on request (via guest_cmd / hypercall). None disables saving.
+
+```yaml
+readiness
+```
+
+```yaml
+manual
+```
+
+#### `core.snapshot.boot_from` Snapshot tag to boot from
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+If set, restore this internal snapshot at startup (-loadvm).
+
+```yaml
+boot
+```
+
+#### `core.snapshot.stop_after_save` End the run after saving
+
+|||
+|-|-|
+|__Type__|boolean|
+|__Default__|`false`|
+
+Shut the guest down immediately after the snapshot is saved.
+
+```yaml
+false
+```
+
+```yaml
+true
+```
+
 ### `core.force_www` Try to force webserver start
 
 |||

--- a/pengutils/pengutils/utils/cli_snapshot.py
+++ b/pengutils/pengutils/utils/cli_snapshot.py
@@ -1,0 +1,100 @@
+"""
+Snapshot CLI
+============
+
+Host-driven VM snapshotting via the Penguin RemoteCtrl Plugin Unix socket.
+Requests are *armed* at a safe execution boundary (default: the next syscall
+return) rather than captured at the instant the command is received.
+
+Example usage
+-------------
+
+.. code-block:: bash
+
+    # Save at the next syscall boundary (default), tag "warm"
+    cli_snapshot.py save --tag warm
+
+    # Save at the next syscall boundary in a specific process
+    cli_snapshot.py save --tag warm --proc lighttpd
+
+    # Save when execution reaches a symbol
+    cli_snapshot.py save --tag warm --when symbol --symbol main --proc lighttpd
+
+    # Save immediately (next main-loop tick)
+    cli_snapshot.py save --tag warm --when now
+
+    # Restore a snapshot into the running guest
+    cli_snapshot.py load --tag warm
+
+Options
+-------
+- ``--sock``: Path to plugin socket (default: results/latest/remotectrl.sock)
+"""
+
+import click
+from rich import print
+from pengutils.utils.util_events import get_default_socket_path, send_command
+
+
+def _send(ctx, sock, cmd):
+    if not sock:
+        sock = get_default_socket_path()
+    try:
+        resp = send_command(cmd, sock=sock)
+        if not resp:
+            print(f"[red]No response from socket {sock}[/red]")
+            ctx.exit(1)
+        if resp.get("status") == "success":
+            print(f"[green]{resp.get('message', 'OK')}[/green]")
+            ctx.exit(0)
+        print(f"[red]Failed: {resp.get('message')}[/red]")
+        ctx.exit(1)
+    except click.exceptions.Exit:
+        raise
+    except Exception as e:
+        print(f"[red]{e}[/red]")
+        print("[red]Is the remotectrl plugin loaded and snapshot configured?[/red]")
+        ctx.exit(1)
+
+
+@click.group(name="snapshot")
+def snapshot_cli():
+    """VM snapshot save/restore commands."""
+    pass
+
+
+@snapshot_cli.command()
+@click.option("--sock", default=None, help="Path to plugin socket (default: results/latest/remotectrl.sock)")
+@click.option("--tag", default=None, help="Snapshot tag (defaults to the configured core.snapshot.tag)")
+@click.option("--when", default="next_syscall",
+              type=click.Choice(["next_syscall", "symbol", "now"]),
+              help="When to actually capture (default: next_syscall)")
+@click.option("--proc", default=None, help="Process-name filter for the boundary")
+@click.option("--symbol", default=None, help="Symbol to capture at (when --when symbol)")
+@click.pass_context
+def save(ctx, sock, tag, when, proc, symbol):
+    """Arm a savevm at a safe execution boundary."""
+    cmd = {"type": "snapshot", "action": "save", "when": when}
+    if tag:
+        cmd["tag"] = tag
+    if proc:
+        cmd["proc"] = proc
+    if symbol:
+        cmd["symbol"] = symbol
+    _send(ctx, sock, cmd)
+
+
+@snapshot_cli.command()
+@click.option("--sock", default=None, help="Path to plugin socket (default: results/latest/remotectrl.sock)")
+@click.option("--tag", default=None, help="Snapshot tag to restore (defaults to the configured core.snapshot.tag)")
+@click.pass_context
+def load(ctx, sock, tag):
+    """Restore a snapshot into the running guest (loadvm)."""
+    cmd = {"type": "snapshot", "action": "load"}
+    if tag:
+        cmd["tag"] = tag
+    _send(ctx, sock, cmd)
+
+
+if __name__ == "__main__":
+    snapshot_cli()

--- a/pengutils/setup.cfg
+++ b/pengutils/setup.cfg
@@ -36,3 +36,4 @@ console_scripts =
     guest_cmd = pengutils.utils.cli_guest_cmd:guest_cmd
     db = pengutils.utils.cli_db:db_cli
     plugins = pengutils.utils.cli_plugins:plugins
+    snapshot = pengutils.utils.cli_snapshot:snapshot_cli

--- a/pyplugins/actuation/vpn.py
+++ b/pyplugins/actuation/vpn.py
@@ -147,6 +147,11 @@ class VPN(Plugin):
         self.wild_ips = set()  # (sock_type, port, procname) tuples
         self.mapped_ports = set()  # Ports we've mapped
         self.active_listeners = set()  # (proto, port)
+        # (sock_type, ip, guest_port) -> {procname, ipvn, host_port}; recorded so
+        # bridges can be re-established on the same host ports after a snapshot
+        # restore (the restored guest is already past its binds).
+        self.bridges_made = {}
+        self._restore_data = None
 
         # Check if we have CONTAINER_{IP,NAME} in env
         self.exposed_ip = env.get("CONTAINER_IP", "127.0.0.1")
@@ -303,6 +308,60 @@ class VPN(Plugin):
         host_port = self.bridge(sock_type, ip, port, procname, ipvn)
         plugins.publish(self, "on_bind", sock_type, ip, port, host_port, self.exposed_ip, procname)
 
+    def save_state(self):
+        """Capture the active bridges (and IP-discovery state) so they can be
+        re-established on the same host ports after a snapshot restore."""
+        return {
+            "bridges": [
+                {"sock_type": k[0], "ip": k[1], "guest_port": k[2],
+                 "procname": v["procname"], "ipvn": v["ipvn"],
+                 "host_port": v["host_port"]}
+                for k, v in self.bridges_made.items()
+            ],
+            "seen_ips": sorted(self.seen_ips),
+            "wild_ips": [list(w) for w in self.wild_ips],
+        }
+
+    def load_state(self, data) -> None:
+        """Stash bridge state captured at snapshot time; replayed in on_restore."""
+        self._restore_data = data or None
+
+    def on_restore(self, tag: str) -> None:
+        """Re-establish bridges after a snapshot restore.
+
+        The restored guest is already past its binds, so NetBinds won't re-emit
+        on_bind events. We replay the recorded bridges, pinning each to the same
+        host port via fixed_maps so host-side URLs stay stable across restore.
+        Live connections are not (and cannot be) replayed.
+        """
+        data = self._restore_data
+        if not data:
+            return
+        self.seen_ips.update(data.get("seen_ips", []))
+        for w in data.get("wild_ips", []):
+            self.wild_ips.add(tuple(w))
+        bridges = data.get("bridges", [])
+        self.logger.info("Re-establishing %d VPN bridge(s) after restore of '%s'",
+                         len(bridges), tag)
+        for b in bridges:
+            key = (b["sock_type"], b["ip"], b["guest_port"])
+            # Pin the same host port so URLs are stable across restore.
+            self.fixed_maps[key] = b["host_port"]
+            self.active_listeners.add(key)
+            try:
+                host_port = self.bridge(b["sock_type"], b["ip"], b["guest_port"],
+                                        b["procname"], b["ipvn"])
+            except Exception as e:
+                self.logger.warning("failed to re-establish bridge %s: %s", key, e)
+                continue
+            # Re-notify downstream consumers (e.g. service probes/automation)
+            # that the bridged service is available again. The restored guest is
+            # past its binds so NetBinds won't re-emit on_bind; replaying it here
+            # keeps on_bind subscribers symmetric across a snapshot restore.
+            plugins.publish(self, "on_bind", b["sock_type"], b["ip"],
+                            b["guest_port"], host_port, self.exposed_ip,
+                            b["procname"])
+
     def map_bound_socket(self, sock_type: str, ip: str, guest_port: int, procname: str) -> int:
         """
         Map a guest socket to a host port, handling privileged ports and collisions.
@@ -420,6 +479,9 @@ class VPN(Plugin):
         with self.port_map_lock:
             host_port = self.map_bound_socket(sock_type, ip, guest_port, procname)
             self.mapped_ports.add(host_port)
+            self.bridges_made[(sock_type, ip, guest_port)] = {
+                "procname": procname, "ipvn": ipvn, "host_port": host_port,
+            }
 
         # Set up the event for the host vpn in the background - lets us run commands in the guest if we'd like
         threading.Thread(

--- a/pyplugins/compat/qemu_compat.py
+++ b/pyplugins/compat/qemu_compat.py
@@ -549,6 +549,9 @@ class QemuCompat:
             "void penguin_unregister_guest_hypercall(uint64_t nr);",
             "void penguin_clear_guest_hypercalls(void);",
             "bool penguin_guest_hypercall_registered(uint64_t nr);",
+            "bool penguin_save_snapshot(const char *name);",
+            "bool penguin_load_snapshot(const char *name);",
+            "void penguin_schedule_snapshot(const char *name, bool load);",
         ):
             if declaration not in cdef_source:
                 cdef_source += f"\n{declaration}\n"
@@ -1088,6 +1091,68 @@ class QemuCompat:
         if err < 0:
             raise ValueError(f"Memory write failed at {addr:#x}")
         return len(view)
+
+    def save_snapshot(self, name: str) -> bool:
+        """Save an internal VM snapshot named ``name`` (savevm).
+
+        Wraps the fork's penguin_save_snapshot(). The underlying
+        save_snapshot() stops the VM, serialises device + RAM state into the
+        active block device's internal-snapshot store, and resumes. Must be
+        invoked from the main loop context (e.g. a readiness/event callback,
+        not a vCPU-thread hypercall handler) to avoid contending with the
+        snapshot's own main-loop pumping; the BQL is taken here if needed.
+        Returns True on success.
+        """
+        fn = self._lib_symbol("penguin_save_snapshot")
+        if fn is None:
+            logger.warning(
+                "QEMU library does not expose penguin_save_snapshot; "
+                "snapshot support requires a rebuilt pandare deb")
+            return False
+        cname = self.ffi.new("char[]", name.encode("utf-8"))
+        ok = bool(self._call_with_bql(lambda: fn(cname)))
+        if not ok:
+            logger.error("savevm '%s' failed (see QEMU stderr)", name)
+        return ok
+
+    def load_snapshot(self, name: str) -> bool:
+        """Restore an internal VM snapshot named ``name`` (loadvm).
+
+        Wraps the fork's penguin_load_snapshot(), which stops the VM, restores
+        device + RAM state, and restores the prior runstate. Same calling-context
+        rules as :meth:`save_snapshot`. Returns True on success.
+        """
+        fn = self._lib_symbol("penguin_load_snapshot")
+        if fn is None:
+            logger.warning(
+                "QEMU library does not expose penguin_load_snapshot; "
+                "snapshot support requires a rebuilt pandare deb")
+            return False
+        cname = self.ffi.new("char[]", name.encode("utf-8"))
+        ok = bool(self._call_with_bql(lambda: fn(cname)))
+        if not ok:
+            logger.error("loadvm '%s' failed (see QEMU stderr)", name)
+        return ok
+
+    def schedule_snapshot(self, name: str, load: bool = False) -> bool:
+        """Schedule a savevm (load=False) or loadvm (load=True) on the main loop.
+
+        Fire-and-forget and safe to call from a vCPU-thread callback (e.g. a
+        guest hypercall / readiness handler): the snapshot runs in the main
+        loop context where it can stop the vCPUs without deadlocking. Prefer
+        this over :meth:`save_snapshot`/:meth:`load_snapshot` from such
+        callbacks. Returns True if the request was successfully scheduled (not
+        whether the snapshot itself succeeded — that is logged to QEMU stderr).
+        """
+        fn = self._lib_symbol("penguin_schedule_snapshot")
+        if fn is None:
+            logger.warning(
+                "QEMU library does not expose penguin_schedule_snapshot; "
+                "snapshot support requires a rebuilt pandare deb")
+            return False
+        cname = self.ffi.new("char[]", name.encode("utf-8"))
+        self._call_with_bql(lambda: fn(cname, bool(load)))
+        return True
 
     def end_analysis(self):
         if hasattr(self.lib, "qemu_system_shutdown_request"):

--- a/pyplugins/core/core.py
+++ b/pyplugins/core/core.py
@@ -168,9 +168,12 @@ class Core(Plugin):
         with open(os.path.join(self.outdir, "core_plugins.yaml"), "w") as f:
             f.write(yaml.dump(plugs))  # Names and args
 
-        # Record config in outdir:
+        # Record config in outdir, rendered like dump_config (octal modes, hex
+        # addresses); read back with CoreLoader (see manager.py).
         with open(os.path.join(self.outdir, "core_config.yaml"), "w") as f:
-            f.write(yaml.dump(self.get_arg("conf").args))
+            f.write(yaml.dump(common.style_config_for_dump(self.get_arg("conf").args),
+                              sort_keys=False, default_flow_style=False, width=None,
+                              Dumper=common.CoreDumper))
 
         signal.signal(signal.SIGUSR1, self.graceful_shutdown)
 
@@ -275,9 +278,12 @@ class Core(Plugin):
         with open(os.path.join(self.outdir, "core_plugins.yaml"), "w") as f:
             f.write(yaml.dump(plugins))  # Names and args
 
-        # Record config in outdir:
+        # Record config in outdir, rendered like dump_config (octal modes, hex
+        # addresses); read back with CoreLoader (see manager.py).
         with open(os.path.join(self.outdir, "core_config.yaml"), "w") as f:
-            f.write(yaml.dump(self.get_arg("conf").args))
+            f.write(yaml.dump(common.style_config_for_dump(self.get_arg("conf").args),
+                              sort_keys=False, default_flow_style=False, width=None,
+                              Dumper=common.CoreDumper))
 
         if hasattr(self, "shutdown_event") and not self.shutdown_event.is_set():
             # Tell the shutdown thread to exit if it was started

--- a/pyplugins/core/readiness.py
+++ b/pyplugins/core/readiness.py
@@ -10,6 +10,10 @@ class Readiness(Plugin):
         self.init_seen = False
         self.netbind_seen = False
 
+        # Broadcast a steady-state signal other plugins can observe (the raw
+        # send_hypercall "readiness" event is single-subscriber and owned here).
+        plugins.register(self, "ready")
+
         plugins.send_hypercall.subscribe("readiness", self.on_readiness)
         plugins.subscribe(plugins.NetBinds, "on_bind", self.on_netbind)
 
@@ -27,6 +31,7 @@ class Readiness(Plugin):
 
         self.init_seen = True
         self._write_marker("igloo_init.ready", value + "\n")
+        plugins.publish(self, "ready", "igloo_init")
 
         guest = self._guest_ip()
         port = self.get_arg("telnet_port") or 23
@@ -40,3 +45,4 @@ class Readiness(Plugin):
             return
         self.netbind_seen = True
         self._write_marker("netbind.ready", f"{procname},{ipvn},{sock_type},{ip},{port}\n")
+        plugins.publish(self, "ready", "netbind")

--- a/pyplugins/core/snapshot.py
+++ b/pyplugins/core/snapshot.py
@@ -56,8 +56,9 @@ class Snapshot(Plugin):
         # there is no separate enable flag.
         self.enabled = (self.save_at is not None) or (self.boot_from is not None)
         self.saved = False
-        # Live one-shot arming handles, so we can guard against double-fire.
-        self._armed = []
+        # The single in-flight armed save (one safe-spot at a time), so we can
+        # guard against a double-fire.
+        self._pending = None
 
         # Lifecycle events for host-side reconciliation around save/restore.
         plugins.register(self, "on_snapshot")
@@ -132,12 +133,12 @@ class Snapshot(Plugin):
         if when == "now":
             return self._do_save_now(tag)
         if when == "next_syscall":
-            return self._arm(tag, self._register_syscall_boundary, proc)
+            return self._arm(tag, "syscall", proc)
         if when == "symbol":
             if not symbol:
                 self.logger.error("snapshot when='symbol' needs a symbol")
                 return False
-            return self._arm(tag, self._register_symbol_boundary, proc, symbol)
+            return self._arm(tag, "symbol", proc, symbol)
         self.logger.error("Unknown snapshot 'when': %s", when)
         return False
 
@@ -152,40 +153,54 @@ class Snapshot(Plugin):
 
     # --- safe-spot arming ---------------------------------------------------
 
-    def _arm(self, tag, register_fn, proc, symbol=None) -> bool:
-        """Register a one-shot boundary hook that fires the save exactly once."""
-        state = {"fired": False, "handle": None, "unregister": None}
+    def _arm(self, tag, kind, proc, symbol=None) -> bool:
+        """Register a one-shot boundary hook that fires the save exactly once.
 
-        def fire(*_args, **_kwargs):
-            if state["fired"]:
-                return
-            state["fired"] = True
-            try:
-                if state["unregister"] and state["handle"] is not None:
-                    state["unregister"](state["handle"])
-            except Exception as e:
-                self.logger.debug("snapshot hook unregister failed: %s", e)
-            self._do_save_now(tag)
-
+        The hook callback MUST be a bound method (``self._on_boundary``), not a
+        closure: the syscalls/uprobes APIs re-resolve callbacks by
+        ``__qualname__`` (``Class.method`` -> ``getattr(plugins, Class).method``)
+        on each event, so a nested closure would be misdetected as a method that
+        doesn't exist on the instance. Only one save is armed at a time.
+        """
+        if self._pending and not self._pending.get("fired"):
+            self.logger.warning("A snapshot is already armed; replacing it")
+            self._disarm()
+        state = {"tag": tag, "fired": False, "handle": None, "unregister": None}
         try:
-            state["handle"], state["unregister"] = register_fn(fire, proc, symbol)
+            if kind == "syscall":
+                state["handle"] = plugins.syscalls.syscall(
+                    "on_all_sys_return", comm_filter=proc)(self._on_boundary)
+                state["unregister"] = plugins.syscalls.unregister
+            else:  # symbol
+                state["handle"] = plugins.uprobes.uprobe(
+                    symbol=symbol, process_filter=proc)(self._on_boundary)
+                state["unregister"] = plugins.uprobes.unregister
         except Exception as e:
             self.logger.error("Failed to arm snapshot boundary: %s", e)
             return False
-        self._armed.append(state)
+        self._pending = state
         where = symbol or (f"proc {proc}" if proc else "any process")
-        self.logger.info("Armed snapshot '%s' at %s (%s)", tag,
-                         register_fn.__name__.replace("_register_", "").replace("_boundary", ""),
-                         where)
+        self.logger.info("Armed snapshot '%s' at %s (%s)", tag, kind, where)
         return True
 
-    def _register_syscall_boundary(self, cb, proc, _symbol):
-        handle = plugins.syscalls.syscall("on_all_sys_return", comm_filter=proc)(cb)
-        return handle, plugins.syscalls.unregister
+    def _on_boundary(self, *_args, **_kwargs):
+        """One-shot boundary callback (bound method — see _arm)."""
+        state = self._pending
+        if not state or state.get("fired"):
+            return
+        state["fired"] = True
+        self._disarm()
+        self._do_save_now(state["tag"])
 
-    def _register_symbol_boundary(self, cb, proc, symbol):
-        handle = plugins.uprobes.uprobe(symbol=symbol, process_filter=proc)(cb)
-        return handle, plugins.uprobes.unregister
+    def _disarm(self) -> None:
+        state = self._pending
+        if not state:
+            return
+        try:
+            if state.get("unregister") and state.get("handle") is not None:
+                state["unregister"](state["handle"])
+        except Exception as e:
+            self.logger.debug("snapshot hook unregister failed: %s", e)
 
     # --- actions ------------------------------------------------------------
 

--- a/pyplugins/core/snapshot.py
+++ b/pyplugins/core/snapshot.py
@@ -1,0 +1,272 @@
+"""
+Snapshot Plugin (snapshot.py) for Penguin
+==========================================
+
+Saves and restores VM snapshots (QEMU savevm/loadvm). Driven by the
+``core.snapshot`` config section (snapshotting is active whenever ``save_at`` or
+``boot_from`` is set — there is no separate enable flag):
+
+- ``save_at: readiness``: save once the guest reaches steady state.
+- ``save_at: manual``: save/restore on request — from inside the guest via the
+  ``snapshot_save`` / ``snapshot_load`` hypercalls, or from the host via the
+  RemoteCtrl socket (see ``cli_snapshot``).
+- ``boot_from``: the run was already restored at boot via ``-loadvm``; this
+  plugin announces the restore so host-side plugins can rehydrate.
+
+All save requests funnel into :meth:`request_save`, which *arms* the capture at a
+chosen execution boundary ("find a safe spot") rather than snapping at the
+request instant:
+
+- ``when="next_syscall"`` (default for host-driven requests): capture at the next
+  syscall return (optionally filtered to a process) — a clean userspace/kernel
+  boundary.
+- ``when="symbol"``: capture when execution reaches a symbol (one-shot uprobe).
+- ``when="now"``: capture immediately (used by the in-guest triggers, which are
+  already at a hypercall boundary).
+
+The actual save/restore is always handed to ``KVMQemu.schedule_snapshot`` (a
+main-loop bottom half), so it is safe to request from a vCPU-thread callback.
+
+Other plugins that hold host-side state (e.g. the VPN bridge) reconcile by
+subscribing to this plugin's ``on_snapshot`` / ``on_restore`` events.
+"""
+
+import json
+import os
+from datetime import datetime
+from os.path import join
+
+import yaml
+
+from penguin import Plugin, plugins
+
+
+class Snapshot(Plugin):
+    def __init__(self) -> None:
+        self.outdir = self.get_arg("outdir")
+        self.proj_dir = self.get_arg("proj_dir")
+        conf = self.get_arg("conf")
+        snap = (conf["core"].get("snapshot") if conf else None) or {}
+
+        self.tag = snap.get("tag", "boot")
+        self.save_at = snap.get("save_at")
+        self.boot_from = snap.get("boot_from")
+        self.stop_after_save = bool(snap.get("stop_after_save"))
+        # Snapshotting is active whenever a save or restore is configured;
+        # there is no separate enable flag.
+        self.enabled = (self.save_at is not None) or (self.boot_from is not None)
+        self.saved = False
+        # Live one-shot arming handles, so we can guard against double-fire.
+        self._armed = []
+
+        # Lifecycle events for host-side reconciliation around save/restore.
+        plugins.register(self, "on_snapshot")
+        plugins.register(self, "on_restore")
+
+        if not self.enabled:
+            self.logger.debug("core.snapshot not enabled; plugin idle")
+            return
+
+        if self.save_at == "readiness":
+            # Observe the Readiness plugin's broadcast (don't steal the
+            # single-subscriber send_hypercall "readiness" event).
+            plugins.subscribe(plugins.Readiness, "ready", self.on_ready)
+
+        # Manual triggers from inside the guest (no-op unless the guest issues
+        # them). Registered regardless of save_at so a user can always poke a
+        # save/restore via guest_cmd.
+        plugins.send_hypercall.subscribe("snapshot_save", self.on_guest_save)
+        plugins.send_hypercall.subscribe("snapshot_load", self.on_guest_load)
+
+        if self.boot_from:
+            # The VM was already restored at boot via -loadvm. Defer host-side
+            # rehydration until ALL plugins have loaded (some load after us):
+            # penguin_run calls dispatch_restore() right after load_plugins,
+            # before the guest resumes.
+            self.logger.info("Run booted from snapshot '%s'", self.boot_from)
+
+    def dispatch_restore(self) -> None:
+        """Rehydrate host-side state for a boot_from restore.
+
+        Called by penguin_run after all plugins are loaded and before the guest
+        resumes. Loads the snapshot's host sidecar into each plugin's
+        load_state, then fires on_restore so plugins can re-establish bridges /
+        replay bindings.
+        """
+        if not self.boot_from:
+            return
+        self._restore_host_state(self.boot_from)
+        self._dispatch_lifecycle("on_restore", self.boot_from)
+        plugins.publish(self, "on_restore", self.boot_from)
+
+    # --- triggers -----------------------------------------------------------
+
+    def on_ready(self, kind: str = "igloo_init"):
+        # Readiness IS the chosen point; capture at the next main-loop tick.
+        if kind == "igloo_init" and not self.saved:
+            self.request_save(self.tag, when="now")
+
+    def on_guest_save(self, tag: str = "", when: str = "now", proc: str = ""):
+        # The guest explicitly asked, from a hypercall boundary.
+        ok = self.request_save(tag or self.tag, when=when or "now",
+                               proc=proc or None)
+        return (0 if ok else 1), ("snapshot armed" if ok else "not armed")
+
+    def on_guest_load(self, tag: str = ""):
+        ok = self.request_restore(tag or self.tag)
+        return (0 if ok else 1), ("restore scheduled" if ok else "not scheduled")
+
+    # --- public API ---------------------------------------------------------
+
+    def request_save(self, tag=None, when="next_syscall", proc=None,
+                     symbol=None) -> bool:
+        """Arm a savevm at a safe execution boundary.
+
+        :param tag: snapshot name (defaults to the configured tag).
+        :param when: ``next_syscall`` | ``symbol`` | ``now``.
+        :param proc: optional process-name filter for the boundary.
+        :param symbol: required when ``when='symbol'``.
+        :return: True if the capture was scheduled/armed.
+        """
+        tag = tag or self.tag
+        if when == "now":
+            return self._do_save_now(tag)
+        if when == "next_syscall":
+            return self._arm(tag, self._register_syscall_boundary, proc)
+        if when == "symbol":
+            if not symbol:
+                self.logger.error("snapshot when='symbol' needs a symbol")
+                return False
+            return self._arm(tag, self._register_symbol_boundary, proc, symbol)
+        self.logger.error("Unknown snapshot 'when': %s", when)
+        return False
+
+    def request_restore(self, tag=None) -> bool:
+        """Schedule a loadvm of ``tag`` into the running guest."""
+        tag = tag or self.tag
+        self.logger.info("Scheduling snapshot restore '%s'", tag)
+        ok = self.panda.schedule_snapshot(tag, load=True)
+        if ok:
+            plugins.publish(self, "on_restore", tag)
+        return ok
+
+    # --- safe-spot arming ---------------------------------------------------
+
+    def _arm(self, tag, register_fn, proc, symbol=None) -> bool:
+        """Register a one-shot boundary hook that fires the save exactly once."""
+        state = {"fired": False, "handle": None, "unregister": None}
+
+        def fire(*_args, **_kwargs):
+            if state["fired"]:
+                return
+            state["fired"] = True
+            try:
+                if state["unregister"] and state["handle"] is not None:
+                    state["unregister"](state["handle"])
+            except Exception as e:
+                self.logger.debug("snapshot hook unregister failed: %s", e)
+            self._do_save_now(tag)
+
+        try:
+            state["handle"], state["unregister"] = register_fn(fire, proc, symbol)
+        except Exception as e:
+            self.logger.error("Failed to arm snapshot boundary: %s", e)
+            return False
+        self._armed.append(state)
+        where = symbol or (f"proc {proc}" if proc else "any process")
+        self.logger.info("Armed snapshot '%s' at %s (%s)", tag,
+                         register_fn.__name__.replace("_register_", "").replace("_boundary", ""),
+                         where)
+        return True
+
+    def _register_syscall_boundary(self, cb, proc, _symbol):
+        handle = plugins.syscalls.syscall("on_all_sys_return", comm_filter=proc)(cb)
+        return handle, plugins.syscalls.unregister
+
+    def _register_symbol_boundary(self, cb, proc, symbol):
+        handle = plugins.uprobes.uprobe(symbol=symbol, process_filter=proc)(cb)
+        return handle, plugins.uprobes.unregister
+
+    # --- actions ------------------------------------------------------------
+
+    def _do_save_now(self, tag: str) -> bool:
+        """Schedule a savevm of the running guest under ``tag`` immediately."""
+        self.logger.info("Scheduling snapshot save '%s'", tag)
+        ok = self.panda.schedule_snapshot(tag, load=False)
+        if ok:
+            self.saved = True
+            self._write_sidecar(tag)
+            self._save_host_state(tag)
+            self._dispatch_lifecycle("on_snapshot", tag)
+            plugins.publish(self, "on_snapshot", tag)
+            if self.stop_after_save:
+                # The save runs on the main loop; the shutdown request is
+                # honoured after the queued snapshot bottom-half completes.
+                self.logger.info("stop_after_save set; ending analysis")
+                self.panda.end_analysis()
+        return ok
+
+    # --- host-side state (output-dir carry + opt-in save/load_state) --------
+
+    def _host_sidecar_path(self, tag: str) -> str:
+        # Travels with the snapshot overlay (qcows/) rather than the per-run
+        # output dir, so a fresh cross-process restore run can find it.
+        return join(self.proj_dir, "qcows", f"snapshot_{tag}.host.json")
+
+    def _iter_plugins(self):
+        # plugins.plugins maps name -> instance for everything loaded.
+        return list(getattr(self.plugins, "plugins", {}).values())
+
+    def _save_host_state(self, tag: str) -> None:
+        states = {}
+        for p in self._iter_plugins():
+            try:
+                data = p.save_state()
+            except Exception as e:
+                self.logger.warning("save_state failed for %s: %s", p.name, e)
+                continue
+            if data is not None:
+                states[p.name] = data
+        if not states:
+            return
+        path = self._host_sidecar_path(tag)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(states, f)
+        self.logger.info("Saved host-side state for %d plugin(s) to %s",
+                         len(states), path)
+
+    def _restore_host_state(self, tag: str) -> None:
+        path = self._host_sidecar_path(tag)
+        if not os.path.isfile(path):
+            self.logger.debug("No host sidecar for snapshot '%s'", tag)
+            return
+        with open(path) as f:
+            states = json.load(f)
+        by_name = {p.name: p for p in self._iter_plugins()}
+        for name, data in states.items():
+            p = by_name.get(name)
+            if p is None:
+                self.logger.debug("Plugin %s not loaded; skipping its state", name)
+                continue
+            try:
+                p.load_state(data)
+            except Exception as e:
+                self.logger.warning("load_state failed for %s: %s", name, e)
+
+    def _dispatch_lifecycle(self, method_name: str, tag: str) -> None:
+        for p in self._iter_plugins():
+            if p is self:
+                continue
+            try:
+                getattr(p, method_name)(tag)
+            except Exception as e:
+                self.logger.warning("%s.%s failed: %s", p.name, method_name, e)
+
+    # --- helpers ------------------------------------------------------------
+
+    def _write_sidecar(self, tag: str) -> None:
+        os.makedirs(self.outdir, exist_ok=True)
+        meta = {"tag": tag, "saved_at": datetime.now().isoformat()}
+        with open(join(self.outdir, "snapshot.yaml"), "w") as f:
+            yaml.safe_dump(meta, f, sort_keys=True)

--- a/pyplugins/interventions/nvram2.py
+++ b/pyplugins/interventions/nvram2.py
@@ -380,6 +380,17 @@ class Nvram2(Plugin):
         except Exception as e:
             self.logger.warning(f"failed to save persisted nvram to {self.persist_path}: {e}")
 
+    def save_state(self):
+        """Snapshot the in-memory NVRAM set-value state for restore continuity."""
+        return {"state": dict(self.state)}
+
+    def load_state(self, data) -> None:
+        """Restore NVRAM set-value state captured at snapshot time."""
+        saved = (data or {}).get("state")
+        if isinstance(saved, dict):
+            self.state.update(saved)
+            self.logger.info("restored %d nvram values from snapshot", len(saved))
+
     def log_write(self, entry: str) -> None:
         """
         Write a log entry to the CSV file.

--- a/pyplugins/interventions/remotectrl.py
+++ b/pyplugins/interventions/remotectrl.py
@@ -285,6 +285,36 @@ class RemoteCtrl(Plugin):
         hid = hooklogger.register_syscall(name, action, pid, proc, logfile)
         return {"id": hid}
 
+    def _handle_snapshot(self, cmd):
+        """Host-driven snapshot request.
+
+        cmd fields: action ('save'|'load', default 'save'), tag, and for save:
+        when ('next_syscall'|'symbol'|'now'), process_filter/proc, symbol.
+        Forwards to the Snapshot plugin's request_save/request_restore so the
+        capture is armed at a safe execution boundary.
+        """
+        snap = plugins.get_plugin_by_name("Snapshot")
+        if not snap:
+            return {"status": "error", "message": "Snapshot plugin not loaded"}
+
+        action = cmd.get("action", "save")
+        tag = cmd.get("tag")
+        if action == "save":
+            when = cmd.get("when", "next_syscall")
+            proc = cmd.get("process_filter") or cmd.get("proc")
+            symbol = cmd.get("symbol")
+            ok = snap.request_save(tag, when=when, proc=proc, symbol=symbol)
+            if ok:
+                return {"status": "success",
+                        "message": f"snapshot save armed (when={when})"}
+            return {"status": "error", "message": "failed to arm snapshot save"}
+        elif action == "load":
+            ok = snap.request_restore(tag)
+            if ok:
+                return {"status": "success", "message": "snapshot restore scheduled"}
+            return {"status": "error", "message": "failed to schedule restore"}
+        return {"status": "error", "message": f"unknown snapshot action: {action}"}
+
     def _handle_list(self, cmd):
         return {"hooks": hooklogger.list_hooks()}
 

--- a/src/penguin/__main__.py
+++ b/src/penguin/__main__.py
@@ -25,6 +25,7 @@ from .graph_search import graph_search
 from .patch_search import patch_search
 from .patch_minimizer import minimize as patch_minimize
 from .plugin_manager import find_local_plugins
+from .utils import hash_image_inputs
 from .compose import run_compose, scaffold_compose
 from .utils_cli import utils as _utils_group
 
@@ -82,7 +83,8 @@ def _validate_project(proj_dir, config_path):
     return config
 
 
-def run_from_config(proj_dir, config_path, output_dir, timeout=None, verbose=False):
+def run_from_config(proj_dir, config_path, output_dir, timeout=None, verbose=False,
+                    from_snapshot=None, ignore_saved_config=False):
     config = _validate_project(proj_dir, config_path)
 
     # You already have a config, let's just run it. This is what happens
@@ -110,6 +112,15 @@ def run_from_config(proj_dir, config_path, output_dir, timeout=None, verbose=Fal
                 "Static analysis failed to identify an init script. Please specify one in your config under env.igloo_init"
             )
 
+    extra_env = {}
+    if from_snapshot:
+        extra_env["PENGUIN_SNAPSHOT_BOOT_FROM"] = from_snapshot
+    if ignore_saved_config:
+        # Opt out of defaulting to the snapshot's own saved config; drive the
+        # restored guest with the provided config instead (fingerprint-gated).
+        extra_env["PENGUIN_SNAPSHOT_IGNORE_SAVED_CONFIG"] = "1"
+    extra_env = extra_env or None
+
     try:
         PandaRunner().run(
             config_path,
@@ -120,6 +131,7 @@ def run_from_config(proj_dir, config_path, output_dir, timeout=None, verbose=Fal
             show_output=True,
             verbose=verbose,
             resolved_kernel=config["core"]["kernel"],
+            extra_env=extra_env,
         )
     except RuntimeError:
         logger.error("No post-run analysis since there was no .run file")
@@ -255,7 +267,53 @@ def _startup_checks(verbose):
             )
 
 
-def _do_package(project_dir, output_path):
+def _stage_snapshots(project_dir_abs, config, tags, temp_dir):
+    """Stage portable copies of snapshot bundles for packaging.
+
+    Snapshots live in qcows/ (omitted from a normal pack). For each tag we copy
+    the overlay + base image + sidecars into temp_dir/qcows and rebase the
+    overlay COPY to a *relative* backing file (qemu-img rebase -u), so the
+    bundle is self-contained and portable — the live project is never touched.
+    Returns True if anything was staged.
+    """
+    qcow_dir = os.path.join(project_dir_abs, "qcows")
+    base_name = f"image_{hash_image_inputs(project_dir_abs, config)}.qcow2"
+    base_path = os.path.join(qcow_dir, base_name)
+    staged = False
+    stage_dir = os.path.join(temp_dir, "qcows")
+
+    for tag in tags:
+        overlay = os.path.join(qcow_dir, f"snapshot_{tag}.qcow2")
+        if not os.path.isfile(overlay):
+            logger.warning(f"No snapshot overlay for tag '{tag}' ({overlay}); skipping")
+            continue
+        os.makedirs(stage_dir, exist_ok=True)
+        # Base image must travel so the overlay's disk resolves.
+        if os.path.isfile(base_path) and not os.path.isfile(os.path.join(stage_dir, base_name)):
+            shutil.copy2(base_path, os.path.join(stage_dir, base_name))
+        staged_overlay = os.path.join(stage_dir, f"snapshot_{tag}.qcow2")
+        shutil.copy2(overlay, staged_overlay)
+        # Point the COPY at a relative backing so it resolves wherever qcows/
+        # lands on unpack. -u is unsafe (metadata-only); no data is rewritten.
+        try:
+            subprocess.run(
+                ["qemu-img", "rebase", "-u", "-b", base_name, "-F", "qcow2", staged_overlay],
+                check=True)
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to rebase staged snapshot '{tag}': {e}")
+            exit(1)
+        for side in (f"snapshot_{tag}.meta.json", f"snapshot_{tag}.host.json",
+                     f"snapshot_{tag}.config.yaml"):
+            src = os.path.join(qcow_dir, side)
+            if os.path.isfile(src):
+                shutil.copy2(src, os.path.join(stage_dir, side))
+        logger.info(f"Staged snapshot '{tag}' (overlay + base + sidecars) for packaging")
+        staged = True
+
+    return staged
+
+
+def _do_package(project_dir, output_path, with_snapshots=()):
     project_dir_abs = os.path.abspath(project_dir)
     config_path = os.path.join(project_dir_abs, "config.yaml")
 
@@ -410,6 +468,13 @@ def _do_package(project_dir, output_path):
                 # copy2 preserves file metadata
                 shutil.copy2(ext_f, os.path.join(ext_dir, os.path.basename(ext_f)))
 
+        # Optionally stage portable snapshot bundles (overlay + base + sidecars)
+        # into temp_dir/qcows so they travel with the project for 'capture & share'.
+        has_snapshots = False
+        if with_snapshots:
+            has_snapshots = _stage_snapshots(project_dir_abs, config,
+                                             with_snapshots, temp_dir)
+
         # Construct the tar command using -I pigz
         tar_cmd = [
             "tar",
@@ -424,6 +489,10 @@ def _do_package(project_dir, output_path):
         # Append external_files directory if we copied anything into it
         if has_external:
             tar_cmd.append("external_files")
+
+        # Append staged snapshot bundle (qcows/) if present
+        if has_snapshots:
+            tar_cmd.append("qcows")
 
         logger.debug(f"Running packaging command: {' '.join(tar_cmd)}")
         try:
@@ -676,9 +745,15 @@ def refresh(ctx, project_dir, only, jobs, init_plugin_path, enable, disable, upd
 @click.option("--force", is_flag=True, default=False, help="Forcefully delete output directory if it exists.")
 @click.option("--timeout", type=int, default=None, help="Number of seconds that run/iteration should last. Default is None (must manually kill)")
 @click.option("-a", "--auto", is_flag=True, help="Run in auto mode (don't start telnet shell).")
+@click.option("--from-snapshot", "from_snapshot", type=str, default=None,
+              help="Restore from a saved VM snapshot tag at startup (sugar for core.snapshot.boot_from).")
+@click.option("--ignore-saved-config", "ignore_saved_config", is_flag=True, default=False,
+              help="When restoring, do NOT default to the config the snapshot was saved with; "
+                   "use the provided config instead (still gated by the snapshot fingerprint).")
 @verbose_option
 @click.pass_context
-def run(ctx, project_dir, config, output, force, timeout, auto):
+def run(ctx, project_dir, config, output, force, timeout, auto, from_snapshot,
+        ignore_saved_config):
     """
     Run from a config.
 
@@ -738,7 +813,8 @@ def run(ctx, project_dir, config, output, force, timeout, auto):
             "Note messages referencing /host paths reflect automatically-mapped shared directories based on your command line arguments"
         )
 
-    run_from_config(project_dir, config, output, timeout=timeout, verbose=ctx.obj['VERBOSE'])
+    run_from_config(project_dir, config, output, timeout=timeout, verbose=ctx.obj['VERBOSE'],
+                    from_snapshot=from_snapshot, ignore_saved_config=ignore_saved_config)
 
 
 @cli.command()
@@ -1088,16 +1164,20 @@ def guest_cmd(ctx, args):
 @cli.command()
 @click.argument("project_dir", type=click.Path(exists=True))
 @click.option("-o", "--out", type=str, default=None, help="Output tar.gz file path. Defaults to <project_dir_name>.tar.gz")
+@click.option("--with-snapshot", "with_snapshot", multiple=True, metavar="TAG",
+              help="Also include the named VM snapshot bundle (overlay + base + sidecars) so the project can boot_from it elsewhere. Repeatable.")
 @verbose_option
 @click.pass_context
-def pack(ctx, project_dir, out):
+def pack(ctx, project_dir, out, with_snapshot):
     """
     Package a penguin project into a distributable archive.
 
-    Creates a tar.gz pulling in configs, base, and static patches while omitting results and qcows.
+    Creates a tar.gz pulling in configs, base, and static patches while omitting
+    results and qcows. Pass --with-snapshot TAG to additionally bundle a saved
+    VM snapshot (made portable via a relative backing rebase) for capture & share.
     """
     _startup_checks(ctx.obj['VERBOSE'])
-    _do_package(project_dir, out)
+    _do_package(project_dir, out, with_snapshots=with_snapshot)
 
 
 @cli.command()

--- a/src/penguin/common.py
+++ b/src/penguin/common.py
@@ -32,14 +32,55 @@ def redirect_logs_to(handler: logging.Handler) -> None:
 
 
 # Hex integers
-def int_to_hex_representer(dumper, data):
-    if not isinstance(data, int):
-        raise ValueError(f"YAML representer received non-integer: {data}. Something has gone very wrong")
+# Integer rendering for dumped configs (see style_config_for_dump). A plain
+# YAML scalar representer only receives the value, never the mapping key, so it
+# cannot tell a permission `mode` from a port by value alone. Instead, config
+# dumping wraps the values it wants specially formatted in these int subclasses
+# and we register one representer per subclass. Plain ints fall through to
+# CoreDumper's default base-10 rendering.
+class HexInt(int):
+    """An int that dumps as hex (``0x...``) — for addresses, masks, etc."""
 
-    if data > 10:
-        # Values < 10 can be base 10
-        return dumper.represent_scalar("tag:yaml.org,2002:int", data)
-    return dumper.represent_scalar("tag:yaml.org,2002:int", hex(data))
+
+class OctInt(int):
+    """An int that dumps as octal (``0o...``) — for file permission modes."""
+
+
+def _hexint_representer(dumper, data):
+    # represent_scalar needs a *string* value; the explicit int tag keeps it an
+    # int on load (CoreLoader parses 0x.../0o... per the YAML 1.2 core schema).
+    return dumper.represent_scalar("tag:yaml.org,2002:int", hex(int(data)))
+
+
+def _octint_representer(dumper, data):
+    return dumper.represent_scalar("tag:yaml.org,2002:int", oct(int(data)))
+
+
+# Config keys whose integer values are file permissions and read best as octal.
+PERMISSION_KEYS = frozenset({"mode"})
+# Integers at or above this render as hex (memory addresses, masks, ...);
+# smaller values (ports <=65535, timeouts, counts) stay decimal.
+HEX_INT_THRESHOLD = 0x10000
+
+
+def style_config_for_dump(obj, _key=None):
+    """Return a copy of a config with ints wrapped for readable YAML output:
+    permission (``mode``) fields as octal, large/address-like ints as hex, and
+    everything else left as plain base-10 ints. Booleans are passed through
+    untouched (``bool`` is an ``int`` subclass but must stay true/false)."""
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, int):
+        if _key in PERMISSION_KEYS:
+            return OctInt(obj)
+        if obj >= HEX_INT_THRESHOLD:
+            return HexInt(obj)
+        return obj
+    if isinstance(obj, dict):
+        return {k: style_config_for_dump(v, k) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [style_config_for_dump(v, _key) for v in obj]
+    return obj
 
 
 # Multi-line strings
@@ -52,9 +93,16 @@ def literal_presenter(dumper, data):
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
 
-# Representer. Need special handling for dumping literals and tuples. Support base dumper or safe
+# Representers: multi-line strings as literal blocks, and the hex/oct int
+# subclasses. Plain ints intentionally keep CoreDumper's default base-10 output.
 CoreDumper.add_representer(str, literal_presenter)
-CoreDumper.add_representer(int, int_to_hex_representer)
+CoreDumper.add_representer(HexInt, _hexint_representer)
+CoreDumper.add_representer(OctInt, _octint_representer)
+# Configs can carry binary blobs (e.g. inlined lib_inject .so contents) as
+# bytes. yamlcore's CoreDumper lacks a bytes representer, so reuse PyYAML's
+# !!binary (base64) one — symmetric with the construct_yaml_binary constructor
+# registered on CoreLoader below, so these round-trip.
+CoreDumper.add_representer(bytes, yaml.representer.SafeRepresenter.represent_binary)
 yaml.add_constructor(
     'tag:yaml.org,2002:binary',
     yaml.constructor.SafeConstructor.construct_yaml_binary,

--- a/src/penguin/defaults.py
+++ b/src/penguin/defaults.py
@@ -77,6 +77,7 @@ default_plugins: dict[str, dict] = {
     "send_hypercall": {
     },
     "readiness": {},
+    "snapshot": {},
     "indiv_debug": {},
 }
 

--- a/src/penguin/manager.py
+++ b/src/penguin/manager.py
@@ -21,7 +21,7 @@ import signal
 import subprocess
 import time
 from penguin import getColoredLogger
-from .common import yaml
+from .common import yaml, CoreLoader
 
 logger = getColoredLogger("penguin.manager.calculate_score")
 
@@ -73,7 +73,10 @@ def calculate_score(result_dir: str, have_console: bool = True) -> dict[str, int
     # --- Load core_config.yaml ---
     try:
         with open(os.path.join(result_dir, "core_config.yaml")) as f:
-            config = yaml.safe_load(f) or {}  # Ensure config is a dict even if file is empty
+            # core_config.yaml is written with CoreDumper (YAML 1.2: octal modes
+            # 0o..., hex addresses 0x...); read it with the matching 1.2 loader
+            # so those parse back as ints (safe_load/1.1 mangles 0o755 to a str).
+            config = yaml.load(f, Loader=CoreLoader) or {}  # dict even if empty
     except FileNotFoundError:
         logger.warning(f"Config file not found in {result_dir}. Cannot determine blocked signals.")
     except yaml.YAMLError as e:

--- a/src/penguin/penguin_config/__init__.py
+++ b/src/penguin/penguin_config/__init__.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     from yamlcore import CoreLoader, CoreDumper
     import yaml
+
     def style_config_for_dump(obj, _key=None):
         return obj
 from pydantic import BaseModel, Field, RootModel, ValidationError

--- a/src/penguin/penguin_config/__init__.py
+++ b/src/penguin/penguin_config/__init__.py
@@ -13,10 +13,12 @@ from collections import defaultdict
 import click
 import jsonschema
 try:
-    from penguin.common import yaml, CoreDumper, CoreLoader
+    from penguin.common import yaml, CoreDumper, CoreLoader, style_config_for_dump
 except ImportError:
     from yamlcore import CoreLoader, CoreDumper
     import yaml
+    def style_config_for_dump(obj, _key=None):
+        return obj
 from pydantic import BaseModel, Field, RootModel, ValidationError
 from pydantic.config import ConfigDict
 
@@ -502,11 +504,14 @@ def dump_config(config, path):
     validation doesn't check this
     """
     _validate_config(config)
+    # Wrap ints for readable rendering (octal modes, hex addresses) without
+    # mutating the caller's config; validation above ran on the originals.
+    styled = style_config_for_dump(config)
     with open(path, "w") as f:
         f.write(
             "# yaml-language-server: $schema=https://github.com/rehosting/penguin/releases/latest/download/config_schema.yaml\n"
         )
-        yaml.dump(config, f, sort_keys=False, default_flow_style=False, width=None, Dumper=CoreDumper)
+        yaml.dump(styled, f, sort_keys=False, default_flow_style=False, width=None, Dumper=CoreDumper)
 
 
 def hash_yaml_config(config: dict):

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -94,6 +94,74 @@ GDBServerPrograms = _newtype(
 )
 
 
+class Snapshot(PartialModelMixin, BaseModel):
+    """VM snapshot (savevm/loadvm) configuration.
+
+    Snapshotting is *active* whenever ``save_at`` or ``boot_from`` is set — there
+    is no separate enable flag. When active, the guest runs on a persistent
+    qcow2 overlay (rather than the throwaway immutable overlay) so an internal VM
+    snapshot can be saved and later restored. Saving a snapshot at a chosen point
+    lets a later run boot directly from that state instead of re-booting the
+    firmware.
+    """
+
+    model_config = ConfigDict(title="Snapshot configuration", extra="forbid")
+
+    backend: Annotated[
+        Literal["internal", "file"],
+        Field(
+            "internal",
+            title="Snapshot backend",
+            description=(
+                "'internal' stores the snapshot inside the qcow2 overlay "
+                "(savevm/loadvm). 'file' (not yet implemented) writes a "
+                "standalone migration file bundle."
+            ),
+            examples=["internal", "file"],
+        ),
+    ]
+    tag: Annotated[
+        str,
+        Field(
+            "boot",
+            title="Snapshot tag",
+            description="Name of the internal VM snapshot to save and/or restore.",
+            examples=["boot", "post_init"],
+        ),
+    ]
+    save_at: Annotated[
+        Optional[Literal["readiness", "manual"]],
+        Field(
+            None,
+            title="When to save the snapshot",
+            description=(
+                "'readiness' saves once the guest reaches steady state; "
+                "'manual' arms the Snapshot plugin to save on request "
+                "(via guest_cmd / hypercall). None disables saving."
+            ),
+            examples=["readiness", "manual"],
+        ),
+    ]
+    boot_from: Annotated[
+        Optional[str],
+        Field(
+            None,
+            title="Snapshot tag to boot from",
+            description="If set, restore this internal snapshot at startup (-loadvm).",
+            examples=["boot"],
+        ),
+    ]
+    stop_after_save: Annotated[
+        bool,
+        Field(
+            False,
+            title="End the run after saving",
+            description="Shut the guest down immediately after the snapshot is saved.",
+            examples=[False, True],
+        ),
+    ]
+
+
 class Core(PartialModelMixin, BaseModel):
     """Core configuration options for this rehosting"""
 
@@ -187,6 +255,7 @@ class Core(PartialModelMixin, BaseModel):
         ),
     ]
     gdbserver: Optional[GDBServerPrograms] = None
+    snapshot: Optional[Snapshot] = None
     force_www: Annotated[
         bool,
         Field(

--- a/src/penguin/penguin_run.py
+++ b/src/penguin/penguin_run.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 import os
+import json
 import shutil
 import shlex
+import subprocess
 import sys
 import tempfile
 import socket
@@ -10,11 +12,12 @@ from pathlib import Path
 from time import sleep
 from penguin import getColoredLogger, plugins
 
-from .common import yaml
+from .common import yaml, style_config_for_dump
+from yamlcore import CoreDumper, CoreLoader
 from .defaults import default_plugin_path, vnc_password
 from penguin.penguin_config import load_config
 from .plugin_manager import ArgsBox
-from .utils import hash_image_inputs, get_penguin_kernel_version
+from .utils import hash_image_inputs, get_penguin_kernel_version, boot_fingerprint
 from .q_config import load_q_config, ROOTFS
 from . import arch_registry
 
@@ -147,6 +150,44 @@ def run_config(
         conf = load_config(proj_dir, conf_yaml, resolved_kernel=resolved_kernel, verbose=True)
     else:
         conf = load_config(proj_dir, conf_yaml, verbose=True)
+
+    # `penguin run --from-snapshot <tag>` is sugar for core.snapshot.boot_from;
+    # it crosses the subprocess boundary as an env var so we apply it here.
+    boot_from_env = os.environ.get("PENGUIN_SNAPSHOT_BOOT_FROM")
+    if boot_from_env:
+        conf["core"].setdefault("snapshot", {})["boot_from"] = boot_from_env
+        logger.info("Restoring from snapshot '%s' (--from-snapshot)", boot_from_env)
+
+    # When restoring, default to the *exact config the snapshot was saved with*
+    # (persisted next to the overlay at save time). The snapshot froze guest
+    # state produced by that config, so reusing it is the coherent, low-surprise
+    # default — running a restored guest under a different config is the kind of
+    # mismatch the fingerprint exists to catch. A user can opt out with
+    # `run --ignore-saved-config` to deliberately drive the restored guest with
+    # the provided config instead (still fingerprint-gated).
+    snap_cfg = conf["core"].get("snapshot") or {}
+    boot_from = snap_cfg.get("boot_from")
+    ignore_saved = bool(os.environ.get("PENGUIN_SNAPSHOT_IGNORE_SAVED_CONFIG"))
+    if boot_from and not ignore_saved:
+        snap_tag = snap_cfg.get("tag", "boot")
+        saved_cfg_path = os.path.join(proj_dir, "qcows",
+                                      f"snapshot_{snap_tag}.config.yaml")
+        if os.path.isfile(saved_cfg_path):
+            with open(saved_cfg_path) as f:
+                saved_conf = yaml.load(f, Loader=CoreLoader)
+            # Carry the restore intent onto the saved config.
+            saved_conf.setdefault("core", {}).setdefault("snapshot", {})
+            saved_conf["core"]["snapshot"]["boot_from"] = boot_from
+            saved_conf["core"]["snapshot"]["tag"] = snap_tag
+            conf = saved_conf
+            logger.info("Loaded the config this snapshot was saved with (%s); "
+                        "pass --ignore-saved-config to override", saved_cfg_path)
+        else:
+            logger.warning("Snapshot '%s' has no saved config (%s); restoring "
+                           "with the provided config", snap_tag, saved_cfg_path)
+    elif boot_from and ignore_saved:
+        logger.info("--ignore-saved-config: restoring with the provided config "
+                    "rather than the snapshot's saved config")
 
     pkversion = get_penguin_kernel_version(conf)
 
@@ -308,10 +349,93 @@ def run_config(
     if telnet_port is None:
         raise OSError("No available port found in the specified range")
 
-    # If core config specifes immutable: False we'll run without snapshot
-    no_snapshot_drive = f"file={config_image},id=hd0"
+    # Resolve snapshot (savevm/loadvm) configuration. Snapshotting is *active*
+    # whenever save_at or boot_from is set (no separate enable flag). When active
+    # we cannot use QEMU's throwaway `snapshot=on` overlay (its internal
+    # snapshots are discarded on exit); instead we run on a persistent qcow2
+    # overlay backed by the cached base image so savevm state survives and a
+    # later run can boot from it. See core.snapshot in the config schema.
+    snap_cfg = conf["core"].get("snapshot") or {}
+    snapshot_save_at = snap_cfg.get("save_at")
+    snapshot_boot_from = snap_cfg.get("boot_from")
+    snapshot_enabled = (snapshot_save_at is not None) or (snapshot_boot_from is not None)
+    drive_image = config_image
+
+    if snapshot_enabled and snap_cfg.get("backend", "internal") == "file":
+        # The standalone migration-file backend (migrate file:/-incoming with
+        # mapped-ram) is designed but not yet implemented — it is async and
+        # captures only RAM+devices, needing the disk overlay bundled alongside.
+        # Until then, only the qcow2-internal backend is wired.
+        raise NotImplementedError(
+            "core.snapshot.backend='file' is not implemented yet; use 'internal'")
+
+    if snapshot_enabled:
+        snap_tag = snap_cfg.get("tag", "boot")
+        overlay_path = os.path.join(qcow_dir, f"snapshot_{snap_tag}.qcow2")
+        meta_path = os.path.join(qcow_dir, f"snapshot_{snap_tag}.meta.json")
+        # A snapshot freezes guest state produced by the boot-frozen inputs; a
+        # restore is only coherent if those inputs still match.
+        fingerprint = boot_fingerprint(proj_dir, conf)
+        if snapshot_boot_from:
+            # Restore mode: the overlay must already hold the named snapshot.
+            if not os.path.isfile(overlay_path):
+                raise ValueError(
+                    f"snapshot.boot_from='{snapshot_boot_from}' requested but "
+                    f"overlay {overlay_path} does not exist; run with "
+                    f"snapshot.save_at set first to create it")
+            saved_fp = None
+            if os.path.isfile(meta_path):
+                with open(meta_path) as f:
+                    saved_fp = json.load(f).get("fingerprint")
+            if saved_fp is None:
+                logger.warning(
+                    "Snapshot '%s' has no fingerprint metadata; cannot verify "
+                    "it matches the current config — restoring anyway", snap_tag)
+            elif saved_fp != fingerprint:
+                raise ValueError(
+                    f"snapshot.boot_from='{snapshot_boot_from}': the boot-frozen "
+                    f"config (kernel, env/append, arch, machine, nvram, netdevs, "
+                    f"pseudofile set) changed since this snapshot was saved, so "
+                    f"the restored guest state would be incoherent. Re-create the "
+                    f"snapshot (snapshot.save_at) or revert the config. "
+                    f"(saved {saved_fp[:12]} != current {fingerprint[:12]})")
+            logger.info("Booting from snapshot '%s' in %s",
+                        snapshot_boot_from, overlay_path)
+        else:
+            # Save mode: start from a fresh overlay over the cached base so
+            # the saved snapshot reflects a clean boot, and record the
+            # boot-fingerprint so a later restore can verify it.
+            if os.path.isfile(overlay_path):
+                os.remove(overlay_path)
+            subprocess.check_output([
+                "qemu-img", "create", "-f", "qcow2",
+                "-b", config_image, "-F", "qcow2", overlay_path,
+            ])
+            with open(meta_path, "w") as f:
+                json.dump({"tag": snap_tag, "fingerprint": fingerprint}, f)
+            # Persist the exact resolved config this snapshot is being saved
+            # with, so a restore can default to it (see the boot_from handling
+            # above). Travels with the overlay in qcows/ and is bundled by
+            # `pack --with-snapshot`.
+            saved_cfg_path = os.path.join(qcow_dir, f"snapshot_{snap_tag}.config.yaml")
+            with open(saved_cfg_path, "w") as f:
+                # Same rendering as dump_config (octal modes, hex addresses);
+                # read back with CoreLoader on restore. The resolved conf is
+                # already validated, so we don't re-validate here.
+                yaml.dump(style_config_for_dump(conf), f, sort_keys=False,
+                          default_flow_style=False, width=None, Dumper=CoreDumper)
+            logger.info("Created snapshot overlay %s over %s (fingerprint %s)",
+                        overlay_path, config_image, fingerprint[:12])
+        drive_image = overlay_path
+
+    # If core config specifes immutable: False we'll run without snapshot.
+    # Snapshotting forces a persistent (non-throwaway) overlay regardless.
+    no_snapshot_drive = f"file={drive_image},id=hd0"
     snapshot_drive = no_snapshot_drive + ",cache=unsafe,snapshot=on"
-    drive = snapshot_drive if conf["core"].get("immutable", True) else no_snapshot_drive
+    if snapshot_enabled:
+        drive = no_snapshot_drive + ",cache=unsafe"
+    else:
+        drive = snapshot_drive if conf["core"].get("immutable", True) else no_snapshot_drive
     if vpn_enabled and ("mips" in q_config["arch"]):  # and "ppc" not in q_config["arch"]):
         machine_args = q_config["qemu_machine"]+",memory-backend=mem0"
     else:
@@ -352,6 +476,10 @@ def run_config(
         args += ["-bios", "/usr/local/share/qemu/edk2-loongarch64-code.fd"]
 
     args += ["-no-reboot"]
+
+    if snapshot_enabled and snapshot_boot_from:
+        # Restore device + RAM state from the named internal snapshot at boot.
+        args += ["-loadvm", snapshot_boot_from]
 
     if conf["core"].get("network", False):
         # Connect guest to network if specified
@@ -550,6 +678,13 @@ def run_config(
         from apis.hypercall import Hypercall
         plugins.load(Hypercall, args)
     plugins.load_plugins(conf_plugins)
+
+    # When booting from a snapshot, rehydrate host-side plugin state now that
+    # all plugins are loaded but before the guest resumes (panda.run below).
+    if snapshot_enabled and snapshot_boot_from:
+        snap_plugin = plugins.get_plugin_by_name("Snapshot")
+        if snap_plugin is not None:
+            snap_plugin.dispatch_restore()
 
     # XXX HACK: normally panda args are set at the constructor. But we want to load
     # our plugins first and these need a handle to panda. So after we've constructed

--- a/src/penguin/plugin_manager.py
+++ b/src/penguin/plugin_manager.py
@@ -210,6 +210,55 @@ class Plugin:
         """Ensure that the plugin is fully initialized before use."""
         pass
 
+    def on_snapshot(self, tag: str) -> None:
+        """Hook called after a VM snapshot is saved.
+
+        Override to persist any host-side state that must be reproduced when
+        the snapshot is later restored. No-op by default. Plugins may also
+        subscribe to the Snapshot plugin's ``on_snapshot`` event instead.
+        """
+        pass
+
+    def on_restore(self, tag: str) -> None:
+        """Hook called after a VM snapshot is restored (or booted via -loadvm).
+
+        Called after :meth:`load_state` has run, so any state captured at save
+        time is already available. Override to rehydrate host-side state (e.g.
+        re-establish bridges, replay recorded bindings) so it matches the
+        restored guest. No-op by default.
+        """
+        pass
+
+    def save_state(self):
+        """Opt-in: return JSON-serialisable host-side state to bundle with a
+        snapshot, or None to save nothing (default).
+
+        A snapshot does not capture host-side plugin state; plugins that hold
+        in-memory state needed for continuity after a cross-process restore
+        should return it here. File-backed state (e.g. NVRAM's nvram_state.yaml)
+        can self-heal via the output dir and need not be returned. The returned
+        value is stored in the snapshot's host sidecar and handed back to
+        :meth:`load_state` on restore.
+        """
+        return None
+
+    def load_state(self, data) -> None:
+        """Opt-in: rehydrate state previously returned by :meth:`save_state`.
+
+        Called on restore before :meth:`on_restore`. No-op by default.
+        """
+        pass
+
+    def reset_state(self) -> None:
+        """Opt-in: reset host-side state to a pristine baseline.
+
+        Reserved for fork/restore-many (restoring the same point repeatedly),
+        where each restore needs a clean host-side slate (fresh counters, port
+        maps, etc.). Not exercised by once-and-continue restore. No-op by
+        default; this is the designed seam, not yet driven by any caller.
+        """
+        pass
+
     @property
     def name(self) -> str:
         """

--- a/src/penguin/utils.py
+++ b/src/penguin/utils.py
@@ -353,9 +353,23 @@ def boot_fingerprint(proj_dir: str, conf: Dict[str, Any]) -> str:
     :return: Hex digest string.
     """
     core = conf.get("core", {})
+    # Content hash of the boot-frozen image inputs (fs tarball + the arch
+    # binaries injected into the guest). Deliberately content-based, NOT the
+    # mtime-based hash_image_inputs: a snapshot must restore after `pack
+    # --with-snapshot` relocates the project, where the fs tarball's mtime
+    # changes but its bytes do not.
+    img = hashlib.sha256()
+    fs = os.path.join(proj_dir, core.get("fs", "") or "")
+    if os.path.isfile(fs):
+        img.update(get_file_hash(fs).encode())
+    arch_dir = get_arch_dir(conf)
+    for f in ["busybox", "hyp_file_op", "send_portalcall", get_driver_kmod_path(conf)]:
+        p = os.path.join(arch_dir, f)
+        if os.path.isfile(p):
+            img.update(get_file_hash(p).encode())
     frozen = {
-        # disk + arch binaries + fs (reuses the image-input hash)
-        "image": hash_image_inputs(proj_dir, conf),
+        # disk + arch binaries + fs, by content (survives relocation)
+        "image": img.hexdigest(),
         # machine the guest runs on
         "kernel": core.get("kernel"),
         "arch": core.get("arch"),

--- a/src/penguin/utils.py
+++ b/src/penguin/utils.py
@@ -12,6 +12,7 @@ filesystem and kernel management, plugin analysis loading, and mitigation provid
 import hashlib
 import heapq
 import importlib
+import json
 import os
 import subprocess
 import penguin
@@ -330,6 +331,47 @@ def hash_image_inputs(proj_dir: str, conf: Dict[str, Any]) -> str:
     # add the fstype - if it changes we need to rebuild
     hsh.update("ext4".encode())
     return hsh.hexdigest()
+
+
+def boot_fingerprint(proj_dir: str, conf: Dict[str, Any]) -> str:
+    """
+    Coarse fingerprint of the *boot-frozen* inputs that a VM snapshot is bound
+    to. A snapshot captures guest state produced by these inputs, so a restore
+    is only coherent if they still match.
+
+    This is intentionally broader than :func:`hash_image_inputs` (which omits the
+    kernel and the boot/append args) and intentionally *coarse*: it freezes whole
+    device-ish config sections rather than tracking which individual NVRAM keys
+    or pseudofiles the guest actually touched. That can refuse a restore that
+    would in fact have been fine; per-access precision can be layered on later.
+
+    Mutable-on-restore config (analysis/logging/breakpoint plugins, and the
+    response logic of already-wired pseudofiles) is deliberately excluded.
+
+    :param proj_dir: Project directory.
+    :param conf: Configuration dictionary.
+    :return: Hex digest string.
+    """
+    core = conf.get("core", {})
+    frozen = {
+        # disk + arch binaries + fs (reuses the image-input hash)
+        "image": hash_image_inputs(proj_dir, conf),
+        # machine the guest runs on
+        "kernel": core.get("kernel"),
+        "arch": core.get("arch"),
+        "machine": core.get("machine"),
+        "mem": core.get("mem"),
+        # boot args shape the booted state
+        "env": conf.get("env"),
+        # device-ish inputs baked into the booted guest
+        "nvram": conf.get("nvram"),
+        "netdevs": conf.get("netdevs"),
+        # the *set* of pseudofile nodes (enumeration is baked in); the response
+        # logic is mutable and excluded by hashing only the keys.
+        "pseudofile_nodes": sorted((conf.get("pseudofiles") or {}).keys()),
+    }
+    blob = json.dumps(frozen, sort_keys=True, default=str)
+    return hashlib.sha256(blob.encode()).hexdigest()
 
 
 def _load_penguin_analysis_from(plugin_file: str) -> PenguinAnalysis:

--- a/tests/unit_tests/basic_target/snapshot_paths_test.py
+++ b/tests/unit_tests/basic_target/snapshot_paths_test.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+Validate the previously-unverified snapshot paths:
+
+  pack   : `pack --with-snapshot` -> unpack into a *different* dir -> run
+           --from-snapshot.  Exercises the portable bundle (overlay rebased to a
+           relative backing + base image + sidecars + saved config) surviving
+           relocation.
+  socket : host-driven trigger.  A run stays alive (no guest-side save); a
+           `snapshot save` command sent over the RemoteCtrl unix socket
+           (`_handle_snapshot` -> Snapshot.request_save) produces the snapshot,
+           which a fresh `--from-snapshot` run then restores.
+
+Usage: python3 snapshot_paths_test.py -i <image> [-a armel] [-k 4.10]
+                                       [-m pack|socket|all]
+"""
+import logging
+import os
+import subprocess
+import shutil
+import time
+from pathlib import Path
+
+import click
+import yaml
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+                    datefmt="%H:%M:%S")
+logger = logging.getLogger("penguin.snappaths")
+
+TEST_DIR = Path(__file__).resolve().parent
+proj_dir = TEST_DIR
+PENGUIN = str(TEST_DIR.parent.parent.parent / "penguin")
+
+# httpd on :8000, wait for the bind, then guest-driven snapshot, then stay alive.
+INIT_SELFSAVE = """#!/igloo/utils/sh
+/igloo/utils/busybox echo "snap-init up"
+/igloo/utils/busybox httpd -f -p 8000 -h / &
+i=0
+while [ $i -lt 25 ]; do
+  /igloo/utils/busybox grep -qi ":1F40" /proc/net/tcp /proc/net/tcp6 2>/dev/null && break
+  /igloo/utils/busybox sleep 1; i=$((i + 1))
+done
+/igloo/utils/busybox sleep 4
+/igloo/utils/send_hypercall snapshot_save TAG now
+while true; do /igloo/utils/busybox sleep 1; done
+"""
+
+# httpd on :8000 then just stay alive; the host triggers the snapshot via socket.
+INIT_STAYALIVE = """#!/igloo/utils/sh
+/igloo/utils/busybox echo "snap-init up"
+/igloo/utils/busybox httpd -f -p 8000 -h / &
+while true; do /igloo/utils/busybox sleep 1; done
+"""
+
+
+def run_cmd(cmd, **kw):
+    logger.info(f"$ {cmd}")
+    return subprocess.run(cmd, shell=True, check=True, **kw)
+
+
+def penguin(image, *args, log, name=None, check=True):
+    cmd = [PENGUIN, "--image", image]
+    if name:
+        cmd += ["--name", name]
+    cmd += list(args)
+    logger.info("$ " + " ".join(cmd))
+    with open(proj_dir / log, "w") as f:
+        r = subprocess.run(cmd, cwd=proj_dir, stdout=f, stderr=subprocess.STDOUT)
+    if check and r.returncode != 0:
+        subprocess.run(["tail", "-n", "120", str(proj_dir / log)])
+        raise RuntimeError(f"penguin {args[0]} failed ({r.returncode}); see {log}")
+    return r.returncode
+
+
+def docker_penguin(image, hostdir, *args, log):
+    """Run the penguin CLI directly in a container with `hostdir` mounted at
+    /work — deterministic paths for pure file ops (pack/unpack) without the
+    wrapper's path-mapping heuristics."""
+    cmd = ["docker", "run", "--rm", "--user", f"{os.getuid()}:{os.getgid()}",
+           "-e", "HOME=/tmp", "-v", f"{hostdir}:/work", image, "penguin", *args]
+    logger.info("$ " + " ".join(cmd))
+    with open(proj_dir / log, "w") as f:
+        r = subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT)
+    if r.returncode != 0:
+        subprocess.run(["tail", "-n", "80", str(proj_dir / log)])
+        raise RuntimeError(f"docker penguin {args[0]} failed ({r.returncode}); see {log}")
+
+
+def build_project(image, arch, slug):
+    fs = Path(proj_dir, f"fs_{slug}")
+    if fs.exists():
+        shutil.rmtree(fs)
+    fs.mkdir()
+    cid = subprocess.check_output(f"docker create {image}", shell=True).decode().strip()
+    run_cmd(f"docker cp -L {cid}:/igloo_static/utils.bin/busybox.{arch} {fs}/busybox")
+    run_cmd(f"docker rm -v {cid}")
+    tarball = Path(TEST_DIR, f"empty_fs_{slug}.tar.gz")
+    run_cmd(f"tar -czf {tarball} -C {fs} .")
+    penguin(image, "init", str(tarball), "--force", log=f"snappaths_{slug}_init.txt")
+    return Path(proj_dir, f"projects/empty_fs_{slug}")
+
+
+def write_config(project, kernel, snapshot, init_contents, plugins):
+    patch = {
+        "env": {"igloo_init": "/snap_init.sh"},
+        "core": {"kernel": str(kernel), "timeout": 90, "snapshot": snapshot},
+        "static_files": {
+            "/snap_init.sh": {"type": "inline_file", "mode": 73, "contents": init_contents},
+        },
+        "plugins": plugins,
+    }
+    patch_path = project / "patch_snappaths.yaml"
+    with open(patch_path, "w") as f:
+        yaml.dump(patch, f, sort_keys=False)
+    cfg_path = project / "config.yaml"
+    with open(cfg_path) as f:
+        cfg = yaml.safe_load(f)
+    cfg.setdefault("patches", [])
+    if "patch_snappaths.yaml" not in cfg["patches"]:
+        cfg["patches"].append("patch_snappaths.yaml")
+    with open(cfg_path, "w") as f:
+        yaml.dump(cfg, f, sort_keys=False)
+    return str(cfg_path)
+
+
+def read_bridges(results_dir):
+    csv = results_dir / "vpn_bridges.csv"
+    if not csv.is_file():
+        return []
+    rows = []
+    for line in csv.read_text().strip().splitlines()[1:]:
+        p = line.split(",")
+        if len(p) == 6:
+            rows.append(dict(zip(["procname", "ipvn", "domain", "guest_ip",
+                                  "guest_port", "host_port"], p)))
+    return rows
+
+
+def assert_restore(image, config, tag, slug, extra=()):
+    """Run --from-snapshot and assert it booted from the snapshot + replayed VPN."""
+    penguin(image, "run", config, "--from-snapshot", tag, *extra,
+            log=f"snappaths_{slug}_restore.txt", name=f"{slug}_r")
+    rlog = (proj_dir / f"snappaths_{slug}_restore.txt").read_text(errors="replace")
+    if "Booting from snapshot" not in rlog:
+        raise AssertionError("restore did not boot from the snapshot overlay")
+    if "Re-establishing" not in rlog:
+        raise AssertionError("VPN.on_restore did not replay bridges")
+    return rlog
+
+
+# --------------------------------------------------------------------------
+PLUGINS = {"vpn_test": {}, "remotectrl": {}}
+
+
+def run_pack(image, arch, kernel):
+    slug = f"{arch}_{kernel}_pack"
+    project = build_project(image, arch, slug)
+    qcows = project / "qcows"
+
+    logger.info(f"[{slug}] SAVE run (guest-driven) to produce a snapshot")
+    cfg = write_config(project, kernel, {"save_at": "manual", "tag": "boot"},
+                       INIT_SELFSAVE.replace("TAG", "boot"), {"vpn_test": {}})
+    penguin(image, "run", cfg, log=f"snappaths_{slug}_save.txt", name=f"{slug}_s")
+    for n in ("snapshot_boot.qcow2", "snapshot_boot.meta.json",
+              "snapshot_boot.host.json", "snapshot_boot.config.yaml"):
+        if not (qcows / n).is_file():
+            raise AssertionError(f"save did not produce {n}")
+    logger.info(f"[{slug}] OK: snapshot + sidecars + saved config present")
+
+    # --- pack --with-snapshot (run penguin directly; deterministic paths) --
+    host_projects = str(proj_dir / "projects")
+    bundle = Path(proj_dir, "projects", f"bundle_{slug}.tar.gz")
+    if bundle.exists():
+        bundle.unlink()
+    docker_penguin(image, host_projects, "pack", f"/work/empty_fs_{slug}",
+                   "-o", f"/work/{bundle.name}", "--with-snapshot", "boot",
+                   log=f"snappaths_{slug}_pack.txt")
+    if not bundle.is_file():
+        raise AssertionError(f"pack did not produce {bundle}")
+    listing = subprocess.check_output(f"tar -tzf {bundle}", shell=True).decode()
+    need = ["qcows/snapshot_boot.qcow2", "qcows/snapshot_boot.config.yaml",
+            "qcows/snapshot_boot.host.json", "config.yaml"]
+    for n in need:
+        if n not in listing:
+            raise AssertionError(f"bundle missing {n}")
+    if "qcows/image_" not in listing:
+        raise AssertionError("bundle missing the base image (overlay backing)")
+    logger.info(f"[{slug}] OK: portable bundle contains overlay+base+sidecars+config")
+
+    # --- unpack into a DIFFERENT dir under projects/ ----------------------
+    unpack_dir = Path(proj_dir, "projects", f"unpacked_{slug}")
+    if unpack_dir.exists():
+        shutil.rmtree(unpack_dir)
+    docker_penguin(image, host_projects, "unpack", f"/work/{bundle.name}",
+                   "-o", f"/work/unpacked_{slug}", "--force",
+                   log=f"snappaths_{slug}_unpack.txt")
+    unpacked = unpack_dir / f"empty_fs_{slug}"
+    if not (unpacked / "config.yaml").is_file():
+        # Fall back to whatever project dir the bundle laid down.
+        cands = [p for p in unpack_dir.iterdir() if (p / "config.yaml").is_file()]
+        if not cands:
+            raise AssertionError(f"unpack produced no project under {unpack_dir}")
+        unpacked = cands[0]
+    logger.info(f"[{slug}] OK: unpacked to {unpacked}")
+
+    # --- restore from the relocated bundle --------------------------------
+    assert_restore(image, str(unpacked / "config.yaml"), "boot", slug)
+    rb = read_bridges(unpacked / "results" / "latest")
+    if not any(r["guest_port"] == "8000" for r in rb):
+        raise AssertionError("relocated restore did not replay the httpd bridge")
+    logger.info(f"[{slug}] OK: pack->unpack(elsewhere)->--from-snapshot RESTORED")
+
+
+def _container_running(name):
+    out = subprocess.run(["docker", "ps", "--filter", f"name=^{name}$",
+                          "--format", "{{.Names}}"], capture_output=True, text=True)
+    return name in out.stdout.split()
+
+
+def run_socket(image, arch, kernel):
+    slug = f"{arch}_{kernel}_socket"
+    cname = f"{slug}_s"
+    subprocess.run(["docker", "rm", "-f", cname], capture_output=True)
+    project = build_project(image, arch, slug)
+    qcows = project / "qcows"
+
+    cfg = write_config(project, kernel, {"save_at": "manual", "tag": "warm"},
+                       INIT_STAYALIVE, PLUGINS)
+
+    # Launch the run in the background so we can poke its socket while it's up.
+    save_log = proj_dir / f"snappaths_{slug}_save.txt"
+    cmd = [PENGUIN, "--image", image, "--name", cname, "run", cfg]
+    logger.info("$ (bg) " + " ".join(cmd))
+    proc = subprocess.Popen(cmd, cwd=proj_dir, stdout=open(save_log, "w"),
+                            stderr=subprocess.STDOUT)
+    try:
+        # Wait for the guest to be up and RemoteCtrl listening.
+        deadline = time.time() + 75
+        ready = False
+        while time.time() < deadline:
+            blob = save_log.read_text(errors="replace")
+            # RemoteCtrl socket up + the guest httpd bound & bridged (:8000 in
+            # the VPN bind line). The init's "snap-init up" echo goes to the
+            # guest console, not this (host stdout) log, so don't wait on it.
+            if "RemoteCtrl: Listening" in blob and ":8000" in blob:
+                ready = True
+                break
+            if proc.poll() is not None:
+                raise AssertionError("run exited before becoming ready")
+            time.sleep(2)
+        if not ready:
+            raise AssertionError("run never reached RemoteCtrl-listening + init-up")
+        time.sleep(5)  # let httpd bind + VPN bridge
+
+        # Find the socket inside the container and trigger a save over it.
+        sock = subprocess.check_output(
+            ["docker", "exec", cname, "sh", "-c",
+             "find / -name remotectrl.sock 2>/dev/null | head -1"]).decode().strip()
+        if not sock:
+            raise AssertionError("remotectrl.sock not found in container")
+        logger.info(f"[{slug}] socket: {sock}; sending `snapshot save`")
+        out = subprocess.run(
+            ["docker", "exec", cname, "snapshot", "save", "--tag", "warm",
+             "--when", "now", "--sock", sock],
+            capture_output=True, text=True)
+        logger.info(f"[{slug}] cli_snapshot rc={out.returncode} out={out.stdout.strip()} "
+                    f"err={out.stderr.strip()}")
+        if out.returncode != 0:
+            raise AssertionError("cli_snapshot save command failed")
+
+        # Wait for the save to land in the overlay (host sidecar appears on save).
+        deadline = time.time() + 40
+        while time.time() < deadline:
+            if (qcows / "snapshot_warm.host.json").is_file():
+                break
+            time.sleep(2)
+        else:
+            subprocess.run(["tail", "-n", "60", str(save_log)])
+            raise AssertionError("socket-triggered save did not produce the snapshot")
+        logger.info(f"[{slug}] OK: socket-triggered snapshot saved")
+    finally:
+        subprocess.run(["docker", "rm", "-f", cname], capture_output=True)
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    for n in ("snapshot_warm.qcow2", "snapshot_warm.config.yaml"):
+        if not (qcows / n).is_file():
+            raise AssertionError(f"socket save missing {n}")
+
+    # Confirm the socket-made snapshot is restorable.
+    assert_restore(image, cfg, "warm", slug)
+    logger.info(f"[{slug}] OK: socket-triggered snapshot RESTORED cross-process")
+
+
+@click.command()
+@click.option("--image", "-i", required=True)
+@click.option("--arch", "-a", default="armel")
+@click.option("--kernel", "-k", default="4.10")
+@click.option("--mode", "-m", type=click.Choice(["pack", "socket", "all"]), default="all")
+def main(image, arch, kernel, mode):
+    if proj_dir.joinpath("projects").exists():
+        shutil.rmtree(proj_dir / "projects")
+    modes = ["pack", "socket"] if mode == "all" else [mode]
+    results = {}
+    for m in modes:
+        logger.info(f"########## {m} ({arch}/{kernel}) ##########")
+        try:
+            (run_pack if m == "pack" else run_socket)(image, arch, kernel)
+            results[m] = "PASS"
+        except Exception as e:
+            results[m] = f"FAIL: {e}"
+            logger.error(f"########## {m}: FAIL: {e} ##########")
+    logger.info("================ SUMMARY ================")
+    for m, st in results.items():
+        logger.info(f"  {m:8} {st}")
+    if any(not s.startswith("PASS") for s in results.values()):
+        raise SystemExit(1)
+    logger.info("ALL PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/basic_target/snapshot_paths_test.py
+++ b/tests/unit_tests/basic_target/snapshot_paths_test.py
@@ -7,12 +7,20 @@ Validate the previously-unverified snapshot paths:
            relative backing + base image + sidecars + saved config) surviving
            relocation.
   socket : host-driven trigger.  A run stays alive (no guest-side save); a
-           `snapshot save` command sent over the RemoteCtrl unix socket
-           (`_handle_snapshot` -> Snapshot.request_save) produces the snapshot,
-           which a fresh `--from-snapshot` run then restores.
+           `snapshot save --when now` command sent over the RemoteCtrl unix
+           socket (`_handle_snapshot` -> Snapshot.request_save) produces the
+           snapshot, which a fresh `--from-snapshot` run then restores.
+  syscall: safe-spot arming.  `snapshot save --when next_syscall` over the
+           socket must ARM at the next syscall boundary (one-shot syscalls-API
+           hook) rather than fire instantly, then fire and produce a restorable
+           snapshot.
+  guestcmd: guesthopper control plane post-restore.  After a cross-process
+           `--from-snapshot` restore, the vsock chardev reconnects to a fresh
+           vhost-device-vsock so `guest_cmd` (guesthopper over vsock) still
+           reaches the restored guest.
 
 Usage: python3 snapshot_paths_test.py -i <image> [-a armel] [-k 4.10]
-                                       [-m pack|socket|all]
+                                       [-m pack|socket|syscall|guestcmd|all]
 """
 import logging
 import os
@@ -32,6 +40,9 @@ logger = logging.getLogger("penguin.snappaths")
 TEST_DIR = Path(__file__).resolve().parent
 proj_dir = TEST_DIR
 PENGUIN = str(TEST_DIR.parent.parent.parent / "penguin")
+# Live-mount src/ and pyplugins/ so local edits apply without an image rebuild.
+PYDEV = os.environ.get("SNAP_TEST_PYDEV", "1") == "1"
+WRAPPER_FLAGS = ["--pydev"] if PYDEV else []
 
 # httpd on :8000, wait for the bind, then guest-driven snapshot, then stay alive.
 INIT_SELFSAVE = """#!/igloo/utils/sh
@@ -61,7 +72,7 @@ def run_cmd(cmd, **kw):
 
 
 def penguin(image, *args, log, name=None, check=True):
-    cmd = [PENGUIN, "--image", image]
+    cmd = [PENGUIN, "--image", image] + WRAPPER_FLAGS
     if name:
         cmd += ["--name", name]
     cmd += list(args)
@@ -102,10 +113,13 @@ def build_project(image, arch, slug):
     return Path(proj_dir, f"projects/empty_fs_{slug}")
 
 
-def write_config(project, kernel, snapshot, init_contents, plugins):
+def write_config(project, kernel, snapshot, init_contents, plugins, core_extra=None):
+    core = {"kernel": str(kernel), "timeout": 90, "snapshot": snapshot}
+    if core_extra:
+        core.update(core_extra)
     patch = {
         "env": {"igloo_init": "/snap_init.sh"},
-        "core": {"kernel": str(kernel), "timeout": 90, "snapshot": snapshot},
+        "core": core,
         "static_files": {
             "/snap_init.sh": {"type": "inline_file", "mode": 73, "contents": init_contents},
         },
@@ -219,6 +233,151 @@ def _container_running(name):
     return name in out.stdout.split()
 
 
+def _bg_run(image, cfg, cname, log, *extra,
+            ready_markers=("RemoteCtrl: Listening", ":8000"), timeout_s=90):
+    """Launch a `penguin run` in the background and wait until `ready_markers`
+    all appear in its (host stdout) log. Returns the Popen so the caller can
+    poke the container, then must clean it up."""
+    subprocess.run(["docker", "rm", "-f", cname], capture_output=True)
+    cmd = [PENGUIN, "--image", image, *WRAPPER_FLAGS, "--name", cname,
+           "run", cfg, *extra]
+    logger.info("$ (bg) " + " ".join(cmd))
+    proc = subprocess.Popen(cmd, cwd=proj_dir, stdout=open(log, "w"),
+                            stderr=subprocess.STDOUT)
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        blob = Path(log).read_text(errors="replace")
+        if all(m in blob for m in ready_markers):
+            return proc
+        if proc.poll() is not None:
+            subprocess.run(["tail", "-n", "60", str(log)])
+            raise AssertionError(f"run {cname} exited before ready; see {log}")
+        time.sleep(2)
+    raise AssertionError(f"run {cname} never reached {ready_markers}; see {log}")
+
+
+def _kill_bg(cname, proc):
+    subprocess.run(["docker", "rm", "-f", cname], capture_output=True)
+    try:
+        proc.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def _find_in_container(cname, pattern):
+    out = subprocess.run(
+        ["docker", "exec", cname, "sh", "-c",
+         f"find / -name {pattern} 2>/dev/null | head -1"],
+        capture_output=True, text=True)
+    return out.stdout.strip()
+
+
+def run_syscall(image, arch, kernel):
+    """Safe-spot arming: a host-driven `snapshot save --when next_syscall`
+    must ARM at the next syscall boundary (not fire instantly), then fire and
+    produce a restorable snapshot."""
+    slug = f"{arch}_{kernel}_syscall"
+    cname = f"{slug}_s"
+    project = build_project(image, arch, slug)
+    qcows = project / "qcows"
+    cfg = write_config(project, kernel, {"save_at": "manual", "tag": "warm"},
+                       INIT_STAYALIVE, PLUGINS)
+    save_log = proj_dir / f"snappaths_{slug}_save.txt"
+    proc = _bg_run(image, cfg, cname, save_log)
+    try:
+        time.sleep(5)  # let httpd bind + VPN bridge
+        sock = _find_in_container(cname, "remotectrl.sock")
+        if not sock:
+            raise AssertionError("remotectrl.sock not found in container")
+        logger.info(f"[{slug}] socket: {sock}; arming `snapshot save --when next_syscall`")
+        out = subprocess.run(
+            ["docker", "exec", cname, "snapshot", "save", "--tag", "warm",
+             "--when", "next_syscall", "--sock", sock],
+            capture_output=True, text=True)
+        logger.info(f"[{slug}] cli_snapshot rc={out.returncode} out={out.stdout.strip()} "
+                    f"err={out.stderr.strip()}")
+        if out.returncode != 0:
+            raise AssertionError("cli_snapshot --when next_syscall failed")
+
+        # The save must ARM at the syscall boundary, then fire (the guest's
+        # sleep loop hits syscalls constantly, so it fires within seconds).
+        deadline = time.time() + 40
+        while time.time() < deadline:
+            if (qcows / "snapshot_warm.host.json").is_file():
+                break
+            time.sleep(2)
+        else:
+            subprocess.run(["tail", "-n", "60", str(save_log)])
+            raise AssertionError("next_syscall-armed save never fired")
+        blob = save_log.read_text(errors="replace")
+        if "Armed snapshot" not in blob or "at syscall" not in blob:
+            raise AssertionError("log does not show syscall-boundary arming")
+        logger.info(f"[{slug}] OK: armed at syscall boundary, fired, snapshot saved")
+    finally:
+        _kill_bg(cname, proc)
+
+    for n in ("snapshot_warm.qcow2", "snapshot_warm.config.yaml"):
+        if not (qcows / n).is_file():
+            raise AssertionError(f"syscall save missing {n}")
+    assert_restore(image, cfg, "warm", slug)
+    logger.info(f"[{slug}] OK: next_syscall snapshot RESTORED cross-process")
+
+
+def run_guestcmd(image, arch, kernel):
+    """guesthopper control plane post-restore: after a cross-process restore,
+    the vsock chardev must reconnect to a fresh vhost-device-vsock so
+    `guest_cmd` (guesthopper over vsock) still works against the restored
+    guest."""
+    slug = f"{arch}_{kernel}_guestcmd"
+    project = build_project(image, arch, slug)
+    qcows = project / "qcows"
+    # guest_cmd: true starts guesthopper in the guest; it is captured in the
+    # snapshot's frozen RAM and must talk over a reconnected vsock on restore.
+    cfg = write_config(project, kernel, {"save_at": "manual", "tag": "warm"},
+                       INIT_SELFSAVE.replace("TAG", "warm"), {"vpn_test": {}},
+                       core_extra={"guest_cmd": True})
+
+    logger.info(f"[{slug}] SAVE run (guest-driven) with guesthopper running")
+    penguin(image, "run", cfg, log=f"snappaths_{slug}_save.txt", name=f"{slug}_s")
+    for n in ("snapshot_warm.qcow2", "snapshot_warm.config.yaml"):
+        if not (qcows / n).is_file():
+            raise AssertionError(f"save did not produce {n}")
+    logger.info(f"[{slug}] OK: snapshot saved with guesthopper in frozen RAM")
+
+    cname = f"{slug}_r"
+    rlog = proj_dir / f"snappaths_{slug}_restore.txt"
+    proc = _bg_run(image, cfg, cname, rlog, "--from-snapshot", "warm",
+                   ready_markers=("Booting from snapshot", "Re-establishing"))
+    try:
+        # Wait for the host vsock UDS to come up, then let guesthopper's vsock
+        # reconnect after the chardev re-attaches.
+        deadline = time.time() + 40
+        vsock = ""
+        while time.time() < deadline:
+            vsock = _find_in_container(cname, "vsocket")
+            if vsock:
+                break
+            time.sleep(2)
+        if not vsock:
+            raise AssertionError("vsocket not found in restore container")
+        logger.info(f"[{slug}] vsocket: {vsock}; running guest_cmd post-restore")
+        time.sleep(5)
+
+        marker = "HELLO_FROM_RESTORED_GUEST"
+        out = subprocess.run(
+            ["docker", "exec", cname, "guest_cmd", "--socket", vsock,
+             f"/igloo/utils/busybox echo {marker}"],
+            capture_output=True, text=True, timeout=60)
+        logger.info(f"[{slug}] guest_cmd rc={out.returncode} out={out.stdout.strip()!r} "
+                    f"err={out.stderr.strip()!r}")
+        if out.returncode != 0 or marker not in out.stdout:
+            raise AssertionError("guest_cmd failed post-restore (vsock did not "
+                                 "reconnect to guesthopper)")
+        logger.info(f"[{slug}] OK: guest_cmd works post-restore (vsock reconnected)")
+    finally:
+        _kill_bg(cname, proc)
+
+
 def run_socket(image, arch, kernel):
     slug = f"{arch}_{kernel}_socket"
     cname = f"{slug}_s"
@@ -231,7 +390,7 @@ def run_socket(image, arch, kernel):
 
     # Launch the run in the background so we can poke its socket while it's up.
     save_log = proj_dir / f"snappaths_{slug}_save.txt"
-    cmd = [PENGUIN, "--image", image, "--name", cname, "run", cfg]
+    cmd = [PENGUIN, "--image", image, *WRAPPER_FLAGS, "--name", cname, "run", cfg]
     logger.info("$ (bg) " + " ".join(cmd))
     proc = subprocess.Popen(cmd, cwd=proj_dir, stdout=open(save_log, "w"),
                             stderr=subprocess.STDOUT)
@@ -300,16 +459,20 @@ def run_socket(image, arch, kernel):
 @click.option("--image", "-i", required=True)
 @click.option("--arch", "-a", default="armel")
 @click.option("--kernel", "-k", default="4.10")
-@click.option("--mode", "-m", type=click.Choice(["pack", "socket", "all"]), default="all")
+@click.option("--mode", "-m",
+              type=click.Choice(["pack", "socket", "syscall", "guestcmd", "all"]),
+              default="all")
 def main(image, arch, kernel, mode):
     if proj_dir.joinpath("projects").exists():
         shutil.rmtree(proj_dir / "projects")
-    modes = ["pack", "socket"] if mode == "all" else [mode]
+    runners = {"pack": run_pack, "socket": run_socket,
+               "syscall": run_syscall, "guestcmd": run_guestcmd}
+    modes = list(runners) if mode == "all" else [mode]
     results = {}
     for m in modes:
         logger.info(f"########## {m} ({arch}/{kernel}) ##########")
         try:
-            (run_pack if m == "pack" else run_socket)(image, arch, kernel)
+            runners[m](image, arch, kernel)
             results[m] = "PASS"
         except Exception as e:
             results[m] = f"FAIL: {e}"

--- a/tests/unit_tests/basic_target/snapshot_test.py
+++ b/tests/unit_tests/basic_target/snapshot_test.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+End-to-end snapshot test: save a VM snapshot at readiness, then start a fresh
+penguin run from that snapshot and confirm it restored.
+
+Reuses the basic_target machinery (busybox-only empty_fs) to build a project,
+injects a stay-alive init (so the guest reaches readiness and remains up while
+the snapshot is taken), then drives two runs:
+  1. save run  : core.snapshot.save_at=readiness  (+ short timeout)
+  2. restore   : penguin run --from-snapshot <tag>
+
+Usage: python3 snapshot_test.py -i <image> [-a armel] [-k 4.10]
+"""
+import logging
+import os
+from pathlib import Path
+import click
+import shutil
+import subprocess
+import yaml
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+                    datefmt="%H:%M:%S")
+logger = logging.getLogger("penguin.snaptest")
+
+TEST_DIR = Path(__file__).resolve().parent
+proj_dir = TEST_DIR
+PENGUIN = str(TEST_DIR.parent.parent.parent / "penguin")  # repo-root ./penguin
+FS_DIR = Path(proj_dir, "fs")
+TAG = "boot"
+
+# Stay-alive init so the guest reaches igloo_init readiness and remains up while
+# the snapshot is captured (the stock empty_fs init exits immediately).
+INIT_SH = """#!/igloo/utils/sh
+/busybox echo "snap-init up"
+while true; do /busybox sleep 1; done
+"""
+
+
+def run_cmd(cmd, **kw):
+    logger.info(f"$ {cmd}")
+    return subprocess.run(cmd, shell=True, check=True, **kw)
+
+
+def penguin(image, *args, log="snap_log.txt"):
+    cmd = " ".join([PENGUIN, "--image", image, *args])
+    logger.info(f"$ {cmd}")
+    try:
+        subprocess.run(cmd, cwd=proj_dir, shell=True, check=True,
+                       stdout=open(proj_dir / log, "w"), stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError:
+        subprocess.run(["tail", "-n", "120", str(proj_dir / log)])
+        raise
+
+
+def build_project(image, arch):
+    FS_DIR.mkdir(exist_ok=True)
+    (FS_DIR / "bin").mkdir(exist_ok=True)
+    cid = subprocess.check_output(f"docker create {image}", shell=True).decode().strip()
+    run_cmd(f"docker cp -L {cid}:/igloo_static/utils.bin/busybox.{arch} {FS_DIR}/busybox")
+    run_cmd(f"docker rm -v {cid}")
+    run_cmd(f"tar -czf {TEST_DIR}/empty_fs.tar.gz -C {FS_DIR} .")
+    penguin(image, "init", f"{TEST_DIR}/empty_fs.tar.gz", "--force", log="snap_init.txt")
+    return Path(proj_dir, "projects/empty_fs")
+
+
+def write_patch(project_path, kernel, snapshot):
+    """Write a patch that pins kernel, a stay-alive init, and snapshot config,
+    and append it to the project's config patches. Returns the config path."""
+    patch = {
+        "env": {"igloo_init": "/snap_init.sh"},
+        "core": {"kernel": str(kernel), "timeout": 45, "snapshot": snapshot},
+        "static_files": {
+            "/snap_init.sh": {"type": "inline_file", "mode": 73, "contents": INIT_SH},
+        },
+    }
+    patch_path = project_path / "patch_snap.yaml"
+    with open(patch_path, "w") as f:
+        yaml.dump(patch, f, sort_keys=False)
+
+    cfg_path = project_path / "config.yaml"
+    with open(cfg_path) as f:
+        cfg = yaml.safe_load(f)
+    patches = cfg.setdefault("patches", [])
+    if "patch_snap.yaml" not in patches:
+        patches.append("patch_snap.yaml")
+    with open(cfg_path, "w") as f:
+        yaml.dump(cfg, f, sort_keys=False)
+    return str(cfg_path)
+
+
+@click.command()
+@click.option("--image", "-i", required=True)
+@click.option("--arch", "-a", default="armel")
+@click.option("--kernel", "-k", default="4.10")
+def main(image, arch, kernel):
+    if proj_dir.joinpath("projects").exists():
+        shutil.rmtree(proj_dir / "projects")
+    project = build_project(image, arch)
+    qcows = project / "qcows"
+
+    # --- 1. SAVE run -------------------------------------------------------
+    logger.info("=== SAVE run (save_at=readiness) ===")
+    config = write_patch(project, kernel, {"save_at": "readiness", "tag": TAG})
+    penguin(image, "run", config, log="snap_save.txt")
+
+    overlay = qcows / f"snapshot_{TAG}.qcow2"
+    meta = qcows / f"snapshot_{TAG}.meta.json"
+    sidecar = project / "results" / "latest" / "snapshot.yaml"
+    for p in (overlay, meta):
+        if not p.is_file():
+            subprocess.run(["tail", "-n", "60", str(proj_dir / "snap_save.txt")])
+            raise AssertionError(f"expected snapshot artifact missing: {p}")
+    logger.info(f"OK: overlay={overlay.stat().st_size}B, meta={meta.read_text()}")
+    if sidecar.is_file():
+        logger.info(f"OK: results sidecar {sidecar.read_text().strip()}")
+
+    save_console = project / "results" / "latest" / "console.log"
+    blob = save_console.read_text(errors="replace") if save_console.exists() else ""
+    if "non-migratable" in blob or "State blocked" in blob:
+        raise AssertionError("savevm was blocked by a non-migratable device")
+    # Confirm a savevm internal snapshot actually exists in the overlay. The
+    # overlay records its backing at the absolute container path it was created
+    # with (/host_empty_fs/qcows/...), so mount there for the backing to resolve.
+    info = subprocess.check_output(
+        f"docker run --rm -v {qcows}:/host_empty_fs/qcows {image} "
+        f"qemu-img snapshot -l /host_empty_fs/qcows/snapshot_{TAG}.qcow2",
+        shell=True).decode()
+    logger.info(f"qemu-img snapshot -l:\n{info}")
+    if TAG not in info:
+        raise AssertionError(f"no internal VM snapshot '{TAG}' found in overlay")
+
+    # --- 2. RESTORE run ----------------------------------------------------
+    logger.info("=== RESTORE run (--from-snapshot) ===")
+    config = write_patch(project, kernel, {"boot_from": TAG})
+    penguin(image, "run", config, "--from-snapshot", TAG, log="snap_restore.txt")
+    rlog = (proj_dir / "snap_restore.txt").read_text(errors="replace")
+    if "Restoring from snapshot" in rlog or "Booting from snapshot" in rlog:
+        logger.info("OK: restore log line present")
+    else:
+        logger.warning("no explicit restore log line; inspect snap_restore.txt")
+    logger.info("Snapshot save+restore test PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/basic_target/snapshot_test.py
+++ b/tests/unit_tests/basic_target/snapshot_test.py
@@ -12,7 +12,6 @@ the snapshot is taken), then drives two runs:
 Usage: python3 snapshot_test.py -i <image> [-a armel] [-k 4.10]
 """
 import logging
-import os
 from pathlib import Path
 import click
 import shutil

--- a/tests/unit_tests/basic_target/snapshot_vpn_test.py
+++ b/tests/unit_tests/basic_target/snapshot_vpn_test.py
@@ -22,7 +22,6 @@ Run via --pydev so the VPN/snapshot pyplugin changes apply without an image
 rebuild:  python3 snapshot_vpn_test.py -i <image> [-a armel] [-k 4.10]
 """
 import logging
-import os
 from pathlib import Path
 import click
 import shutil

--- a/tests/unit_tests/basic_target/snapshot_vpn_test.py
+++ b/tests/unit_tests/basic_target/snapshot_vpn_test.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Cross-process snapshot test exercising the *complex* restore paths:
+
+  * vhost-user-vsock chardev reconnect into a freshly-launched QEMU (increment 3)
+  * VPN bridge replay after restore (VPN.on_restore -> same host port)
+  * the vsock data plane working again post-restore (HTTP through the bridge)
+
+Shape:
+  1. SAVE run  : boot the guest, start `busybox httpd` on :8000, wait for the
+     bind to be bridged host-side, then fire the `snapshot_save` hypercall from
+     inside the guest (when=now) and stay alive. The bridge is live at snapshot
+     time, so it lands in the host-side sidecar.
+  2. RESTORE   : `penguin run --from-snapshot boot` in a *fresh* process.
+     -loadvm restores RAM+devices (httpd still running), the vsock device
+     reconnects to a new vhost-device-vsock, VPN.on_restore replays the bridge
+     on the SAME host port and re-publishes on_bind, and the bundled vpn_test
+     plugin re-connects through the bridge -> proves the whole vsock path is
+     alive again across processes.
+
+Run via --pydev so the VPN/snapshot pyplugin changes apply without an image
+rebuild:  python3 snapshot_vpn_test.py -i <image> [-a armel] [-k 4.10]
+"""
+import logging
+import os
+from pathlib import Path
+import click
+import shutil
+import subprocess
+import yaml
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+                    datefmt="%H:%M:%S")
+logger = logging.getLogger("penguin.snapvpn")
+
+TEST_DIR = Path(__file__).resolve().parent
+proj_dir = TEST_DIR
+PENGUIN = str(TEST_DIR.parent.parent.parent / "penguin")  # repo-root ./penguin
+TAG = "boot"
+
+# Guest init: serve the rootfs over httpd:8000 (so vpn_test's GET of
+# /igloo/boot/preinit resolves, exactly as the netbinds test expects), wait for
+# the bind to appear (8000 == 0x1F40 in /proc/net/tcp*), give the host a moment
+# to bridge it, then take a snapshot from inside the guest and stay alive.
+INIT_SH = """#!/igloo/utils/sh
+/igloo/utils/busybox echo "snap-vpn init up"
+/igloo/utils/busybox httpd -f -p 8000 -h / &
+i=0
+while [ $i -lt 25 ]; do
+  if /igloo/utils/busybox grep -qi ":1F40" /proc/net/tcp /proc/net/tcp6 2>/dev/null; then
+    /igloo/utils/busybox echo "snap-vpn httpd bound :8000"
+    break
+  fi
+  /igloo/utils/busybox sleep 1
+  i=$((i + 1))
+done
+# Let NetBinds -> VPN bridge the listener host-side before we capture.
+/igloo/utils/busybox sleep 4
+/igloo/utils/busybox echo "snap-vpn requesting snapshot"
+/igloo/utils/send_hypercall snapshot_save boot now
+while true; do /igloo/utils/busybox sleep 1; done
+"""
+
+
+def run_cmd(cmd, **kw):
+    logger.info(f"$ {cmd}")
+    return subprocess.run(cmd, shell=True, check=True, **kw)
+
+
+def penguin(image, *args, log="snapvpn_log.txt"):
+    cmd = " ".join([PENGUIN, "--image", image, *args])
+    logger.info(f"$ {cmd}")
+    try:
+        subprocess.run(cmd, cwd=proj_dir, shell=True, check=True,
+                       stdout=open(proj_dir / log, "w"), stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError:
+        subprocess.run(["tail", "-n", "150", str(proj_dir / log)])
+        raise
+
+
+def build_project(image, arch, slug):
+    """Build a per-arch empty_fs project (named ``empty_fs_<slug>``)."""
+    fs_dir = Path(proj_dir, f"fs_{slug}")
+    if fs_dir.exists():
+        shutil.rmtree(fs_dir)
+    fs_dir.mkdir()
+    (fs_dir / "bin").mkdir()
+    # A real arch-bearing binary so `penguin init` can detect the architecture.
+    cid = subprocess.check_output(f"docker create {image}", shell=True).decode().strip()
+    run_cmd(f"docker cp -L {cid}:/igloo_static/utils.bin/busybox.{arch} {fs_dir}/busybox")
+    run_cmd(f"docker rm -v {cid}")
+    tarball = Path(TEST_DIR, f"empty_fs_{slug}.tar.gz")
+    run_cmd(f"tar -czf {tarball} -C {fs_dir} .")
+    penguin(image, "init", str(tarball), "--force", log=f"snapvpn_{slug}_init.txt")
+    return Path(proj_dir, f"projects/empty_fs_{slug}")
+
+
+def write_patch(project_path, kernel, snapshot, plugins=None):
+    """Pin kernel, stay-alive httpd init, and snapshot config.
+
+    ``plugins`` lets a caller control the non-default plugin set; the restore
+    run deliberately omits vpn_test so that vpn_test running anyway proves the
+    snapshot's *saved* config (which had it) was used, not this provided one.
+    """
+    patch = {
+        "env": {"igloo_init": "/snap_init.sh"},
+        "core": {"kernel": str(kernel), "timeout": 90, "snapshot": snapshot},
+        "static_files": {
+            "/snap_init.sh": {"type": "inline_file", "mode": 73, "contents": INIT_SH},
+        },
+        "plugins": plugins if plugins is not None else {"vpn_test": {}},
+    }
+    patch_path = project_path / "patch_snapvpn.yaml"
+    with open(patch_path, "w") as f:
+        yaml.dump(patch, f, sort_keys=False)
+
+    cfg_path = project_path / "config.yaml"
+    with open(cfg_path) as f:
+        cfg = yaml.safe_load(f)
+    patches = cfg.setdefault("patches", [])
+    if "patch_snapvpn.yaml" not in patches:
+        patches.append("patch_snapvpn.yaml")
+    with open(cfg_path, "w") as f:
+        yaml.dump(cfg, f, sort_keys=False)
+    return str(cfg_path)
+
+
+def read_bridges(results_dir):
+    """Parse vpn_bridges.csv -> list of dicts."""
+    csv = results_dir / "vpn_bridges.csv"
+    if not csv.is_file():
+        return []
+    rows = []
+    lines = csv.read_text().strip().splitlines()
+    for line in lines[1:]:
+        parts = line.split(",")
+        if len(parts) == 6:
+            rows.append(dict(zip(
+                ["procname", "ipvn", "domain", "guest_ip", "guest_port", "host_port"],
+                parts)))
+    return rows
+
+
+def http_bridge_port(rows):
+    for r in rows:
+        if r["guest_port"] == "8000" and r["domain"] == "tcp":
+            return int(r["host_port"])
+    return None
+
+
+def _save_run(image, arch, slug, kernel):
+    """Shared SAVE phase: boot, bridge httpd, guest-driven snapshot. Returns
+    (project, save_port)."""
+    project = build_project(image, arch, slug)
+    qcows = project / "qcows"
+
+    logger.info(f"[{slug}] === SAVE run (guest-driven snapshot_save after bind) ===")
+    # SAVE config carries vpn_test; the restore configs below deliberately omit it.
+    config = write_patch(project, kernel, {"save_at": "manual", "tag": TAG},
+                         plugins={"vpn_test": {}})
+    penguin(image, "run", config, log=f"snapvpn_{slug}_save.txt")
+
+    overlay = qcows / f"snapshot_{TAG}.qcow2"
+    host_sidecar = qcows / f"snapshot_{TAG}.host.json"
+    saved_cfg = qcows / f"snapshot_{TAG}.config.yaml"
+    for p in (overlay, host_sidecar, saved_cfg):
+        if not p.is_file():
+            subprocess.run(["tail", "-n", "80", str(proj_dir / f"snapvpn_{slug}_save.txt")])
+            raise AssertionError(f"expected snapshot artifact missing: {p}")
+    logger.info(f"[{slug}] OK: overlay={overlay.stat().st_size}B, saved config persisted")
+    if '"VPN"' not in host_sidecar.read_text():
+        raise AssertionError("host sidecar did not capture VPN bridge state")
+    if "vpn_test" not in saved_cfg.read_text():
+        raise AssertionError("saved config did not capture the resolved plugin set")
+
+    save_results = project / "results" / "latest"
+    save_port = http_bridge_port(read_bridges(save_results))
+    if save_port is None:
+        raise AssertionError("SAVE run never bridged the guest httpd :8000")
+    save_vpn_txt = save_results / "vpn_test.txt"
+    if not (save_vpn_txt.is_file() and "successful" in save_vpn_txt.read_text()):
+        raise AssertionError("SAVE run VPN data-plane check failed (pre-snapshot)")
+    logger.info(f"[{slug}] OK: SAVE bridged httpd :8000 -> host :{save_port}, "
+                "data plane works (pre-snapshot)")
+    return project, save_port
+
+
+def run_one(image, arch, kernel):
+    """SAVE + cross-process RESTORE that DEFAULTS to the snapshot's saved config.
+
+    The restore is launched with a config that *omits* vpn_test; vpn_test
+    running anyway proves the snapshot's saved config (which had it) was loaded.
+    """
+    slug = f"{arch}_{kernel}"
+    project, save_port = _save_run(image, arch, slug, kernel)
+
+    logger.info(f"[{slug}] === RESTORE (default to saved config; provided omits vpn_test) ===")
+    config = write_patch(project, kernel, {"boot_from": TAG, "tag": TAG}, plugins={})
+    penguin(image, "run", config, "--from-snapshot", TAG,
+            log=f"snapvpn_{slug}_restore.txt")
+    rlog = (proj_dir / f"snapvpn_{slug}_restore.txt").read_text(errors="replace")
+
+    if "Booting from snapshot" not in rlog:
+        raise AssertionError("restore did not boot from the snapshot overlay")
+    if "Loaded the config this snapshot was saved with" not in rlog:
+        raise AssertionError("restore did not default to the snapshot's saved config")
+    if "Re-establishing" not in rlog:
+        raise AssertionError("VPN.on_restore did not replay bridges")
+    logger.info(f"[{slug}] OK: restore loaded SAVED config and replayed bridges")
+
+    restore_results = project / "results" / "latest"
+    restore_port = http_bridge_port(read_bridges(restore_results))
+    if restore_port is None:
+        raise AssertionError("RESTORE run did not re-establish the httpd bridge")
+    if restore_port != save_port:
+        raise AssertionError(
+            f"bridge host port not stable across restore: "
+            f"save={save_port} restore={restore_port}")
+    logger.info(f"[{slug}] OK: bridge replayed on SAME host port :{restore_port}")
+
+    # vpn_test was NOT in the provided restore config — if it ran, the saved
+    # config was used. It also exercises the restored vsock data plane end-to-end.
+    restore_vpn_txt = restore_results / "vpn_test.txt"
+    if not (restore_vpn_txt.is_file() and "successful" in restore_vpn_txt.read_text()):
+        subprocess.run(["tail", "-n", "150", str(proj_dir / f"snapvpn_{slug}_restore.txt")])
+        raise AssertionError(
+            "vpn_test did not run/succeed after restore: saved config was not "
+            "used, or the restored vsock data plane is broken")
+    logger.info(f"[{slug}] OK: vpn_test ran from SAVED config + data plane works "
+                "after cross-process restore")
+
+
+def run_optout(image, arch, kernel):
+    """SAVE + RESTORE with --ignore-saved-config: the provided config (which
+    omits vpn_test) must win, so vpn_test must NOT run, while the snapshot
+    still restores and VPN bridges still replay."""
+    slug = f"{arch}_{kernel}_optout"
+    project, save_port = _save_run(image, arch, slug, kernel)
+
+    logger.info(f"[{slug}] === RESTORE --ignore-saved-config (provided config wins) ===")
+    config = write_patch(project, kernel, {"boot_from": TAG, "tag": TAG}, plugins={})
+    penguin(image, "run", config, "--from-snapshot", TAG, "--ignore-saved-config",
+            log=f"snapvpn_{slug}_restore.txt")
+    rlog = (proj_dir / f"snapvpn_{slug}_restore.txt").read_text(errors="replace")
+
+    if "--ignore-saved-config" not in rlog:
+        raise AssertionError("opt-out path did not log ignoring the saved config")
+    if "Booting from snapshot" not in rlog or "Re-establishing" not in rlog:
+        raise AssertionError("opt-out restore did not boot/replay as expected")
+
+    restore_results = project / "results" / "latest"
+    if (restore_results / "vpn_test.txt").is_file():
+        raise AssertionError(
+            "vpn_test ran despite --ignore-saved-config + provided config "
+            "omitting it: the saved config was NOT correctly overridden")
+    logger.info(f"[{slug}] OK: provided config honored (vpn_test absent), "
+                "snapshot still restored + bridges replayed")
+
+
+# Mirror tests/unit_tests/test_target/test.py's known-good arch/kernel matrix.
+DEFAULT_KERNELS = ["4.10", "6.13"]
+DEFAULT_ARCHES = ["armel", "aarch64", "mipsel", "mipseb",
+                  "mips64el", "mips64eb", "x86_64"]
+# Arches that only boot under specific kernels.
+NONDEFAULT_KERNEL_ARCHES = {"6.13": ["powerpc64", "loongarch64", "riscv64"]}
+
+
+@click.command()
+@click.option("--image", "-i", required=True)
+@click.option("--arch", "-a", multiple=True, default=DEFAULT_ARCHES)
+@click.option("--kernel", "-k", multiple=True, default=DEFAULT_KERNELS)
+@click.option("--mode", "-m", type=click.Choice(["default", "optout"]), default="default",
+              help="default: restore loads the snapshot's saved config. "
+                   "optout: restore with --ignore-saved-config (provided config wins).")
+def main(image, arch, kernel, mode):
+    if proj_dir.joinpath("projects").exists():
+        shutil.rmtree(proj_dir / "projects")
+    run_fn = run_one if mode == "default" else run_optout
+
+    allowed = set(DEFAULT_ARCHES)
+    for arches in NONDEFAULT_KERNEL_ARCHES.values():
+        allowed.update(arches)
+    if any(a not in allowed for a in arch):
+        raise SystemExit(f"Unsupported arch; allowed: {sorted(allowed)}")
+
+    combos = []
+    for k in kernel:
+        for a in arch:
+            restricted = {kern for kern, arches in NONDEFAULT_KERNEL_ARCHES.items()
+                          if a in arches}
+            if restricted and k not in restricted:
+                continue
+            combos.append((a, k))
+
+    results = {}
+    for a, k in combos:
+        slug = f"{a}_{k}_{mode}"
+        logger.info(f"########## {slug} ##########")
+        try:
+            run_fn(image, a, k)
+            results[slug] = "PASS"
+            logger.info(f"########## {slug}: PASS ##########")
+        except Exception as e:
+            results[slug] = f"FAIL: {e}"
+            logger.error(f"########## {slug}: FAIL: {e} ##########")
+
+    logger.info("================ SUMMARY ================")
+    for slug, status in results.items():
+        logger.info(f"  {slug:24} {status}")
+    failed = [s for s, st in results.items() if not st.startswith("PASS")]
+    if failed:
+        raise SystemExit(f"{len(failed)}/{len(results)} combos FAILED: {failed}")
+    logger.info(f"ALL {len(results)} combos PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Configuration-driven VM snapshots (QEMU internal `savevm`/`loadvm`): capture a running guest and resume it later — same-process, or in a fresh cross-process `penguin run`.

**Requires** the matching QEMU changes: rehosting/qemu#10 (migratable `vhost-user-vsock` + `penguin_*_snapshot` ABI).

## Changes
- **`core.snapshot`** config (`save_at: readiness|manual`, `boot_from`, `tag`, `backend`) with a coarse **boot-fingerprint** that refuses an incoherent restore.
- **`Snapshot` pyplugin** — guest- and host-driven save triggers, safe-spot arming (`next_syscall` / `symbol` / `now`), host-side state sidecar; RemoteCtrl `_handle_snapshot` + `pengutils … snapshot` CLI.
- **Restore defaults to the exact config the snapshot was saved with** (persisted next to the overlay); `run --ignore-saved-config` opts out.
- **VPN** bridges replay on restore on the **same host ports**, plus `on_bind` re-publish so subscribers stay symmetric across a restore.
- **`pack --with-snapshot`** bundles a portable overlay + base + sidecars.
- **`int_to_hex_representer` fix** (it crashed on any int > 10): octal file modes, hex addresses, decimal otherwise; gave `CoreDumper` a `!!binary` representer and switched `core_config.yaml` reads to `CoreLoader`.
- Regenerated `docs/schema_doc.md`; added cross-process + VPN snapshot tests.

## Validation
- Save + **cross-process restore on all 17 arch/kernel combos** (armel, aarch64, mips{el,eb}, mips64{el,eb}, x86_64 on 4.10+6.13; powerpc64, loongarch64, riscv64 on 6.13). Each verifies the bridge replays on the same host port and httpd is reachable through the restored vsock data plane.
- Saved-config default proven (restore config that omits `vpn_test` still runs it from the saved config); `--ignore-saved-config` proven to honor the provided config.
- `int_to_hex_representer`/`core_config.yaml` round-trips (octal modes + `!!binary` blobs); netbinds regression passes (only the pre-existing flaky `udp_echo` fails, identically with/without this change).

## Not yet exercised on-target (follow-up)
- Host-driven trigger via the RemoteCtrl socket + `cli_snapshot`.
- Safe-spot arming `next_syscall` / `symbol` (only `now` exercised).
- `pack --with-snapshot` → unpack-elsewhere → `--from-snapshot` round-trip.
- `guest_cmd` (guesthopper control plane) post-restore.

## Deliberately deferred (design seams only)
- `core.snapshot.backend: file` (standalone migration bundle) — guarded as not-implemented.
- restore-many / fork (pristine disk copy + per-restore host reset).
- Per-access fingerprint precision (coarse for now).