### PR TITLE
docs: resolve release tag via REST API (rehosting-arc has no gh CLI)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -62,7 +62,19 @@ jobs:
           set -euo pipefail
           tag="${{ github.event.inputs.tag }}"
           if [ -z "$tag" ]; then
-            tag="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q .tagName)"
+            # The rehosting-arc runner has no `gh` CLI, so hit the REST API
+            # directly (curl + jq are installed above). `releases/latest`
+            # returns the newest published release — i.e. the one the
+            # just-finished publish workflow created.
+            tag="$(curl -fsSL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest" \
+              | jq -r .tag_name)"
+          fi
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            echo "Could not resolve a release tag" >&2
+            exit 1
           fi
           echo "Building docs for release: $tag"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem
The first real `workflow_run` auto-trigger of `docs.yaml` (after the v3.0.37 publish) **failed**: the *Resolve release tag* step falls back to `gh release view` when no dispatch `tag` input is given, but the `rehosting-arc` runner has no `gh` CLI installed → `gh: command not found` (exit 127).

The earlier v3.0.36 **dispatch** test passed only because it supplied `-f tag=v3.0.36`, which skips the fallback branch entirely — so the bug was masked until a real auto-trigger exercised the fallback.

## Fix
Resolve the latest release tag via the GitHub REST API using `curl` + `jq` (both already installed in the deps step), and fail loudly if the tag can't be resolved. No `gh` dependency.

## Verify
After merge, the next publish-driven `workflow_run` should resolve the tag and attach `penguin.pdf` + `docs.tar.gz`. Can also re-run docs for the missing v3.0.37 via `gh workflow run docs.yaml -f tag=v3.0.37`.