### PR TITLE
CI: stop pinning moby/buildkit:master (regressed /proc/acpi on runners)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,7 +96,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            image=moby/buildkit:master
             network=host
           buildkitd-config-inline: |
             [registry."${{ env.REGISTRY }}"]
@@ -168,7 +167,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            image=moby/buildkit:master
             network=host
           buildkitd-config-inline: |
             [registry."${{ env.REGISTRY }}"]
@@ -258,7 +256,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
-            image=moby/buildkit:master
             network=host
           buildkitd-config-inline: |
             [registry."${{ env.REGISTRY }}"]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -85,7 +85,6 @@ jobs:
             uses: docker/setup-buildx-action@v3
             with:
               driver-opts: |
-                image=moby/buildkit:master
                 network=host
               buildkitd-config-inline: |
                 [registry."${{ secrets.REHOSTING_ARC_REGISTRY }}"]


### PR DESCRIPTION
## Problem

The **Release Container** run on `main` failed ([run](https://github.com/rehosting/penguin/actions/runs/27710227664)) with:

```
runc run failed: unable to start container process: error during container init:
can't mask dir "/proc/acpi": mount src=tmpfs, dst=/proc/acpi, flags=MS_RDONLY,
data=nr_blocks=1,nr_inodes=1: invalid argument
```

It fails the first `RUN` needing container init. This is pre-existing and unrelated to recent merges: all four `setup-buildx-action` steps (3 in `build.yaml`, 1 in `publish.yaml`) pin the **floating** `moby/buildkit:master`, and a recent master regressed on the runners (runc/kernel interaction masking `/proc/acpi`).

## Fix

Drop the `image=moby/buildkit:master` override from all four buildx setups so buildx uses its **default pinned-stable** buildkit. `network=host` and the inline registry config are kept unchanged.

Same regression and same fix as `rehosting/embedded-toolchains` (#9 / #10), where it took the build from failing to green.