### PR TITLE
init: stop over-broad static analyses from polluting/breaking rehostings (#830)

### DIFF
--- a/pyplugins/analysis/env.py
+++ b/pyplugins/analysis/env.py
@@ -2,6 +2,7 @@ import itertools
 import re
 from os.path import join as pjoin
 from penguin import plugins, Plugin, yaml
+from penguin.defaults import well_known_env_vars
 
 ENV_MAGIC_VAL = "DYNVALDYNVALDYNVAL"  # We want this to be longer than the other strings we might compare to
 # If we change this we also need to change the regex below
@@ -19,23 +20,9 @@ uboot_output = "env_uboot.txt"
 missing_output = "env_missing.yaml"
 mtd_output = "env_mtd.txt"
 
-DEFAULT_ENV_VARS = [
-    "root",
-    "console",
-    "clocksource",
-    "elevator",
-    "nohz",
-    "idle",
-    "acpi",
-    "LD_LIBRARY_PATH",
-    # Vars that control penguin's init script - ignore
-    "SHARED_DIR",
-    "ROOT_SHELL",
-    "WWW",
-    "CID",
-    "STRACE",
-    "igloo_init"
-]
+# Well-known kernel cmdline params + penguin-internal knobs (shared with the
+# init-time EnvFinder), plus igloo_init which we always set ourselves.
+DEFAULT_ENV_VARS = list(well_known_env_vars) + ["igloo_init"]
 
 
 class EnvTracker(Plugin):

--- a/pyplugins/init/env_finder.py
+++ b/pyplugins/init/env_finder.py
@@ -4,6 +4,7 @@ Identify potential environment variables and their values in the filesystem.
 
 import re
 
+from penguin.defaults import well_known_env_vars
 from penguin.init_plugin import InitPlugin, cached_analysis
 from penguin.static_analyses import FileSystemHelper
 
@@ -12,7 +13,12 @@ class EnvFinder(InitPlugin):
     """
     Identify potential environment variables and their values in the filesystem.
     """
-    BORING_VARS: list[str] = ["TERM"]
+    # Standard kernel cmdline params + penguin-internal knobs we should never
+    # "discover" as vendor-specific env vars (shared with the runtime tracker).
+    BORING_VARS: list[str] = well_known_env_vars
+
+    # Reject implausibly long keys - a glued scrape, not a real var name.
+    MAX_ENV_KEY_LEN: int = 64
 
     @cached_analysis
     def env(self) -> dict[str, list | None]:
@@ -37,6 +43,15 @@ class EnvFinder(InitPlugin):
         # Now search the filesystem for shell scripts accessing /proc/cmdline
         pattern = re.compile(r"\/proc\/cmdline.*?([A-Za-z0-9_]+)=", re.MULTILINE)
         potential_keys = FileSystemHelper.find_regex(pattern, extract_dir, ignore=self.BORING_VARS).keys()
+
+        # Drop well-known params (case-insensitive) and implausible/glued keys.
+        boring_lower = {v.lower() for v in self.BORING_VARS}
+        potential_keys = [
+            k for k in potential_keys
+            if k.lower() not in boring_lower
+            and not k.isnumeric()
+            and len(k) <= self.MAX_ENV_KEY_LEN
+        ]
 
         # For each key, try pulling out potential values from the filesystem
         for k in potential_keys:

--- a/pyplugins/init/interface_finder.py
+++ b/pyplugins/init/interface_finder.py
@@ -12,6 +12,49 @@ class InterfaceFinder(InitPlugin):
     """
     Identify network interfaces in the filesystem.
     """
+
+    # Linux interface names are capped at IFNAMSIZ-1 chars; anything longer is a
+    # glued/runaway scrape, not a real device name.
+    IFNAMSIZ: int = 15
+
+    # The command-argument scrape captures the token after `ifconfig`/`ip link`
+    # etc. in any string, so help/usage text yields unbounded English garbage
+    # ("Specify", "command", "together", "bonding_masters", "afstats", ...). A
+    # denylist can't enumerate English; instead allowlist by interface-name
+    # shape. Real names start with a letter and contain a digit (eth0, vlan1,
+    # enp0s25, and underscore-segmented driver names like rmnet_mhi0,
+    # pcie_mhi0, sipa_dummy0); English words don't contain digits.
+    NETDEV_SHAPE = re.compile(r"^[a-z][a-z0-9_.\-]*\d[a-z0-9_.\-]*$")
+
+    # OpenWrt-style named bridges/vlans (br-lan, br-wan, bond-mgmt) have no
+    # trailing number, so allow a known-prefix + hyphenated name explicitly.
+    NETDEV_NAMED = re.compile(r"^(?:br|bond|lan|wan)-[a-z0-9_]+$")
+
+    # Genuinely standalone interface names with no digit (not NIC prefixes like
+    # eth/wlan/br, whose numbered forms already match the shape rule).
+    NETDEV_BARE: set[str] = {
+        "lo", "et", "lan", "wan", "ppp", "pppoe", "l2tp", "vpn", "dsl",
+        "lte", "wwan", "sta", "mesh",
+    }
+
+    # Network words that *do* match the shape rule (trailing digit) but are not
+    # interfaces.
+    NETDEV_DENY: set[str] = {"inet", "inet6", "ipv4", "ipv6", "ipv4cfg", "ipv6cfg"}
+
+    def _keep_iface(self, iface: str) -> bool:
+        """Whether a scraped token is a plausible real interface name."""
+        iface = str(iface)
+        if not iface or len(iface) > self.IFNAMSIZ:
+            return False
+        if iface.isnumeric() or iface in self.NETDEV_DENY:
+            return False
+        # Container/virtual scaffolding is dynamic, never a firmware interface.
+        if iface.startswith(("veth", "docker", "virbr")):
+            return False
+        if iface in self.NETDEV_BARE:
+            return True
+        return bool(self.NETDEV_SHAPE.match(iface) or self.NETDEV_NAMED.match(iface))
+
     @cached_analysis
     def interfaces(self) -> dict[str, list[str]] | None:
         """
@@ -25,9 +68,8 @@ class InterfaceFinder(InitPlugin):
         pattern = re.compile(r"/sys/class/net/([a-zA-Z0-9_]+)", re.MULTILINE)
         sys_net_ifaces = FileSystemHelper.find_regex(pattern, extract_dir).keys()
 
-        # Filter out the default network interfaces
-        sys_net_ifaces = [i for i in sys_net_ifaces if not i.startswith("veth") and not i.startswith("br")
-                          and not i == "lo"]
+        # Filter out scaffolding/placeholder/glued names
+        sys_net_ifaces = [i for i in sys_net_ifaces if self._keep_iface(i)]
 
         # Now search for references to standard network commands: ifconfig, ip, brctl
         # We'll use these to identify interfaces
@@ -37,7 +79,13 @@ class InterfaceFinder(InitPlugin):
         interface_regex = r"([a-zA-Z0-9][a-zA-Z0-9_-]{2,15})"
 
         ifconfig_matches = re.compile(rf"ifconfig\s+{interface_regex}")
-        ip_link_matches = re.compile(rf"ip\s+(?:addr|link|route|add|set|show)\s+{interface_regex}")
+        # iproute2: `ip [opts] OBJECT [COMMAND] [dev] <name>`. Match the OBJECT
+        # and optional COMMAND so the capture lands on the interface name, not
+        # the sub-command keyword (old pattern captured 'set' in `ip link set eth0`).
+        ip_link_matches = re.compile(
+            rf"ip\s+(?:-\S+\s+)*(?:addr|address|link|route|neigh|rule)\s+"
+            rf"(?:add|del|delete|set|show|list|flush|change|replace)?\s*(?:dev\s+)?{interface_regex}"
+        )
         ifup_down_matches = re.compile(rf"if(?:up|down)\s+{interface_regex}")
         ethtool_matches = re.compile(rf"ethtool\s+{interface_regex}")
         route_matches = re.compile(rf"route\s+(?:add|del)\s+{interface_regex}")
@@ -54,15 +102,8 @@ class InterfaceFinder(InitPlugin):
         for p in patterns:
             interfaces.update(FileSystemHelper.find_regex(p, extract_dir).keys())
 
-        bad_prefixes = ["veth", "br"]
-        bad_vals = ["lo", "set", "add", "del", "route", "show", "addr", "link", "up", "down",
-                    "flush", "help", "default"]
-
-        # Filter out the default network interfaces
-        interfaces = [iface for iface in interfaces if
-                      not any([x in iface for x in bad_vals]) and
-                      not any([iface.startswith(x) for x in bad_prefixes]) and
-                      not iface.isnumeric()]
+        # Drop command keywords, placeholders, and glued/oversized captures.
+        interfaces = [iface for iface in interfaces if self._keep_iface(iface)]
 
         result = {}
         if len(sys_net_ifaces):

--- a/pyplugins/init/library_symbols.py
+++ b/pyplugins/init/library_symbols.py
@@ -3,6 +3,7 @@ Examine libraries in the filesystem for NVRAM keys and exported symbols.
 """
 
 import os
+import re
 import struct
 import subprocess
 import tempfile
@@ -30,6 +31,31 @@ class LibrarySymbols(InitPlugin):
     """
     NVRAM_KEYS: list[str] = ["Nvrams", "router_defaults"]
     serializer = "json_xz"
+
+    # When the pointer-table walk runs past the real defaults table it reads
+    # adjacent sections (.comment, .ARM.attributes, string arrays), yielding
+    # keys with control chars or non-identifier starts and values that are
+    # compiler/toolchain banners. None of these are real NVRAM entries.
+    _TOOLCHAIN_RE = re.compile(r"GCC:|\(Buildroot|GNU [CA]|clang version|Copyright|[ae]abi\b")
+
+    @staticmethod
+    def _plausible_nvram(key: str, val) -> bool:
+        """Whether a scraped (key, val) is a plausible NVRAM default rather than
+        garbage read past the end of the table."""
+        if not key:
+            return False
+        # printable ASCII only - no control/high bytes
+        if not all(32 <= ord(c) < 127 for c in key):
+            return False
+        if any(c in key for c in ' /\t\n\r<>"'):
+            return False
+        # real keys start with a letter or underscore
+        if not (key[0].isalpha() or key[0] == "_"):
+            return False
+        # a toolchain/version-string value means we walked off the table
+        if isinstance(val, str) and LibrarySymbols._TOOLCHAIN_RE.search(val):
+            return False
+        return True
 
     @cached_analysis
     def library_info(self) -> dict[str, dict]:
@@ -243,11 +269,7 @@ class LibrarySymbols(InitPlugin):
                         key = LibrarySymbols._get_string_from_address(elffile, ptrs[0], is_64, is_eb)
                         val = LibrarySymbols._get_string_from_address(elffile, ptrs[1], is_64, is_eb)
 
-                        if (
-                            key
-                            and not any([x in key for x in ' /\t\n\r<>"'])
-                            and not key[0].isnumeric()
-                        ):
+                        if LibrarySymbols._plausible_nvram(key, val):
                             fail_count = 0
                             if key not in nvram_data:
                                 nvram_data[key] = val

--- a/pyplugins/init/pseudofile_finder.py
+++ b/pyplugins/init/pseudofile_finder.py
@@ -5,6 +5,8 @@ Find device and proc pseudofiles referenced by the extracted filesystem.
 import os
 import re
 
+from collections import defaultdict
+
 from penguin.config_patchers import RESOURCES
 from penguin.init_plugin import InitPlugin, cached_analysis
 from penguin.static_analyses import FileSystemHelper
@@ -44,6 +46,12 @@ class PseudofileFinder(InitPlugin):
         "fd", "root", "pts", "shm",  # Added in init
         "ttyAMA0", "ttyAMA1",  # ARM
         "stdin", "stdout", "stderr",  # Symlinks to /proc/self/fd/X
+        # Standard devtmpfs char devices (un-numbered) and not-a-pseudofile
+        # nodes. /dev/log is a syslog AF_UNIX socket and /dev/initctl a sysvinit
+        # FIFO - a zero/discard model breaks the clients that open them.
+        "hwrng", "rtc", "watchdog", "fb", "snd", "dsp", "mixer", "audio",
+        "rfkill", "uinput", "kvm", "vhost-net", "vhci", "cuse",
+        "log", "initctl", "gpiochip0",
     ]
 
     IGLOO_PROCFS: list[str] = [
@@ -153,8 +161,74 @@ class PseudofileFinder(InitPlugin):
 
     # Directories that we want to just ignore entirely - don't create any entries
     # within these directories. IRQs and device-tree are related to the emulated CPU
-    # self and PID are related to the process itself and dynamically created
-    PROC_IGNORE: list[str] = ["irq", "self", "PID", "device-tree", "net", "vmcore"]
+    # self and PID are related to the process itself and dynamically created.
+    #
+    # The sys/fs/* and sys/kernel/* entries are real filesystem mounts (cgroup,
+    # binfmt_misc, fuse, debugfs, ...), not sysctls. Modeling a *child* path
+    # under them - e.g. a scraped /proc/sys/fs/binfmt_misc/WSLInterop/signal -
+    # makes the guest register a ctl_table under a filesystem-backed node, which
+    # panics register_sysctl() on older kernels (4.10). See penguin#830.
+    PROC_IGNORE: list[str] = [
+        "irq", "self", "PID", "device-tree", "net", "vmcore",
+        "sys/fs/binfmt_misc",
+        "sys/fs/cgroup",
+        "sys/fs/fuse",
+        "sys/fs/nfsd",
+        "sys/fs/pstore",
+        "sys/kernel/security",
+        "sys/kernel/debug",
+        "sys/kernel/config",
+        "fs/cgroup",
+        # Per-interface / per-device network sysctl trees. The kernel creates
+        # conf/<iface> and neigh/<iface> for every interface that exists, so a
+        # scraped path like /proc/sys/net/ipv4/conf/${interface}/rp_filter (or
+        # any non-default iface name) is a real kernel sysctl, not something to
+        # model - doing so shadows the kernel's own per-interface knob.
+        "sys/net/ipv4/conf",
+        "sys/net/ipv6/conf",
+        "sys/net/ipv4/neigh",
+        "sys/net/ipv6/neigh",
+        "sys/net/mpls/conf",
+    ]
+
+    # Char-device basenames that must never be modeled, and under which no child
+    # path may be modeled. A scraped path like /dev/null/dev/ptmx/... is always
+    # a glued-string artifact (nothing lives *under* a leaf char device); faithfully
+    # modeling it recreates /dev/null as a directory and breaks every `>/dev/null`
+    # in the guest's init. These are provided by devtmpfs and must keep their real
+    # semantics (a zero/discard model would, e.g., kill entropy on /dev/random).
+    # See penguin#830.
+    CRITICAL_DEVICES: set[str] = {
+        "null", "zero", "full", "console", "tty", "ptmx",
+        "random", "urandom", "mem", "kmem", "port", "kmsg",
+    }
+
+    # Well-known device-node families the kernel auto-creates via devtmpfs (the
+    # guest mounts devtmpfs on /dev). Matched against the *last* path component.
+    # We never model these: the real node already exists, and our default
+    # zero/discard model would only shadow or conflict with it. Block devices
+    # (group B) are real storage and must not become char pseudofiles.
+    WELL_KNOWN_DEVICE_RE: list = [
+        re.compile(p) for p in (
+            # block storage
+            r"^sd[a-z]\d*$", r"^mmcblk\d+(p\d+)?$", r"^mtdblock\d+$",
+            r"^nvme\d+n\d+(p\d+)?$", r"^dm-\d+$", r"^sr\d+$", r"^md\d+$",
+            r"^vd[a-z]\d*$", r"^hd[a-z]\d*$",
+            # numbered char devices
+            r"^rtc\d*$", r"^watchdog\d*$", r"^fb\d+$", r"^gpiochip\d+$",
+            r"^i2c-\d+$", r"^spidev\d+\.\d+$", r"^hwrng$",
+            r"^event\d+$", r"^mouse\d+$", r"^js\d+$",
+            # serial / console leaf nodes
+            r"^tty\d+$", r"^ttyS\d+$", r"^ttyAMA\d+$", r"^ttyUSB\d+$",
+            r"^ttyACM\d+$",
+        )
+    ]
+
+    # Caps to reject implausible scraped paths (glued strings, runaway captures).
+    # Legit sysctls reach ~7 components (e.g. sys/dev/parport/parport0/devices/
+    # lp/deviceid), so the depth cap only catches genuine runaway glue.
+    MAX_PSEUDO_DEPTH: int = 8        # number of path components after /dev or /proc
+    MAX_PSEUDO_COMPONENT: int = 64   # length of a single path component
 
     @staticmethod
     def _known_procfs() -> list[str]:
@@ -218,6 +292,94 @@ class PseudofileFinder(InitPlugin):
 
         return [k for k in filtered_files if k not in directories_to_remove]
 
+    def _modelable_dev(self, sub: str) -> bool:
+        """
+        Whether a scraped /dev sub-path (the part after ``/dev/``) is worth
+        modeling as a pseudofile.
+
+        Rejects well-known devtmpfs nodes and block devices, anything nested
+        under a critical char device (a glued-string scrape artifact), and
+        implausibly long or deep paths. See penguin#830.
+        """
+        sub = sub.strip("/")
+        if not sub:
+            return False
+        parts = sub.split("/")
+        if len(parts) > self.MAX_PSEUDO_DEPTH:
+            return False
+        if any(len(p) > self.MAX_PSEUDO_COMPONENT for p in parts):
+            return False
+        # A child under a known *leaf* device node would clobber that node into a
+        # directory (the /dev/null -> folder problem, and ttyS0/watchdog/mtdblock
+        # /... too). Unknown parents are assumed to be directories and kept, so
+        # real vendor trees (/dev/nss/..., /dev/oprofile/..., /dev/misc/rtc) live.
+        if len(parts) > 1 and self._is_leaf_device(parts[0]):
+            return False
+        if sub in self.CRITICAL_DEVICES:
+            return False
+        base = parts[-1]
+        if any(rx.match(base) for rx in self.WELL_KNOWN_DEVICE_RE):
+            return False
+        return True
+
+    def _is_leaf_device(self, name: str) -> bool:
+        """
+        Whether ``/dev/<name>`` is a known leaf device node (not a directory).
+        Used to reject child paths that would clobber the node into a directory.
+        Conservative: only names we are confident are leaves, so unknown vendor
+        directories keep their children.
+        """
+        return name in self.CRITICAL_DEVICES or any(
+            rx.match(name) for rx in self.WELL_KNOWN_DEVICE_RE
+        )
+
+    def _modelable_proc(self, sub: str) -> bool:
+        """
+        Whether a scraped /proc sub-path is worth modeling. Caps depth and
+        component length to drop runaway/glued captures; mount-backed subtrees
+        are already dropped via PROC_IGNORE.
+        """
+        sub = sub.strip("/")
+        if not sub:
+            return False
+        parts = sub.split("/")
+        if len(parts) > self.MAX_PSEUDO_DEPTH:
+            return False
+        if any(len(p) > self.MAX_PSEUDO_COMPONENT for p in parts):
+            return False
+        return True
+
+    @staticmethod
+    def _drop_glued_sysctls(proc_files: list[str], known_procfs: list[str]) -> list[str]:
+        """
+        Drop scraped ``/proc/sys`` paths that extend a known sysctl mid-component
+        (e.g. ``.../hostname2006`` from ``hostname``, ``.../somaxconnabi`` from
+        ``somaxconn``). These are greedy-scrape glue, not real sysctls: a real
+        child would be separated by ``/``. Scoped to the sysctl tree, whose names
+        we know exhaustively from resources/proc_sys.txt. See penguin#830.
+        """
+        # parent dir -> set of known leaf names, for mid-component glue detection
+        known_children: dict[str, set] = defaultdict(set)
+        for k in known_procfs:
+            k = k.strip("/").rstrip("/")
+            if not k:
+                continue
+            parent, _, leaf = k.rpartition("/")
+            known_children[parent].add(leaf)
+
+        kept = []
+        for sub in proc_files:
+            s = sub.strip("/")
+            if s.startswith("sys/"):
+                parent, _, leaf = s.rpartition("/")
+                if any(
+                    leaf != kl and leaf.startswith(kl)
+                    for kl in known_children.get(parent, ())
+                ):
+                    continue  # mid-component extension of a known sysctl
+            kept.append(sub)
+        return kept
+
     @cached_analysis
     def pseudofiles(self) -> dict[str, list[str]]:
         """
@@ -237,9 +399,15 @@ class PseudofileFinder(InitPlugin):
         )
 
         # Filter proc files, applying PROC_IGNORE and known procfs entries
