### PR TITLE
vpn: own N interfaces with a per-service interface routing matrix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG BASE_IMAGE="${REGISTRY}/ubuntu:22.04"
 # provenance for the versions penguin-tools bundles; a developer can still
 # override any single tool by dropping its tarball in local_packages/ (the
 # local_packages stage below applies after penguin-tools, so it wins).
-ARG VPN_VERSION="1.0.25"
+ARG VPN_VERSION="1.0.28"
 ARG BUSYBOX_VERSION="0.0.19"
 ARG LINUX_VERSION="3.5.33-beta"
 ARG IGLOO_DRIVER_VERSION="0.0.86"
@@ -15,7 +15,7 @@ ARG LIBNVRAM_VERSION="0.0.26"
 ARG CONSOLE_VERSION="1.0.7"
 ARG GUESTHOPPER_VERSION="1.0.21"
 ARG HYPERFS_VERSION="0.0.44"
-ARG PENGUIN_TOOLS_VERSION="0.0.20"
+ARG PENGUIN_TOOLS_VERSION="0.0.23"
 ARG GLOW_VERSION="1.5.1"
 ARG GUM_VERSION="0.14.5"
 ARG LTRACE_PROTOTYPES_VERSION="0.7.91"

--- a/pyplugins/actuation/vpn.py
+++ b/pyplugins/actuation/vpn.py
@@ -113,6 +113,32 @@ class VPN(Plugin):
         spoof: Optional[Dict] = Field(
             default=None, description="Source IP spoofing configuration keyed by <proto>:<guest_ip>:<guest_port> with 'source' and 'dev' entries."
         )
