### PR TITLE
publish: add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  # Manual trigger: cut a release on demand (also useful for verifying the
+  # release pipeline after CI changes). Like a push to main, this bumps the
+  # version and publishes — there is no dry-run.
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds `workflow_dispatch` to `publish.yaml` so a release can be cut on demand (and the release pipeline verified after CI changes) rather than only on push to main.

Same behavior as a push: bumps the version and publishes — there is no dry-run. Useful now that publish is restructured onto the shared `build-and-push.yml@v1` (first end-to-end run can be triggered deliberately instead of waiting for the next organic merge).