### PR TITLE
publish: decouple docs + migrate build onto rehosting/ci shared workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,141 @@
+name: Docs
+
+# Docs (Sphinx HTML + LaTeX PDF) and the GitHub Pages deploy, decoupled from
+# publish.yaml. Triggered when publish.yaml creates a Release, this builds the
+# docs FROM the just-published image, deploys Pages, and attaches the PDF +
+# docs tarball to that release. A docs/PDF failure here no longer blocks the
+# image publish or the GitHub release.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to (re)build docs for
+        required: true
+
+permissions:
+  contents: write   # attach PDF/docs.tar.gz assets to the release
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "docs"
+  cancel-in-progress: false
+
+env:
+  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+
+jobs:
+  build_docs:
+    runs-on: rehosting-arc
+    steps:
+      - name: Install dependencies and label git workspace safe
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install git curl jq gzip
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
+
+      # Harbor cert trust + insecure buildx + login via the shared org action.
+      - name: Set up Arc registry (cert, buildx, login)
+        uses: rehosting/ci/actions/arc-registry-setup@v1
+        with:
+          registry: ${{ secrets.REHOSTING_ARC_REGISTRY }}
+          username: ${{ secrets.REHOSTING_ARC_REGISTRY_USER }}
+          password: ${{ secrets.REHOSTING_ARC_REGISTRY_PASSWORD }}
+
+      - name: Add docs stage to Dockerfile
+        run: |
+          cat <<'EOF' >> Dockerfile
+
+          FROM penguin AS docs
+
+          RUN pip install sphinx \
+              sphinx-autobuild \
+              sphinx-rtd-theme \
+              myst-parser \
+              sphinx-copybutton \
+              furo \
+              linkify-it-py \
+              sphinx-prompt \
+              sphinxemoji \
+              sphinx-notfound-page \
+              sphinx-last-updated-by-git
+          RUN apt-get update && apt-get install -y texlive-latex-base texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra
+          EOF
+
+      - name: Build docs image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          push: false
+          tags: rehosting/penguin:docs
+          build-args: |
+            REGISTRY=${{ secrets.REHOSTING_ARC_REGISTRY }}/proxy
+          cache-from: |
+            type=registry,ref=${{ secrets.REHOSTING_ARC_REGISTRY }}/rehosting/penguin:cache,mode=max
+            type=registry,ref=${{ secrets.REHOSTING_ARC_REGISTRY }}/rehosting/penguin:cache_docs,mode=max
+            type=registry,ref=${{ secrets.REHOSTING_ARC_REGISTRY }}/rehosting/penguin:cache_last_published,mode=max
+          cache-to: |
+            type=registry,ref=${{ secrets.REHOSTING_ARC_REGISTRY }}/rehosting/penguin:cache_docs,mode=max
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10.12"
+      - name: Install dependencies
+        run: pip install click pyyaml
+
+      - name: Generate Docs
+        run: |
+          timeout 10m python3 $GITHUB_WORKSPACE/tests/unit_tests/test_target/test.py -i rehosting/penguin:docs --docs-only
+          cp $GITHUB_WORKSPACE/tests/unit_tests/test_target/results/latest/sphinx/latex/penguin.pdf $GITHUB_WORKSPACE/tests/unit_tests/test_target/results/latest/sphinx/html
+          tar -czvf $GITHUB_WORKSPACE/docs.tar.gz -C $GITHUB_WORKSPACE/tests/unit_tests/test_target/results/latest/sphinx/html .
+
+      - name: Attach docs assets to the release
+        uses: softprops/action-gh-release@v2.3.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          files: |
+            ${{ github.workspace }}/tests/unit_tests/test_target/results/latest/sphinx/latex/penguin.pdf
+            ${{ github.workspace }}/docs.tar.gz
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: html
+          path: ${{ github.workspace }}/docs.tar.gz
+
+  deploy_static:
+    needs: build_docs
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: html
+      - name: Unzip HTML
+        run: |
+          mkdir html_content
+          tar -xvf docs.tar.gz -C html_content
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'html_content'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,6 +32,16 @@ jobs:
     steps:
       - name: Install dependencies and label git workspace safe
         run: |