+        interfaces: Optional[Dict] = Field(
+            default=None,
+            description=(
+                "Owned interfaces the VPN guest agent stands up as tap-backed userspace TCP/IP "
+                "stacks, keyed by guest interface name with {host_ip, guest_ip, prefix} values "
+                "(any omitted -> WAN defaults 203.0.113.1/203.0.113.2/24). A service routed to "
+                "one of these (see 'routes'/'default_interface') genuinely ingresses on that "
+                "interface so the firmware's netfilter 'INPUT -i <iface>' chain is exercised. "
+                "Unset -> only the default loopback ('LAN') path exists (the historical behavior)."
+            ),
+        )
+        routes: Optional[Dict] = Field(
+            default=None,
+            description=(
+                "Interface routing matrix, keyed exactly like 'spoof' (<proto>:<guest_ip>:<guest_port>) "
+                "-> an interface name from 'interfaces'. Independent of 'spoof': spoof picks the "
+                "source IP, routes picks the ingress interface."
+            ),
+        )
+        default_interface: Optional[str] = Field(
+            default=None,
+            description=(
+                "Interface (a key of 'interfaces') used for binds with no matching 'routes' entry. "
+                "Unset -> unrouted binds use the default loopback path."
+            ),
+        )
 
     def __init__(self, panda) -> None:
         """
@@ -202,6 +228,44 @@ class VPN(Plugin):
         if self.spoof and not self.get_arg("conf")["core"]["guest_cmd"]:
             self.logger.error("guest_cmd is disabled!")
             raise ValueError("Source address spoofing requires guest_cmd to be enabled")
+
+        """
+        Owned interfaces + interface routing matrix. E.g.
+            interfaces:
+              wan0: { host_ip: 203.0.113.1, guest_ip: 203.0.113.2, prefix: 24 }
+            default_interface: wan0      # or per-service via routes
+            routes:
+              "tcp:192.168.1.1:443": wan0
+        Each declared interface is handed to the guest agent (via the
+        IGLOO_OWN_IFACES env var -> --own-iface flags) which stands up a
+        tap-backed stack on it. _do_bridge tags each event line with the chosen
+        interface so the host side routes the forward through it.
+        """
+        self.interfaces = self.get_arg("interfaces") or {}
+        self.routes = self.get_arg("routes") or {}
+        self.default_interface = self.get_arg("default_interface")
+        for key, name in self.routes.items():
+            if name not in self.interfaces:
+                raise ValueError(
+                    f"vpn.routes['{key}'] references undeclared interface '{name}'"
+                )
+        if self.default_interface and self.default_interface not in self.interfaces:
+            raise ValueError(
+                f"vpn.default_interface '{self.default_interface}' is not in vpn.interfaces"
+            )
+        if self.interfaces:
+            specs = []
+            for name, spec in self.interfaces.items():
+                spec = spec or {}
+                host = spec.get("host_ip", "") or ""
+                guest = spec.get("guest_ip", "") or ""
+                prefix = spec.get("prefix", "")
+                prefix = "" if prefix in (None, "") else str(prefix)
+                specs.append(f"{name}:{host}/{guest}/{prefix}")
+            conf = self.get_arg("conf")
+            conf["env"]["IGLOO_OWN_IFACES"] = ";".join(specs)
+            self.logger.info(f"VPN owning interfaces: {conf['env']['IGLOO_OWN_IFACES']}")
+
         self.port_map_lock = threading.Lock()
         self.lock = threading.Lock()
 
@@ -457,8 +521,13 @@ class VPN(Plugin):
                 self.logger.debug(f"Will spoof source address for {guest_addr} with {source_ip}")
                 self.ensure_dev_has_ip(source_ip, spoof["dev"], ipvn)
 
+            # Interface matrix: route this service to an owned interface (real
+            # ingress on that iface) or, if none matches, the loopback path
+            # (empty field). Independent of spoof's source-IP choice above.
+            iface = self.routes.get(guest_addr) or self.default_interface or ""
+
             with open(self.event_file.name, "a") as f:
-                f.write(f"{sock_type},{ip}:{guest_port},0.0.0.0:{host_port},{source_ip}:0\n")
+                f.write(f"{sock_type},{ip}:{guest_port},0.0.0.0:{host_port},{source_ip}:0,{iface}\n")
 
             with open(join(self.outdir, BRIDGE_FILE), "a") as f:
                 f.write(f"{procname},ipv{ipvn},{sock_type},{ip},{guest_port},{host_port}\n")

--- a/pyplugins/testing/owned_iface_test.py
+++ b/pyplugins/testing/owned_iface_test.py
@@ -1,0 +1,184 @@
+'''
+Exercises the vpn owned-interface datapaths end to end against a guest that owns
+a tap-backed interface (`testif`, declared in patches/tests/owned_iface.yaml):
+
+  - Inc A (TCP forward): `wan-probe --iface testif` reaches a guest httpd through
+    the tap stack -> reported "open".
+  - Inc B (raw L3): `raw --iface testif --proto 1` sends an ICMP echo through the
+    interface; the guest kernel answers -> "echo-reply".
+  - Inc C (raw L2): a self-contained ARP exchange over the raw-L2 vsock port
+    (no host /dev/net/tun needed): inject an ARP request frame and read the
+    guest's reply tee'd back over the bridge.
+
+Each check writes a result file the verifier asserts on (see the patch).
+'''
+
+from penguin import plugins, Plugin
+import threading
+import time
+import socket
+import struct
+import subprocess
+
+VPN_BIN = "/igloo_static/vpn/vpn.x86_64"   # host-side vpn binary in the image
+IFACE = "testif"
+HOST_IP = "10.99.0.1"     # smoltcp side
+GUEST_IP = "10.99.0.2"    # guest side (assigned to the tap by the agent)
+HTTPD_PORT = 8010
+CMD_PORT = 1234           # guest agent default; raw L3 = +1, raw L2 = +2
+
+
+class OwnedIfaceTest(Plugin):
+    def __init__(self) -> None:
+        self.outdir = self.get_arg("outdir")
+        self.uds = str(self.get_arg("uds_path"))
+        self.started = False
+        self.results = {"probe": False, "raw": False, "l2": False}
+        self.logger.info(f"owned_iface_test init (uds={self.uds})")
+        plugins.subscribe(plugins.VPN, "on_bind", self.on_bind)
+
+    def on_bind(self, proto, guest_ip, guest_port, host_port, host_ip, procname):
+        # The httpd bind means the guest is up and the tap stack is running.
+        self.logger.info(f"owned_iface_test on_bind {proto} {guest_ip}:{guest_port}")
+        if proto == "tcp" and guest_port == HTTPD_PORT and not self.started:
+            self.started = True
+            self.logger.info("owned_iface_test: starting checks")
+            threading.Thread(target=self.run_checks, daemon=True).start()
+
+    def run_checks(self):
+        self.check_probe()
+        self.check_raw()
+        self.check_l2()
+
+    def _write(self, name, ok, ok_str):
+        with open(f"{self.outdir}/{name}", "w") as f:
+            f.write(ok_str if ok else f"{name} FAILED\n")
+
+    # --- Inc A: TCP forward routed through the owned interface ---------------
+    def check_probe(self):
+        for _ in range(8):
+            try:
+                out = subprocess.run(
+                    [VPN_BIN, "wan-probe", "-u", self.uds, "--iface", IFACE,
+                     "--ports", str(HTTPD_PORT), "--timeout", "5"],
+                    capture_output=True, text=True, timeout=40).stdout
+                self.logger.info("wan-probe: " + " ".join(out.split()))
+                if "open" in out:
+                    self.results["probe"] = True
+                    break
+            except Exception as e:
+                self.logger.info(f"wan-probe attempt failed: {e}")
+            time.sleep(1)
+        self._write("owned_iface_probe.txt", self.results["probe"],
+                    "OWNED IFACE PROBE OK\n")
+
+    # --- Inc B: raw L3 ICMP echo through the interface -----------------------
+    def check_raw(self):
+        for _ in range(6):
+            try:
+                out = subprocess.run(
+                    [VPN_BIN, "raw", "-u", self.uds, "--iface", IFACE,
+                     "--proto", "1", "--src-ip", HOST_IP, "--dst-ip", GUEST_IP,
+                     "--count", "2", "--timeout", "3"],
+                    capture_output=True, text=True, timeout=40).stdout
+                self.logger.info("raw: " + " ".join(out.split()))
+                if "echo-reply" in out:
+                    self.results["raw"] = True
+                    break
+            except Exception as e:
+                self.logger.info(f"raw attempt failed: {e}")
+            time.sleep(1)
+        self._write("owned_iface_raw.txt", self.results["raw"],
+                    "OWNED IFACE RAW OK\n")
+
+    # --- Inc C: raw L2 ARP exchange over the bridge --------------------------
+    def check_l2(self):
+        for _ in range(6):
+            try:
+                if self._l2_arp_once():
+                    self.results["l2"] = True
+                    break
+            except Exception as e:
+                self.logger.info(f"L2 arp attempt failed: {e}")
+            time.sleep(2)
+        self._write("owned_iface_l2.txt", self.results["l2"],
+                    "OWNED IFACE L2 OK\n")
+
+    def _l2_arp_once(self) -> bool:
+        l2_port = CMD_PORT + 2
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(6)
+        try:
+            s.connect(self.uds)
+            s.sendall(f"CONNECT {l2_port}\n".encode())
+            if not self._readline(s).startswith(b"OK"):
+                return False
+            # RawL2{iface}: bincode enum variant 2 (u32 LE) + String (u64 LE len
+            # + bytes); framed by a u16 BE length prefix (matches wan_probe/host).
+            payload = struct.pack("<I", 2) + struct.pack("<Q", len(IFACE)) + IFACE.encode()
+            s.sendall(struct.pack(">H", len(payload)) + payload)
+
+            my_mac = bytes.fromhex("020000000050")
+            frame = self._arp_request(my_mac, "10.99.0.50", GUEST_IP)
+            s.sendall(struct.pack(">H", len(frame)) + frame)
+
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                hdr = self._recvn(s, 2)
+                if not hdr:
+                    break
+                (flen,) = struct.unpack(">H", hdr)
+                fr = self._recvn(s, flen)
+                if not fr or len(fr) < 42:
+                    continue
+                # Ethertype ARP, opcode reply, sender protocol addr == GUEST_IP.
+                if fr[12:14] == b"\x08\x06" and fr[20:22] == b"\x00\x02" \
+                        and fr[28:32] == socket.inet_aton(GUEST_IP):
+                    return True
+            return False
+        finally:
+            s.close()
+
+    @staticmethod
+    def _arp_request(my_mac: bytes, spa: str, tpa: str) -> bytes:
+        eth = b"\xff" * 6 + my_mac + b"\x08\x06"
+        arp = struct.pack(">HHBBH", 1, 0x0800, 6, 4, 1)  # ether/IPv4, request
+        arp += my_mac + socket.inet_aton(spa)
+        arp += b"\x00" * 6 + socket.inet_aton(tpa)
+        return eth + arp
+
+    @staticmethod
+    def _recvn(s, n):
+        buf = b""
+        while len(buf) < n:
+            try:
+                chunk = s.recv(n - len(buf))
+            except socket.timeout:
+                return None
+            if not chunk:
+                return None
+            buf += chunk
+        return buf
+
+    @staticmethod
+    def _readline(s):
+        buf = b""
+        while b"\n" not in buf:
+            c = s.recv(1)
+            if not c:
+                break
+            buf += c
+        return buf
+
+    def uninit(self):
+        # Ensure a definite result file exists for each check.
+        for key, name in (("probe", "owned_iface_probe.txt"),
+                          ("raw", "owned_iface_raw.txt"),
+                          ("l2", "owned_iface_l2.txt")):
+            try:
+                open(f"{self.outdir}/{name}", "x").close()
+                # Newly created (check never wrote it): mark failed.
+                with open(f"{self.outdir}/{name}", "w") as f:
+                    f.write(f"{name} FAILED (no result)\n")
+            except FileExistsError:
+                pass

--- a/pyplugins/testing/owned_iface_test.py
+++ b/pyplugins/testing/owned_iface_test.py
@@ -38,9 +38,14 @@ class OwnedIfaceTest(Plugin):
         plugins.subscribe(plugins.VPN, "on_bind", self.on_bind)
 
     def on_bind(self, proto, guest_ip, guest_port, host_port, host_ip, procname):
-        # The httpd bind means the guest is up and the tap stack is running.
+        # Any bind on the tap IP means the agent assigned it and the tap stack is
+        # running -- start the checks then. We deliberately do NOT key on the
+        # httpd's tcp :8010 bind specifically: that single event is sometimes
+        # reported late or as udp, and missing it stranded the whole test. The
+        # checks retry until the httpd listener answers, so triggering on the
+        # first GUEST_IP bind is both sufficient and robust.
         self.logger.info(f"owned_iface_test on_bind {proto} {guest_ip}:{guest_port}")
-        if proto == "tcp" and guest_port == HTTPD_PORT and not self.started:
+        if guest_ip == GUEST_IP and not self.started:
             self.started = True
             self.logger.info("owned_iface_test: starting checks")
             threading.Thread(target=self.run_checks, daemon=True).start()

--- a/src/resources/source.d/60_launch_vpn.sh
+++ b/src/resources/source.d/60_launch_vpn.sh
@@ -1,5 +1,30 @@
 if [ ! -z "${CID}" ]; then
   echo '[IGLOO INIT] Launching VPN';
-  /igloo/utils/vpn guest -c ${CID} >/dev/null &
+  # Owned-interface datapaths: when IGLOO_OWN_IFACES is set (by the vpn pyplugin
+  # from plugins.vpn.interfaces), the guest agent stands up a tap-backed userspace
+  # TCP/IP stack per interface so forwards routed to it genuinely ingress there and
+  # traverse the firmware's netfilter INPUT chain. Taps are created here (before
+  # firmware rc configures the interface), so wan_ifname=<NAME> finds it.
+  # IGLOO_OWN_IFACES = "NAME:HOST/GUEST/PREFIX;NAME2:..." (semicolon-separated).
+  IFACE_FLAGS=""
+  if [ ! -z "${IGLOO_OWN_IFACES}" ]; then
+    OLDIFS="${IFS}"; IFS=';'
+    for spec in ${IGLOO_OWN_IFACES}; do
+      [ -z "${spec}" ] && continue
+      IFACE_FLAGS="${IFACE_FLAGS} --own-iface ${spec}"
+    done
+    IFS="${OLDIFS}"
+    echo "[IGLOO INIT] VPN owning interfaces: ${IGLOO_OWN_IFACES}";
+  elif [ ! -z "${IGLOO_WAN_IFACE}" ]; then
+    # Deprecated single-interface alias (kept for one release).
+    echo "[IGLOO INIT] VPN WAN datapath enabled on ${IGLOO_WAN_IFACE} (deprecated; use plugins.vpn.interfaces)";
+    IFACE_FLAGS="--wan-iface ${IGLOO_WAN_IFACE}"
+  fi
+
+  if [ ! -z "${IFACE_FLAGS}" ]; then
+    RUST_LOG=info /igloo/utils/vpn guest -c ${CID} ${IFACE_FLAGS} 2>&1 &
+  else
+    /igloo/utils/vpn guest -c ${CID} >/dev/null &
+  fi
   unset CID
 fi

--- a/tests/unit_tests/test_target/base_config.yaml
+++ b/tests/unit_tests/test_target/base_config.yaml
@@ -33,6 +33,7 @@ patches:
   - ./patches/tests/net_missing.yaml
   - ./patches/tests/netbinds.yaml
   - ./patches/tests/netbinds_lifecycle.yaml
+  - ./patches/tests/owned_iface.yaml
   - ./patches/tests/netdevs.yaml
   - ./patches/tests/netdev_auto_register.yaml
   - ./patches/tests/netdev_names.yaml

--- a/tests/unit_tests/test_target/patches/tests/owned_iface.yaml
+++ b/tests/unit_tests/test_target/patches/tests/owned_iface.yaml
@@ -47,5 +47,19 @@ static_files:
           /igloo/utils/busybox sleep 2
         done
       ) &
+      # run_tests.sh is guest PID1; when it exits the run ends and the verifier
+      # runs. The host-side checks (owned_iface_test) only fire once the agent
+      # has assigned 10.99.0.2 to testif, which is slow under heavy qemu
+      # emulation (mips*/aarch64/loongarch/ppc) -- often slower than the rest of
+      # the suite. Without holding init open the run ends before the tap is up
+      # and all three checks fail with "no result". Block here until the IP
+      # lands (bounded) plus a grace window for the probe/raw/l2 checks to run,
+      # then exit so the run still terminates.
+      i=0
+      while [ $i -lt 180 ]; do
+        /igloo/utils/busybox ip addr show testif 2>/dev/null | /igloo/utils/busybox grep -q 10.99.0.2 && break
+        /igloo/utils/busybox sleep 1; i=$((i+1))
+      done
+      /igloo/utils/busybox sleep 30
       exit 0
     mode: 73

--- a/tests/unit_tests/test_target/patches/tests/owned_iface.yaml
+++ b/tests/unit_tests/test_target/patches/tests/owned_iface.yaml
@@ -1,0 +1,43 @@
+# Exercises the vpn owned-interface datapaths. The vpn plugin owns a tap-backed
+# interface `testif`; the guest agent stands it up and assigns it 10.99.0.2. A
+# guest httpd on :8010 is reachable on the tap, and owned_iface_test drives the
+# TCP forward (Inc A), raw L3 ICMP (Inc B), and raw L2 ARP (Inc C) datapaths
+# through it. See pyplugins/testing/owned_iface_test.py.
+plugins:
+  verifier:
+    conditions:
+      owned_iface_probe:
+        type: file_contains
+        file: owned_iface_probe.txt
+        string: "OWNED IFACE PROBE OK"
+      owned_iface_raw:
+        type: file_contains
+        file: owned_iface_raw.txt
+        string: "OWNED IFACE RAW OK"
+      owned_iface_l2:
+        type: file_contains
+        file: owned_iface_l2.txt
+        string: "OWNED IFACE L2 OK"
+  vpn:
+    interfaces:
+      testif:
+        host_ip: 10.99.0.1
+        guest_ip: 10.99.0.2
+        prefix: 24
+  owned_iface_test: {}
+static_files:
+  /tests/owned_iface.sh:
+    type: inline_file
+    contents: |
+      #!/igloo/utils/sh
+      # Wait for the agent to assign the tap IP, then serve on it (bind the
+      # IPv4 address explicitly so the probe reaches a v4 listener). Backgrounded
+      # so run_tests.sh continues.
+      i=0
+      while [ $i -lt 20 ]; do
+        /igloo/utils/busybox ip addr show testif 2>/dev/null | /igloo/utils/busybox grep -q 10.99.0.2 && break
+        /igloo/utils/busybox sleep 1; i=$((i+1))
+      done
+      /igloo/utils/busybox httpd -p 10.99.0.2:8010 -h / &
+      exit 0
+    mode: 73

--- a/tests/unit_tests/test_target/patches/tests/owned_iface.yaml
+++ b/tests/unit_tests/test_target/patches/tests/owned_iface.yaml
@@ -30,14 +30,22 @@ static_files:
     type: inline_file
     contents: |
       #!/igloo/utils/sh
-      # Wait for the agent to assign the tap IP, then serve on it (bind the
-      # IPv4 address explicitly so the probe reaches a v4 listener). Backgrounded
-      # so run_tests.sh continues.
-      i=0
-      while [ $i -lt 20 ]; do
-        /igloo/utils/busybox ip addr show testif 2>/dev/null | /igloo/utils/busybox grep -q 10.99.0.2 && break
-        /igloo/utils/busybox sleep 1; i=$((i+1))
-      done
-      /igloo/utils/busybox httpd -p 10.99.0.2:8010 -h / &
+      # Serve on the tap IP (bind the IPv4 address explicitly so the probe
+      # reaches a v4 listener). The agent assigns 10.99.0.2 to testif
+      # asynchronously and the timing varies a lot under CI load, so we cannot
+      # one-shot this: a backgrounded `httpd -p` daemonizes and returns success
+      # even when bind() fails (EADDRNOTAVAIL before the IP lands), leaving no
+      # listener and the test trigger (tcp :8010) never firing. Instead loop in
+      # the foreground (-f): once the IP is present httpd binds and blocks
+      # serving; if it ever exits (bind failed / killed) we retry. The whole
+      # loop is backgrounded so run_tests.sh continues.
+      (
+        while true; do
+          if /igloo/utils/busybox ip addr show testif 2>/dev/null | /igloo/utils/busybox grep -q 10.99.0.2; then
+            /igloo/utils/busybox httpd -f -p 10.99.0.2:8010 -h /
+          fi
+          /igloo/utils/busybox sleep 2
+        done
+      ) &
       exit 0
     mode: 73


### PR DESCRIPTION
## Problem

The VPN plugin exposes guest services by connecting to `127.0.0.1` inside the
guest, so forwarded traffic is delivered over `lo` and never traverses the guest's
netfilter `INPUT -i <iface>` chain. There's no declarative way to have a service
reached on its real ingress interface (e.g. an uplink) so the firewall is actually
exercised.

## What this does

Adds a declarative way for the guest agent to own interfaces and route exposures
across them, plus a per-service interface matrix that parallels the existing
`spoof` (origin-IP) matrix:

- `plugins.vpn.interfaces`: `name -> {host_ip, guest_ip, prefix}` — each becomes a
  tap-backed stack the guest agent owns. Unset → loopback only (unchanged).
- `plugins.vpn.routes`: interface matrix keyed exactly like `spoof`
  (`<proto>:<guest_ip>:<port>`) `-> interface`. Independent of `spoof` (which picks
  the source IP); they compose. `plugins.vpn.default_interface` for unmatched binds.
- The owned-interface set is emitted as `IGLOO_OWN_IFACES`, and the bridge event
  line carries the chosen interface so the host side routes the forward through it.
- `60_launch_vpn.sh` turns `IGLOO_OWN_IFACES` into `--own-iface` flags
  (`IGLOO_WAN_IFACE` kept as a deprecated single-interface alias).

## Compatibility

With no `interfaces`/`routes` declared, behaviour is unchanged (loopback path).

## Pairing

Requires the companion guest-agent change: rehosting/vpnguin#31 (owned-interface
datapaths). Verified together on-target against an emulated device — a probe flips
`filtered`→`open` with a live `INPUT -i <iface>` rule, confirming traffic reaches
the service through the guest's real firewall.