+        known_procfs = self._known_procfs()
         proc_files = self._filter_files(
-            extract_dir, proc_pattern, self.PROC_IGNORE, self._known_procfs()
+            extract_dir, proc_pattern, self.PROC_IGNORE, known_procfs
         )
+
+        # Drop implausible / well-known / glued scrapes before modeling them.
+        dev_files = [x for x in dev_files if self._modelable_dev(x)]
+        proc_files = [x for x in proc_files if self._modelable_proc(x)]
+        proc_files = self._drop_glued_sysctls(proc_files, known_procfs)
 
         # Return dev and proc files in the appropriate format
         return {

--- a/pyplugins/init/pseudofile_patches.py
+++ b/pyplugins/init/pseudofile_patches.py
@@ -7,8 +7,20 @@ import os
 
 from collections import defaultdict
 
+from penguin import getColoredLogger
 from penguin.defaults import expert_knowledge_pseudofiles
 from penguin.init_plugin import InitContext, InitPlugin
+
+logger = getColoredLogger("penguin.init.pseudofile_patches")
+
+# Char devices we must never (re)model or nest a child under. Backstop for the
+# PseudofileFinder filtering: even if a bad path reaches here (hand-edited static
+# result, future finder), modeling a child turns /dev/null into a directory and
+# breaks the guest. See penguin#830.
+CRITICAL_DEV_NODES: tuple[str, ...] = (
+    "/dev/null", "/dev/zero", "/dev/full", "/dev/console", "/dev/tty",
+    "/dev/ptmx", "/dev/random", "/dev/urandom", "/dev/mem", "/dev/kmem",
+)
 
 
 class PseudofilesExpert(InitPlugin):
@@ -37,6 +49,17 @@ class PseudofilesTailored(InitPlugin):
 
         for section, file_names in pseudofiles.items():
             for file_name in file_names:
+                # Never (re)model a critical char device or anything nested
+                # under one - see CRITICAL_DEV_NODES / penguin#830.
+                if file_name in CRITICAL_DEV_NODES or any(
+                    file_name.startswith(node + "/") for node in CRITICAL_DEV_NODES
+                ):
+                    logger.warning(
+                        f"Refusing to model critical device path {file_name!r} "
+                        "(would shadow a devtmpfs node or recreate it as a directory)"
+                    )
+                    continue
+
                 if section == 'dev' and file_name.startswith("/dev/mtd"):
                     # TODO: do we want to make placeholders for MTD or not?
                     continue

--- a/src/penguin/defaults.py
+++ b/src/penguin/defaults.py
@@ -30,6 +30,23 @@ default_netdevs: list[str] = (
     + ["enx0", "enp0s25", "wlp2s0"]
 )
 
+# Well-known kernel command-line parameters and penguin-internal env knobs.
+# These appear near /proc/cmdline references in firmware scripts but are not
+# vendor-specific knobs worth "discovering": surfacing them as candidate env
+# vars only pollutes the config and wastes search iterations, and varying some
+# of them (console=, root=, ...) actively breaks boot. Shared by the init-time
+# EnvFinder and the runtime env tracker so both ignore the same set.
+well_known_env_vars: list[str] = [
+    # standard kernel command-line parameters
+    "root", "rootfstype", "rootwait", "rootdelay", "ro", "rw", "init",
+    "console", "clocksource", "elevator", "nohz", "idle", "acpi", "mem",
+    "quiet", "debug", "loglevel", "panic", "reboot", "earlyprintk", "ramdisk_size",
+    "mtdparts", "single", "initrd", "vt", "fbcon", "ubi", "ubiroot", "noinitrd",
+    # penguin-internal init knobs (set by us, not discovered)
+    "SHARED_DIR", "ROOT_SHELL", "WWW", "CID", "STRACE", "LD_LIBRARY_PATH",
+    "TERM",
+]
+
 # Resolve current path then go to ../resources/init.sh
 default_init_script: str = open(
     f"{dirname(dirname(__file__))}/resources/init.sh").read()

--- a/tests/unit_tests/test_static_analyses.py
+++ b/tests/unit_tests/test_static_analyses.py
@@ -1,4 +1,5 @@
 import tempfile
+import types
 import unittest
 from pathlib import Path
 
@@ -9,6 +10,18 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PseudofileFinder = dict(
     _import_plugin_classes(str(REPO_ROOT / "pyplugins/init/pseudofile_finder.py"))
 )["PseudofileFinder"]
+PseudofilesTailored = dict(
+    _import_plugin_classes(str(REPO_ROOT / "pyplugins/init/pseudofile_patches.py"))
+)["PseudofilesTailored"]
+InterfaceFinder = dict(
+    _import_plugin_classes(str(REPO_ROOT / "pyplugins/init/interface_finder.py"))
+)["InterfaceFinder"]
+EnvFinder = dict(
+    _import_plugin_classes(str(REPO_ROOT / "pyplugins/init/env_finder.py"))
+)["EnvFinder"]
+LibrarySymbols = dict(
+    _import_plugin_classes(str(REPO_ROOT / "pyplugins/init/library_symbols.py"))
+)["LibrarySymbols"]
 
 
 def make_plugin(cls, extracted_dir):
@@ -58,6 +71,243 @@ class TestPseudofileFinder(unittest.TestCase):
         self.assertNotIn("/dev/fd/.placeholder", result["dev"])
         self.assertNotIn("/dev/shm", result["dev"])
         self.assertIn("/dev/vendor_knob", result["dev"])
+
+    def test_drops_glued_paths_under_critical_devices(self):
+        """penguin#830: a greedy scrape glues strings into a path nested under
+        /dev/null; modeling it recreates /dev/null as a directory. Drop it."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Mimic packed binary strings with no separators between them.
+            Path(tmpdir, "blob.bin").write_bytes(
+                b"/dev/null/dev/ptmx/dev/ptsSSH_FX_OKhmac\x00"
+                b"/dev/watchdog\x00"
+                b"/dev/vendor_knob\x00"
+            )
+
+            result = make_plugin(PseudofileFinder, tmpdir).pseudofiles
+
+        # Nothing under or equal to /dev/null may be modeled.
+        self.assertFalse(
+            [d for d in result["dev"] if d.startswith("/dev/null")],
+            result["dev"],
+        )
+        # Real custom devices survive.
+        self.assertIn("/dev/vendor_knob", result["dev"])
+
+    def test_drops_children_of_leaf_device_nodes(self):
+        """Any /dev/<leaf>/child forces <leaf> to become a directory, clobbering
+        a real device node - not just /dev/null. Only known /dev directories may
+        contain children."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "script.sh").write_text(
+                "echo x > /dev/null/x\n"
+                "cat /dev/ttyS0/garbage\n"
+                "cat /dev/watchdog/foo\n"
+                "dd of=/dev/mtdblock0/bar\n"
+                "cat /dev/net/tun\n"          # legit: /dev/net is a directory
+                "cat /dev/vendor_knob\n"      # legit: single-component leaf
+            )
+
+            result = make_plugin(PseudofileFinder, tmpdir).pseudofiles
+
+        for bad in ("/dev/null/x", "/dev/ttyS0/garbage", "/dev/watchdog/foo",
+                    "/dev/mtdblock0/bar"):
+            self.assertNotIn(bad, result["dev"])
+        self.assertIn("/dev/net/tun", result["dev"])
+        self.assertIn("/dev/vendor_knob", result["dev"])
+
+    def test_drops_well_known_and_block_devices(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "script.sh").write_text(
+                "cat /dev/rtc0\n"
+                "cat /dev/watchdog0\n"
+                "dd if=/dev/sda1\n"
+                "dd if=/dev/mmcblk0p1\n"
+                "cat /dev/fb0\n"
+                "logger -f /dev/log\n"
+                "cat /dev/vendor_knob\n"
+            )
+
+            result = make_plugin(PseudofileFinder, tmpdir).pseudofiles
+
+        for dev in ("/dev/rtc0", "/dev/watchdog0", "/dev/sda1",
+                    "/dev/mmcblk0p1", "/dev/fb0", "/dev/log"):
+            self.assertNotIn(dev, result["dev"])
+        self.assertIn("/dev/vendor_knob", result["dev"])
+
+    def test_drops_binfmt_misc_mount_children(self):
+        """penguin#830: a scraped sysctl under the binfmt_misc fs mount crashes
+        register_sysctl() on old kernels; never model children of fs mounts."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "blob.bin").write_bytes(
+                b"/proc/sys/fs/binfmt_misc/WSLInterop/signal\x00"
+                b"/proc/vendor_knob\x00"
+            )
+
+            result = make_plugin(PseudofileFinder, tmpdir).pseudofiles
+
+        self.assertFalse(
+            [p for p in result["proc"] if "binfmt_misc" in p],
+            result["proc"],
+        )
+        self.assertIn("/proc/vendor_knob", result["proc"])
+
+    def test_drops_glued_sysctls(self):
+        """penguin#830: greedy scrapes glue trailing bytes onto real sysctls
+        (hostname->hostname2006). Drop the mid-component extensions, keep real
+        (even novel vendor) sysctls."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "blob.bin").write_bytes(
+                b"/proc/sys/kernel/hostname2006\x00"
+                b"/proc/sys/net/core/somaxconnabi\x00"
+                b"/proc/sys/net/ipv6flush\x00"
+                b"/proc/sys/net/vendor_knob\x00"   # real novel sysctl - keep
+            )
+
+            result = make_plugin(PseudofileFinder, tmpdir).pseudofiles
+
+        self.assertNotIn("/proc/sys/kernel/hostname2006", result["proc"])
+        self.assertNotIn("/proc/sys/net/core/somaxconnabi", result["proc"])
+        self.assertNotIn("/proc/sys/net/ipv6flush", result["proc"])
+        self.assertIn("/proc/sys/net/vendor_knob", result["proc"])
+
+    def test_drops_per_interface_conf_sysctls(self):
+        """The kernel provides net/ipv[46]/conf|neigh/<iface>/* for every real
+        interface; never model them (any iface name, incl. unexpanded vars)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "rc.net").write_text(
+                "echo 1 > /proc/sys/net/ipv4/conf/br0/forwarding\n"
+                "echo 0 > /proc/sys/net/ipv4/conf/wan/rp_filter\n"
+                "echo 1 > /proc/sys/net/ipv6/conf/lan/disable_ipv6\n"
+                "echo 0 > /proc/sys/net/ipv4/neigh/eth1/retrans_time\n"
+                "cat /proc/sys/net/vendor_knob\n"
+            )
+
+            result = make_plugin(PseudofileFinder, tmpdir).pseudofiles
+
+        self.assertFalse(
+            [p for p in result["proc"]
+             if "/conf/" in p or "/neigh/" in p],
+            result["proc"],
+        )
+        self.assertIn("/proc/sys/net/vendor_knob", result["proc"])
+
+
+class TestPseudofilesTailored(unittest.TestCase):
+    def test_never_models_critical_node_children(self):
+        """Backstop: even if a bad path reaches the patcher, it must not model a
+        critical device or a child under one."""
+        plugin = PseudofilesTailored.__new__(PseudofilesTailored)
+        plugin.plugins = types.SimpleNamespace(
+            PseudofileFinder=types.SimpleNamespace(
+                pseudofiles={
+                    "dev": [
+                        "/dev/null",
+                        "/dev/null/dev/ptmx",
+                        "/dev/vendor_knob",
+                    ],
+                    "proc": [],
+                }
+            )
+        )
+
+        out = plugin.patch(ctx=None)
+        modeled = set(out["pseudofiles"])
+        self.assertNotIn("/dev/null", modeled)
+        self.assertFalse([p for p in modeled if p.startswith("/dev/null/")])
+        self.assertIn("/dev/vendor_knob", modeled)
+
+
+class TestInterfaceFinder(unittest.TestCase):
+    def test_excludes_command_keywords_and_placeholders(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "script.sh").write_text(
+                "ifconfig interface [up|down]\n"   # 'interface' is a doc placeholder
+                "ip link set eth0 up\n"            # 'set' is a sub-command keyword
+                "ifconfig eth0 up\n"               # eth0 is real
+            )
+
+            result = make_plugin(InterfaceFinder, tmpdir).interfaces or {}
+
+        found = set(result.get("commands", []))
+        self.assertNotIn("interface", found)
+        self.assertNotIn("set", found)
+        self.assertIn("eth0", found)
+
+    def test_keeps_named_bridges_drops_bare_and_veth(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "script.sh").write_text(
+                "ifconfig br-lan up\n"     # real bridge - keep
+                "ifconfig veth0 up\n"      # container veth - drop
+            )
+
+            result = make_plugin(InterfaceFinder, tmpdir).interfaces or {}
+
+        found = set(result.get("commands", []))
+        self.assertIn("br-lan", found)
+        self.assertNotIn("veth0", found)
+
+    def test_captures_device_after_ip_subcommand(self):
+        """`ip link set eth0 up` must surface eth0, not the 'set' keyword."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "script.sh").write_text(
+                "ip link set eth0 up\n"
+                "ip addr show wlan1\n"
+            )
+
+            result = make_plugin(InterfaceFinder, tmpdir).interfaces or {}
+
+        found = set(result.get("commands", []))
+        self.assertIn("eth0", found)
+        self.assertIn("wlan1", found)
+        self.assertNotIn("set", found)
+        self.assertNotIn("show", found)
+
+
+class TestEnvFinder(unittest.TestCase):
+    def _run(self, tmpdir):
+        plugin = make_plugin(EnvFinder, tmpdir)
+        plugin.plugins = types.SimpleNamespace(
+            InitFinder=types.SimpleNamespace(inits=[])
+        )
+        return plugin.env
+
+    def test_ignores_well_known_kernel_params(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # The finder captures the first KEY= that follows a /proc/cmdline
+            # reference on a line, so give each key its own reference.
+            Path(tmpdir, "rcS").write_text(
+                "grep /proc/cmdline root=/dev/mtdblock1\n"
+                "grep /proc/cmdline console=ttyS0\n"
+                "grep /proc/cmdline vendor_mode=fast\n"
+            )
+
+            env = self._run(tmpdir)
+
+        # Standard kernel params must not be surfaced as discovered knobs...
+        self.assertNotIn("root", env)
+        self.assertNotIn("console", env)
+        # ...but a real vendor-specific knob still is.
+        self.assertIn("vendor_mode", env)
+
+
+class TestLibrarySymbolsNvram(unittest.TestCase):
+    def test_rejects_pointer_walk_garbage(self):
+        """When the NVRAM pointer walk runs off the table it reads toolchain
+        banners and control-char keys - reject those, keep real defaults."""
+        plausible = LibrarySymbols._plausible_nvram
+        # real defaults survive
+        self.assertTrue(plausible("ASUS_EULA", "0"))
+        self.assertTrue(plausible("wl0_ssid", "ASUS"))
+        self.assertTrue(plausible("_hidden", ""))
+        # garbage from over-walking the table
+        self.assertFalse(plausible("*nvram", "GCC: (Buildroot 2012.02) 4.5.3"))
+        self.assertFalse(plausible("-1", "aeabi"))
+        self.assertFalse(plausible(".swap", "x"))
+        self.assertFalse(plausible("{", "x"))
+        self.assertFalse(plausible("\x057-A", "A0"))
+        self.assertFalse(plausible("\x17", "A0"))
+        # real-looking key paired with a toolchain-banner value is still bogus
+        self.assertFalse(plausible("enabled", "GCC: (Buildroot 2012.02) 4.5.3"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Init-time static analyses scrape `/dev`, `/proc`, interface names, env vars and
NVRAM defaults from firmware binaries with greedy heuristics and model every
result with no validation. This produces **over-broad output that pollutes or
breaks rehostings** — most visibly the dynamic pseudofile generator in #830,
but the same class affects netdevs, env, and NVRAM. This PR hardens all five
scrape-based analyses to drop garbage while preserving real results.

Fixes #830.

## What changed

**Pseudofiles** (`pseudofile_finder.py`, `pseudofile_patches.py`)
- Refuse to model a child under a known **leaf** device node — `/dev/null/x`,
  `/dev/ttyS0/x`, `/dev/watchdog/x`, … force the node to be created as a
  **directory** (the #830 `/dev/null`→folder break). Real `/dev` directories
  (`/dev/net`, `/dev/nss`, `/dev/oprofile`, …) are preserved.
- Stop modeling well-known devtmpfs nodes (block devices, `rtc*`, `hwrng`,
  `ttyUSB*`, `watchdog`, `/dev/log`) — the kernel provides them; a
  `zero`/`discard` model only shadows them.
- Prefix-ignore mount-backed `/proc` subtrees (`sys/fs/binfmt_misc` → the 4.10
  panic, `cgroup`, …) and per-interface sysctls (`net/ipv[46]/conf|neigh/<iface>`).
- Drop trailing-glue sysctls (`hostname2006` from `hostname`) using the known
  sysctl set in `resources/proc_sys.txt`; depth/length caps for runaway captures.

**Netdevs** (`interface_finder.py`)
- Replace the futile keyword denylist with a **shape allowlist**: a real name
  starts with a letter and contains a digit (`eth0`, `enp0s25`, `rmnet_mhi0`),
  is a named bridge (`br-lan`), or a known standalone name (`lan`, `wan`,
  `pppoe`). English garbage (`Specify`, `command`, `together`, …) has no digit.

**Env** (`env_finder.py`, `analysis/env.py`, `defaults.py`)
- Don't surface standard kernel cmdline params (`root`, `console`, …) as
  discoverable vendor knobs; share one well-known list with the runtime tracker.

**NVRAM** (`library_symbols.py`)
- Reject pointer-walk overrun: control-char/non-identifier keys and
  toolchain-banner values (`GCC: (Buildroot …)`, `aeabi`).

## Validation

Unit tests in `test_static_analyses.py` (14 cases). Validated against **10 real
devices** — 5 with committed static analysis and 5
live `penguin init` runs.

**The MT3000 is the exact device from #830.** Live before/after: every garbage
example from the issue is dropped (`/dev/null/dev/ptmx/...`,
`/proc/sys/fs/binfmt_misc/WSLInteropos/signal`, `hostname2006`,
`somaxconnabi`, `ipv6flush`, …) while all 14 real interfaces and every
legitimate pseudofile are preserved. Across all 10 devices: garbage dropped,
real devices/interfaces kept, **zero false-positives on human-curated patches**.

## Notes

- Filters run only on the dynamic scrape; human-curated `patch_*.yaml` are
  untouched (e.g. file-backed block devices like the kindle `/dev/mmcblk0`).
- Conscious residual: NVRAM `MODEL_x: MODEL_y` pairs (a string array read as
  key/value) can't be distinguished by shape and are left as-is.