+          # rehosting-arc's runner image ships broken apt sources; repoint to the
+          # MIT mirror before installing (same fixup the old publish job used).
+          sudo rm -rf /var/lib/apt/lists/*
+          sudo apt-get clean
+          for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+            if [ -f "$f" ]; then
+              sudo sed -i -E 's/([a-z]+\.)?archive\.ubuntu\.com/mirrors.mit.edu/g' "$f"
+              sudo sed -i -E 's/security\.ubuntu\.com/mirrors.mit.edu/g' "$f"
+            fi
+          done
           sudo apt-get update
           sudo apt-get -y install git curl jq gzip
           git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,134 +5,105 @@ on:
     branches:
       - main
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: write
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# One release at a time; don't cancel an in-progress production release.
 concurrency:
   group: "release"
   cancel-in-progress: false
 
 jobs:
-    build_container:
-        runs-on: rehosting-arc
+  # 1. Compute the next version (off the self-hosted pool).
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      v: ${{ steps.version.outputs.v-version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get next version
+        id: version
+        uses: reecetech/version-increment@2023.10.1
+        with:
+          use_api: true
 
-        steps:
-          - name: Update and Install Dependencies
-            run: |
-              # Nuke the existing corrupted lists
-              sudo rm -rf /var/lib/apt/lists/*
-              sudo apt-get clean
-              
-              # Targeted replacement to avoid mangling the protocol slashes
-              # This targets the domain names specifically
-              SOURCES_FILES="/etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources"
-              
-              for f in $SOURCES_FILES; do
-                if [ -f "$f" ]; then
-                  echo "Updating $f to use MIT mirror..."
-                  sudo sed -i -E 's/([a-z]+\.)?archive\.ubuntu\.com/mirrors.mit.edu/g' "$f"
-                  sudo sed -i -E 's/security\.ubuntu\.com/mirrors.mit.edu/g' "$f"
-                fi
-              done
-     
-              # Verify the file content if it fails again
-              # cat /etc/apt/sources.list.d/ubuntu.sources
+  # 2. Build + push the image to Harbor AND Docker Hub via the shared workflow.
+  #    tag-sha tags Harbor :<sha>; extra-tags add the Docker Hub :<sha>/:<version>/
+  #    :latest (dockerhub-token enables the Docker Hub push). cache-*-extra keep
+  #    refreshing the :cache_last_published ref that PR/docs/publish builds read.
+  #    NOTE: the cache refs hardcode the registry host because a reusable-workflow
+  #    `with:` block can't reference `secrets`; publish only runs on the main repo
+  #    (push to main), never forks, so this is safe. Auth still uses the secret.
+  build:
+    needs: version
+    uses: rehosting/ci/.github/workflows/build-and-push.yml@v1
+    with:
+      image: rehosting/penguin
+      extra-tags: |
+        rehosting/penguin:${{ needs.version.outputs.v }}
+        rehosting/penguin:latest
+        rehosting/penguin:${{ github.sha }}
+      build-args: |
+        OVERRIDE_VERSION=${{ needs.version.outputs.v }}
+        APT_MIRROR=MIT
+      dockerhub-user: rehosting
+      cache-from-extra: |
+        type=registry,ref=harbor.harbor.svc.cluster.local/rehosting/penguin:cache_last_published,mode=max
+      cache-to-extra: |
+        type=registry,ref=harbor.harbor.svc.cluster.local/rehosting/penguin:cache_last_published,mode=max
+    secrets:
+      registry: ${{ secrets.REHOSTING_ARC_REGISTRY }}
+      registry-user: ${{ secrets.REHOSTING_ARC_REGISTRY_USER }}
+      registry-password: ${{ secrets.REHOSTING_ARC_REGISTRY_PASSWORD }}
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
-              sudo apt-get update
-              sudo apt-get install -yy curl jq
+  # 3. Config schema + GitHub release (after the image exists). Docs/PDF/Pages
+  #    are built out-of-band by docs.yaml on `release: published`.
+  release:
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python for config schema
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10.12"
+      - name: Install dependencies for config schema
+        run: pip install pydantic pydantic-partial pyyaml yamlcore
+      - name: Generate config schema
+        run: python3 src/penguin/penguin_config/gen_docs.py schema > config_schema.yaml
 
-          - name: Get next version
-            uses: reecetech/version-increment@2023.10.1
-            id: version
-            with:
-              use_api: true
-          - name: Log in to Docker Hub
-            uses: docker/login-action@v3
-            with:
-              username: rehosting
-              password: ${{secrets.DOCKERHUB_TOKEN}}
+      - name: Upload config schema to server
+        uses: easingthemes/ssh-deploy@main
+        with:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          ARGS: "-rlgoDzvc -i --delete"
+          SOURCE: config_schema.yaml
+          REMOTE_HOST: rehosti.ng
+          REMOTE_USER: github
+          TARGET: /var/www/igloo
 
-          - name: Install dependencies and label git workspace safe
-            run: |
-              sudo apt-get update
-              sudo apt-get -y install git curl jq gzip tmux
-              git config --global --add safe.directory "$GITHUB_WORKSPACE"
-            
-          - name: Checkout code
-            uses: actions/checkout@v4
-            with:
-              fetch-depth: 0
-      
-          # Harbor cert trust + insecure buildx + login via the shared org action
-          # (replaces the inline cert/buildx/login blocks).
-          - name: Set up Arc registry (cert, buildx, login)
-            uses: rehosting/ci/actions/arc-registry-setup@v1
-            with:
-              registry: ${{ secrets.REHOSTING_ARC_REGISTRY }}
-              username: ${{ secrets.REHOSTING_ARC_REGISTRY_USER }}
-              password: ${{ secrets.REHOSTING_ARC_REGISTRY_PASSWORD }}
-
-          - name: Build Docker image and push to Dockerhub
-            uses: docker/build-push-action@v6.18.0
-            with:
-              context: .
-              push: true
-              cache-from: |
-                type=registry,ref=${{secrets.REHOSTING_ARC_REGISTRY}}/rehosting/penguin:cache,mode=max
-                type=registry,ref=${{secrets.REHOSTING_ARC_REGISTRY}}/rehosting/penguin:cache_last_published,mode=max
-              cache-to: |
-                type=registry,ref=${{secrets.REHOSTING_ARC_REGISTRY}}/rehosting/penguin:cache,mode=max
-                type=registry,ref=${{secrets.REHOSTING_ARC_REGISTRY}}/rehosting/penguin:cache_last_published,mode=max
-              tags: rehosting/penguin:${{ github.sha }},rehosting/penguin:${{ steps.version.outputs.v-version }},rehosting/penguin:latest,${{secrets.REHOSTING_ARC_REGISTRY}}/rehosting/penguin:${{ github.sha }}
-              build-args: |
-                OVERRIDE_VERSION=${{ steps.version.outputs.v-version }}
-                REGISTRY=${{ secrets.REHOSTING_ARC_REGISTRY }}/proxy
-                APT_MIRROR=MIT
-          
-          - name: Set up Python for config schema
-            uses: actions/setup-python@v5
-            with:
-              python-version: "3.10"
-          - name: Install dependencies for config schema
-            run: pip install pydantic pydantic-partial pyyaml yamlcore
-          - name: Generate config schema
-            run: python3 src/penguin/penguin_config/gen_docs.py schema > config_schema.yaml
-
-          - name: Upload config schema to server
-            uses: easingthemes/ssh-deploy@main
-            with:
-              SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-              ARGS: "-rlgoDzvc -i --delete"
-              SOURCE: config_schema.yaml
-              REMOTE_HOST: rehosti.ng
-              REMOTE_USER: github
-              TARGET: /var/www/igloo
-
-          # Docs (Sphinx + LaTeX PDF) + GitHub Pages are built/deployed
-          # out-of-band by docs.yaml, triggered on `release: published`. That
-          # keeps this release path fast and stops a docs/PDF failure from
-          # blocking the image publish + GitHub release. docs.yaml attaches the
-          # PDF to the release it triggered on.
-
-          - name: Create release
-            id: create_release
-            uses: softprops/action-gh-release@v2.3.3
-            env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            with:
-              tag_name: ${{ steps.version.outputs.v-version }}
-              name: Release ${{ steps.version.outputs.v-version }} ${{ github.ref }}
-              body: |
-                Release ${{ steps.version.outputs.v-version }} @${{ github.ref }}
-              draft: false
-              generate_release_notes: true
-              prerelease: false
-              files: |
-                config_schema.yaml
-              # The PDF + docs.tar.gz are attached to this release by docs.yaml
-              # after it builds the docs (release: published trigger).
+      - name: Create release
+        id: create_release
+        uses: softprops/action-gh-release@v2.3.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.version.outputs.v }}
+          name: Release ${{ needs.version.outputs.v }} ${{ github.ref }}
+          body: |
+            Release ${{ needs.version.outputs.v }} @${{ github.ref }}
+          draft: false
+          generate_release_notes: true
+          prerelease: false
+          # The PDF + docs.tar.gz are attached to this release by docs.yaml
+          # after it builds the docs (release: published trigger).
+          files: |
+            config_schema.yaml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,20 +56,7 @@ jobs:
             with:
               username: rehosting
               password: ${{secrets.DOCKERHUB_TOKEN}}
-          
-          - name: Trust Harbor's self-signed certificate
-            run: |
-              echo "Fetching certificate from ${{ secrets.REHOSTING_ARC_REGISTRY }}"
-              openssl s_client -showcerts -connect ${{ secrets.REHOSTING_ARC_REGISTRY }}:443 < /dev/null 2>/dev/null | openssl x509 -outform PEM | sudo tee /usr/local/share/ca-certificates/harbor.crt > /dev/null
-              sudo update-ca-certificates
-          
-          - name: Log in to Rehosting Arc Registry
-            uses: docker/login-action@v3
-            with:
-              registry: ${{ secrets.REHOSTING_ARC_REGISTRY }}
-              username: ${{ secrets.REHOSTING_ARC_REGISTRY_USER }}
-              password: ${{ secrets.REHOSTING_ARC_REGISTRY_PASSWORD }}
-         
+
           - name: Install dependencies and label git workspace safe
             run: |
               sudo apt-get update
@@ -81,16 +68,15 @@ jobs:
             with:
               fetch-depth: 0
       
-          - name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@v3
+          # Harbor cert trust + insecure buildx + login via the shared org action
+          # (replaces the inline cert/buildx/login blocks).
+          - name: Set up Arc registry (cert, buildx, login)
+            uses: rehosting/ci/actions/arc-registry-setup@v1
             with:
-              driver-opts: |
-                network=host
-              buildkitd-config-inline: |
-                [registry."${{ secrets.REHOSTING_ARC_REGISTRY }}"]
-                  insecure = true
-                  http = true
-          
+              registry: ${{ secrets.REHOSTING_ARC_REGISTRY }}
+              username: ${{ secrets.REHOSTING_ARC_REGISTRY_USER }}
+              password: ${{ secrets.REHOSTING_ARC_REGISTRY_PASSWORD }}
+
           - name: Build Docker image and push to Dockerhub
             uses: docker/build-push-action@v6.18.0
             with:
@@ -126,61 +112,12 @@ jobs:
               REMOTE_HOST: rehosti.ng
               REMOTE_USER: github
               TARGET: /var/www/igloo
-          
-          # ACTIONS: deploy docs to GitHub Pages
 
-          - name: Setup Pages
-            uses: actions/configure-pages@v5
-
-          - name: Add dependencies
-            run: |
-              cat <<'EOF' >> Dockerfile
-              
-              FROM penguin AS docs
-
-              RUN pip install sphinx \
-                  sphinx-autobuild \
-                  sphinx-rtd-theme \
-                  myst-parser \
-                  sphinx-copybutton \
-                  furo \
-                  linkify-it-py \
-                  sphinx-prompt \
-                  sphinxemoji \
-                  sphinx-notfound-page \
-                  sphinx-last-updated-by-git
-              RUN apt-get update && apt-get install -y texlive-latex-base texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra
-              EOF
-          - name: Build Docker image and push to Docker Hub
-            uses: docker/build-push-action@v6
-            with:
-              context: .
-              load: true
-              push: false
-              tags: rehosting/penguin:docs
-              build-args: |
-                REGISTRY=${{ secrets.REHOSTING_ARC_REGISTRY }}/proxy
-              cache-from: |
-                type=registry,ref=${{ secrets.REHOSTING_ARC_REGISTRY }}/rehosting/penguin:cache,mode=max
-                type=registry,ref=${{ secrets.REHOSTING_ARC_REGISTRY }}/rehosting/penguin:cache_docs,mode=max
-                type=registry,ref=${{ secrets.REHOSTING_ARC_REGISTRY }}/rehosting/penguin:cache_last_published,mode=max
-              cache-to: |
-                type=registry,ref=${{ secrets.REHOSTING_ARC_REGISTRY }}/rehosting/penguin:cache_docs,mode=max
-          
-          - name: Install dependencies
-            run: pip install click pyyaml
-          
-          - name: Generate Docs
-            run: |
-              timeout 10m python3 $GITHUB_WORKSPACE/tests/unit_tests/test_target/test.py -i rehosting/penguin:docs --docs-only
-              cp $GITHUB_WORKSPACE/tests/unit_tests/test_target/results/latest/sphinx/latex/penguin.pdf $GITHUB_WORKSPACE/tests/unit_tests/test_target/results/latest/sphinx/html
-              tar -czvf $GITHUB_WORKSPACE/docs.tar.gz -C $GITHUB_WORKSPACE/tests/unit_tests/test_target/results/latest/sphinx/html .
-
-          - name: Upload artifact
-            uses: actions/upload-artifact@v4
-            with:
-              name: html
-              path: ${{ github.workspace }}/docs.tar.gz
+          # Docs (Sphinx + LaTeX PDF) + GitHub Pages are built/deployed
+          # out-of-band by docs.yaml, triggered on `release: published`. That
+          # keeps this release path fast and stops a docs/PDF failure from
+          # blocking the image publish + GitHub release. docs.yaml attaches the
+          # PDF to the release it triggered on.
 
           - name: Create release
             id: create_release
@@ -197,31 +134,5 @@ jobs:
               prerelease: false
               files: |
                 config_schema.yaml
-                ${{ github.workspace }}/tests/unit_tests/test_target/results/latest/sphinx/latex/penguin.pdf 
-                ${{ github.workspace }}/tests/unit_tests/test_target/results/latest/sphinx/docs.tar.gz
-    
-    deploy_static:
-      needs: build_container
-      runs-on: ubuntu-latest
-      environment:
-        name: github-pages
-        url: ${{ steps.deployment.outputs.page_url }}
-      steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: html
-      - name: Unzip HTML
-        run: |
-          mkdir html_content
-          tar -xvf docs.tar.gz -C html_content
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          # Upload entire repository
-          path: 'html_content'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+              # The PDF + docs.tar.gz are attached to this release by docs.yaml
+              # after it builds the docs (release: published trigger).


### PR DESCRIPTION
Track-3 release split + full migration onto `rehosting/ci`. **Draft** — `publish.yaml`/`docs.yaml` only fire on push-to-main / release, so this **cannot be dry-run**; the first real exercise is the next merge→release. Review carefully before merge.

## 1. Decouple docs
- `publish.yaml` no longer builds docs; new `docs.yaml` (`on: release: published`, + `workflow_dispatch` tag input) builds Sphinx HTML + LaTeX PDF, deploys Pages, and attaches the PDF + tarball to the triggering release. A docs/PDF failure no longer blocks the image publish or release.
- Fixed the `docs.tar.gz` release-asset path bug.

## 2. Migrate onto rehosting/ci
- `publish.yaml` restructured: **version** (ubuntu-latest) → **build** (`uses: rehosting/ci/.github/workflows/build-and-push.yml@v1`) → **release** (ubuntu-latest, schema + GitHub release).
- The shared workflow gained two features for this: optional **Docker Hub login** (`dockerhub-token`) and **`cache-to-extra`** (keep refreshing `:cache_last_published`). Landed in `rehosting/ci@v1` (v1.2.0).
- Registry setup in both workflows uses `arc-registry-setup@v1`.
- **Dropped**: the bespoke build-push step and the apt-mirror hack from the release path (build runs via the shared workflow; version/release are GitHub-hosted). `docs.yaml` keeps the apt-mirror fixup since it still apt-installs on rehosting-arc.

## Risks (can't be dry-run)
- `build` now depends on `rehosting/ci@v1`. Cache refs hardcode the Harbor host (a reusable-workflow `with:` can't reference `secrets`); safe because publish only runs on the main repo, never forks.
- First publish after merge is the real test of: dual-registry push, version/latest tags, `cache_last_published` refresh, and the docs→release asset handoff.
