### PR TITLE
docs: trigger via workflow_run (on: release never fires from GITHUB_TOKEN release)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,18 +1,25 @@
 name: Docs
 
 # Docs (Sphinx HTML + LaTeX PDF) and the GitHub Pages deploy, decoupled from
-# publish.yaml. Triggered when publish.yaml creates a Release, this builds the
-# docs FROM the just-published image, deploys Pages, and attaches the PDF +
-# docs tarball to that release. A docs/PDF failure here no longer blocks the
-# image publish or the GitHub release.
+# publish.yaml. Runs AFTER the "Release Container" (publish) workflow completes,
+# builds the docs from the just-published image, deploys Pages, and attaches the
+# PDF + docs tarball to the latest release. A docs/PDF failure here no longer
+# blocks the image publish or the GitHub release.
+#
+# NOTE: this uses `workflow_run`, NOT `on: release`. publish creates the release
+# with the default GITHUB_TOKEN, and GitHub does not fire `release` events from
+# GITHUB_TOKEN-created releases (recursion prevention) — so `on: release` would
+# never trigger. `workflow_run` fires regardless.
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release Container"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to (re)build docs for
-        required: true
+        description: Release tag to (re)build docs for (default: latest release)
+        required: false
+        default: ""
 
 permissions:
   contents: write   # attach PDF/docs.tar.gz assets to the release
@@ -23,12 +30,11 @@ concurrency:
   group: "docs"
   cancel-in-progress: false
 
-env:
-  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
-
 jobs:
   build_docs:
     runs-on: rehosting-arc
+    # Only after a SUCCESSFUL publish (or a manual dispatch).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Install dependencies and label git workspace safe
         run: |
@@ -46,11 +52,26 @@ jobs:
           sudo apt-get -y install git curl jq gzip
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      # Resolve which release to build docs for: the dispatch input if given,
+      # else the latest release (which the just-finished publish created).
+      - name: Resolve release tag
+        id: rel
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ github.event.inputs.tag }}"
+          if [ -z "$tag" ]; then
+            tag="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q .tagName)"
+          fi
+          echo "Building docs for release: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ steps.rel.outputs.tag }}
 
       # Harbor cert trust + insecure buildx + login via the shared org action.
       - name: Set up Arc registry (cert, buildx, login)
@@ -114,7 +135,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.RELEASE_TAG }}
+          tag_name: ${{ steps.rel.outputs.tag }}
           files: |
             ${{ github.workspace }}/tests/unit_tests/test_target/results/latest/sphinx/latex/penguin.pdf
             ${{ github.workspace }}/docs.tar.gz

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to (re)build docs for (default: latest release)
+        description: "Release tag to (re)build docs for (default: latest release)"
         required: false
         default: ""
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,7 +66,9 @@ jobs:
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   # 3. Config schema + GitHub release (after the image exists). Docs/PDF/Pages
-  #    are built out-of-band by docs.yaml on `release: published`.
+  #    are built out-of-band by docs.yaml, which runs via `workflow_run` after
+  #    this workflow completes (a GITHUB_TOKEN-created release can't fire
+  #    `on: release`).
   release:
     needs: [version, build]
     runs-on: ubuntu-latest


### PR DESCRIPTION
The verification release (v3.0.36) cut fine but **docs.yaml never ran**: publish creates the release with the default `GITHUB_TOKEN`, and GitHub does not fire `on: release` workflows from GITHUB_TOKEN-created releases (recursion prevention).

Fix: docs.yaml now triggers on `workflow_run` (Release Container completed, success) — which fires regardless of token — and resolves the release tag from the `workflow_dispatch` input or the latest release. Gated on a successful publish. Keeps docs fully decoupled (own run; a docs failure doesn't fail publish).