### PR TITLE
Fix penguin schema (plugin args via AST) + local Docker build hiccups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -322,7 +322,7 @@ ARG FW2TAR_TAG
 RUN git clone --depth=1 -b ${FW2TAR_TAG} https://github.com/rehosting/fw2tar.git /tmp/fw2tar
 RUN git clone --depth=1 https://github.com/davidribyrne/cramfs.git /cramfs && \
     cd /cramfs && make
-RUN git clone --depth=1 https://github.com/rehosting/unblob.git /unblob
+RUN git clone --depth=1 --branch main-pre-26.6.4 https://github.com/rehosting/unblob.git /unblob
 
 RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 ARG SSH

--- a/Dockerfile
+++ b/Dockerfile
@@ -306,9 +306,14 @@ RUN if [ ! -z "${OVERRIDE_VERSION}" ]; then \
         echo "Pretending version is ${OVERRIDE_VERSION}"; \
     else \
         python3 -m pip install setuptools_scm; \
-        echo -n "v" >> /app/version.txt; \
-        python3 -m setuptools_scm -r /app/ >> /app/version.txt; \
-        echo "Generating version from git"; \
+        SCM_VERSION="$(python3 -m setuptools_scm -r /app/ 2>/dev/null)"; \
+        if [ -z "${SCM_VERSION}" ]; then \
+            SCM_VERSION="0.0.0.dev0"; \
+            echo "setuptools_scm produced no version (e.g. a git worktree, whose .git is a pointer file, or a checkout without tags); defaulting to dev version ${SCM_VERSION}"; \
+        else \
+            echo "Generating version from git"; \
+        fi; \
+        echo "v${SCM_VERSION}" > /app/version.txt; \
     fi;
 
 ### Build fw2tar deps ahead of time ###

--- a/penguin
+++ b/penguin
@@ -162,6 +162,7 @@ penguin_run() {
     local replace=false # --replace: reclaim a colliding container name
     local image="" # Container to run; resolved below (flag > env > file > default)
     local image_explicit=false # whether --image was passed
+    local image_is_default=false # whether image fell through to the built-in moving default
     local extra_docker_args=""
     local standalone=false
     local engine_override="" # --docker/--podman/--engine; empty means auto-detect
@@ -289,6 +290,7 @@ penguin_run() {
             image="$(head -n1 "$image_file" | tr -d '[:space:]')"
         else
             image="rehosting/penguin:latest"
+            image_is_default=true
         fi
     fi
 
@@ -838,12 +840,14 @@ penguin_run() {
 
     # We are about to launch a fresh container (all exec-into-existing and
     # teardown commands have exited above). Nudge away from the moving :latest
-    # tag -- the main source of "it worked yesterday" irreproducibility. Skip for
-    # local builds (image is built here, not pulled) and reproduce (pins its own).
-    if ! $build && ! $reproduce; then
-        if [[ "$image" == *:latest || "$image" != *:* ]]; then
-            echo "${BOLD}WARNING:${RESET} using moving image '${image}' (resolves to :latest). Pin a release via --image, PENGUIN_IMAGE, or a .penguin-image file for reproducible runs." >&2
-        fi
+    # tag -- the main source of "it worked yesterday" irreproducibility. Only
+    # warn when the image fell through to the built-in default: if the user
+    # named an image (--image, PENGUIN_IMAGE, or .penguin-image) they made a
+    # deliberate choice -- even ':latest' of their own image is a specific build
+    # to them -- so don't nag. Skip for local builds (image is built here, not
+    # pulled) and reproduce (pins its own).
+    if ! $build && ! $reproduce && $image_is_default; then
+        echo "${BOLD}WARNING:${RESET} using moving image '${image}' (resolves to :latest). Pin a release via --image, PENGUIN_IMAGE, or a .penguin-image file for reproducible runs." >&2
     fi
 
     # Check if we're in an interactive terminal, if so add -it

--- a/src/penguin/__main__.py
+++ b/src/penguin/__main__.py
@@ -864,7 +864,6 @@ def schema(ctx, section, project_dir, as_json):
     """
     _startup_checks(ctx.obj['VERBOSE'])
     from penguin.penguin_config import gen_docs
-    from penguin.penguin_config.gen_docs import DocsField
 
     if not section:
         if as_json:
@@ -887,9 +886,12 @@ def schema(ctx, section, project_dir, as_json):
             except AttributeError:
                 click.echo(f"(section '{section}' is a primitive type with no sub-schema)")
             return
+        # Resolve through the owning field so field-level metadata (e.g. the
+        # `plugins` section's title, which lives on its Field rather than its
+        # type) is preserved; DocsField.from_type alone would drop it.
         md = gen_docs.gen_docs(
             path=section.split("."),
-            docs_field=DocsField.from_type(resolved),
+            docs_field=gen_docs.resolve_section_docs_field(section),
         )
         _render_markdown(md)
         return

--- a/src/penguin/__main__.py
+++ b/src/penguin/__main__.py
@@ -859,8 +859,9 @@ def schema(ctx, section, project_dir, as_json):
 
     With no SECTION, lists the top-level config sections. With a dotted SECTION
     (e.g. `core`, `pseudofiles.read`, `pseudofiles.read.const_buf`), renders that
-    part of the schema. If SECTION names a plugin that declares an `Args` schema,
-    its arguments are rendered instead.
+    part of the schema. `schema plugins` additionally lists the declared
+    arguments of every discovered plugin; `schema <plugin>` (or the dotted
+    `schema plugins.<plugin>`) renders one plugin's arguments.
     """
     _startup_checks(ctx.obj['VERBOSE'])
     from penguin.penguin_config import gen_docs
@@ -874,8 +875,37 @@ def schema(ctx, section, project_dir, as_json):
             lines.append(f"- `{name}` — {title}")
         lines.append("")
         lines.append("Run `penguin schema <section>` to see details, e.g. `penguin schema core`.")
-        lines.append("Run `penguin schema <plugin>` to see a plugin's arguments.")
+        lines.append("Run `penguin schema plugins` to see every plugin's arguments, "
+                     "or `penguin schema <plugin>` for a single plugin.")
         _render_markdown("\n".join(lines))
+        return
+
+    from penguin.penguin_config import structure as _structure
+    plugin_path = _structure.Core.model_fields["plugin_path"].default
+
+    # The `plugins` section is special: its type is just `dict[str, Plugin]`
+    # (the generic per-plugin keys), which says nothing about what arguments any
+    # given plugin actually accepts. Augment it with every discovered plugin's
+    # declared `Args` so `penguin schema plugins` surfaces real plugin arguments.
+    if section == "plugins":
+        # Read declared Args via AST (no import) so every plugin is covered, not
+        # just those importable outside a live emulator — the same static
+        # approach config-load validation uses.
+        if as_json:
+            from penguin.plugin_manager import discover_declaring_plugins_static
+            found, _skipped = discover_declaring_plugins_static(plugin_path)
+            click.echo(yaml.dump(
+                {name: _arg_specs_to_schema(specs) for name, specs in found},
+                indent=2, sort_keys=False,
+            ))
+            return
+        section_md = gen_docs.gen_docs(
+            path=["plugins"],
+            docs_field=gen_docs.resolve_section_docs_field("plugins"),
+        )
+        args_md = gen_docs.gen_all_plugin_args_docs(
+            plugin_path, level=2, show_skipped=True, static=True)
+        _render_markdown(section_md + "\n" + args_md)
         return
 
     resolved = gen_docs.resolve_section(section)
@@ -896,24 +926,37 @@ def schema(ctx, section, project_dir, as_json):
         _render_markdown(md)
         return
 
-    # Not a config section: maybe it's a plugin name.
-    from penguin.plugin_manager import get_plugin_args_model, get_plugin_class
-    from penguin.penguin_config import structure as _structure
+    # Not a config section: maybe it's a plugin name. Accept both the bare name
+    # (`schema vpn`) and the dotted form under the section (`schema plugins.vpn`).
+    from penguin.plugin_manager import (
+        get_plugin_args_model, get_plugin_class, plugin_declared_arg_specs)
 
+    plugin = section[len("plugins."):] if section.startswith("plugins.") else section
     proj = project_dir or os.getcwd()
-    plugin_path = _structure.Core.model_fields["plugin_path"].default
-    args_model = get_plugin_args_model(section, proj, plugin_path)
+
+    # Prefer the imported model (richer types); fall back to AST-extracted specs
+    # so plugins that can't be imported outside a live emulator still render —
+    # matching `schema plugins`.
+    args_model = get_plugin_args_model(plugin, proj, plugin_path)
     if args_model is not None:
         if as_json:
             click.echo(yaml.dump(args_model.model_json_schema(), indent=2))
             return
-        _render_markdown(gen_docs.gen_plugin_args_docs(section, args_model))
+        _render_markdown(gen_docs.gen_plugin_args_docs(plugin, args_model))
         return
 
-    cls = get_plugin_class(section, proj, plugin_path)
+    specs = plugin_declared_arg_specs(plugin, proj, plugin_path)
+    if specs is not None:
+        if as_json:
+            click.echo(yaml.dump(_arg_specs_to_schema(specs), indent=2, sort_keys=False))
+            return
+        _render_markdown(gen_docs.gen_plugin_args_docs_from_specs(plugin, specs))
+        return
+
+    cls = get_plugin_class(plugin, proj, plugin_path)
     if cls is not None:
         doc = cls.__doc__ or "(no docstring)"
-        _render_markdown(f"# Plugin `{section}`\n\nThis plugin does not declare an `Args` schema.\n\n{doc}")
+        _render_markdown(f"# Plugin `{plugin}`\n\nThis plugin does not declare an `Args` schema.\n\n{doc}")
         return
 
     logger.error(
@@ -926,6 +969,24 @@ def schema(ctx, section, project_dir, as_json):
 def structure_json_schema():
     from penguin.penguin_config import structure
     return structure.Main.model_json_schema()
+
+
+def _arg_specs_to_schema(arg_specs):
+    """
+    Turn a list of statically-extracted ``ArgSpec`` into a JSON-serializable dict
+    keyed by argument name (type/default rendered from source — see
+    ``plugin_manager.discover_declaring_plugins_static``).
+    """
+    out = {}
+    for spec in arg_specs:
+        entry = {"type": spec.type, "required": spec.required}
+        if not spec.required and spec.default is not None:
+            kind, val = spec.default
+            entry["default"] = val if kind == "literal" else f"{val}  # (non-literal)"
+        if spec.description:
+            entry["description"] = spec.description
+        out[spec.name] = entry
+    return out
 
 
 @cli.command(context_settings=dict(

--- a/src/penguin/penguin_config/gen_docs.py
+++ b/src/penguin/penguin_config/gen_docs.py
@@ -310,7 +310,11 @@ def _advance_section(type_, seg):
     Move one user-facing step into the schema by `seg`, transparently skipping
     non-consuming wrappers (Optional, RootModel newtypes, and dict values).
 
-    Returns the resolved sub-type, or None if `seg` doesn't resolve.
+    Returns ``(resolved_sub_type, field_info)`` where ``field_info`` is the
+    Pydantic ``FieldInfo`` that ``seg`` resolved to (carrying field-level
+    metadata like the title), or ``None`` when the step resolved through a
+    dict value or tagged-union variant rather than a named field. Returns
+    ``(None, None)`` when ``seg`` doesn't resolve.
     """
     while True:
         # Collapse Optional[... T ...] to T
@@ -330,20 +334,20 @@ def _advance_section(type_, seg):
                     disc = variant.model_fields.get(info.discriminator)
                     vals = typing.get_args(disc.annotation) if disc else ()
                     if vals and vals[0] == seg:
-                        return variant
-                return None
+                        return variant, None
+                return None, None
             type_ = ann  # newtype: unwrap and retry the same segment
             continue
 
         if hasattr(type_, "model_fields"):
             field = type_.model_fields.get(seg)
-            return field.annotation if field is not None else None
+            return (field.annotation, field) if field is not None else (None, None)
 
         if typing.get_origin(type_) is dict:
             type_ = typing.get_args(type_)[1]  # descend into the value type
             continue
 
-        return None
+        return None, None
 
 
 def resolve_section(dotted):
@@ -353,22 +357,49 @@ def resolve_section(dotted):
     """
     type_ = structure.Main
     for seg in [s for s in dotted.split(".") if s]:
-        type_ = _advance_section(type_, seg)
+        type_, _field = _advance_section(type_, seg)
         if type_ is None:
             return None
     return type_
 
 
-def gen_plugin_args_docs(name, args_model, deprecation_note=True):
+def resolve_section_docs_field(dotted):
+    """
+    Resolve a dotted config-section path to a `DocsField`, carrying the
+    field-level metadata (title, description, examples) of the section.
+
+    `resolve_section` returns only the bare type, which loses metadata that
+    lives on the `Field` rather than the model — e.g. the `plugins` section is
+    a plain `dict[str, Plugin]` whose title only exists on its `Field`. Using
+    `DocsField.from_type` on that bare dict yields a title-less field and makes
+    `gen_docs` raise. Resolving through the owning field keeps the metadata so
+    rendering matches the full-tree docs. Returns None if the path doesn't
+    resolve.
+    """
+    type_ = structure.Main
+    field = None
+    for seg in [s for s in dotted.split(".") if s]:
+        type_, field = _advance_section(type_, seg)
+        if type_ is None:
+            return None
+    if field is not None:
+        return DocsField.from_field(field)
+    return DocsField.from_type(type_)
+
+
+def gen_plugin_args_docs(name, args_model, deprecation_note=True, level=1):
     """
     Render a plugin's declared ``Args`` model as a markdown section.
 
     ``args_model`` is a ``PluginArgs`` subclass; we render one row per field with
     its type, default, required-ness, and description. Set ``deprecation_note``
     to False to omit the per-plugin first-class-syntax note (the aggregate
-    reference states it once instead).
+    reference states it once instead). ``level`` sets the markdown heading depth
+    of the plugin's section header (1 → ``#`` for a standalone page, 2 → ``##``
+    when nested under an aggregate page's single ``#`` title).
     """
-    out = [f"# Plugin `{name}` arguments", ""]
+    heading = "#" * level
+    out = [f"{heading} Plugin `{name}` arguments", ""]
     fields = args_model.model_fields
     if not fields:
         out.append("This plugin declares an `Args` schema with no fields.")
@@ -438,7 +469,7 @@ def gen_all_plugin_args_docs(plugin_path=None, manager=None, panda=None):
                                            for n, _ in found))
     out.append("")
     for name, model in found:
-        out.append(gen_plugin_args_docs(name, model, deprecation_note=False))
+        out.append(gen_plugin_args_docs(name, model, deprecation_note=False, level=2))
     if skipped:
         out.append("")
         out.append(f"<!-- {len(skipped)} plugin file(s) could not be imported "

--- a/src/penguin/penguin_config/gen_docs.py
+++ b/src/penguin/penguin_config/gen_docs.py
@@ -398,23 +398,56 @@ def gen_plugin_args_docs(name, args_model, deprecation_note=True, level=1):
     of the plugin's section header (1 → ``#`` for a standalone page, 2 → ``##``
     when nested under an aggregate page's single ``#`` title).
     """
-    heading = "#" * level
-    out = [f"{heading} Plugin `{name}` arguments", ""]
-    fields = args_model.model_fields
-    if not fields:
-        out.append("This plugin declares an `Args` schema with no fields.")
-        return "\n".join(out) + "\n"
-    out.append("|Argument|Type|Default|Required|Description|")
-    out.append("|-|-|-|-|-|")
-    for fname, info in fields.items():
+    rows = []
+    for fname, info in args_model.model_fields.items():
         try:
             type_name = gen_docs_type_name(info.annotation)
         except Exception:
             type_name = getattr(info.annotation, "__name__", str(info.annotation))
         required = info.is_required()
         default = "" if required else "`" + gen_docs_yaml_dump(info.default) + "`"
-        desc = info.description or ""
-        out.append(f"|`{fname}`|{type_name}|{default}|{'yes' if required else ''}|{desc}|")
+        rows.append((fname, type_name, default, required, info.description or ""))
+    return _render_plugin_args_section(name, rows, deprecation_note, level)
+
+
+def gen_plugin_args_docs_from_specs(name, arg_specs, deprecation_note=True, level=1):
+    """
+    Render a plugin's arguments from statically-extracted ``ArgSpec``s (see
+    ``plugin_manager.discover_declaring_plugins_static``) — the import-free path,
+    so plugins that can't be imported outside a live emulator are still covered.
+
+    Types and defaults are rendered from source (e.g. ``List[str]``, ``false``)
+    rather than via pydantic, so output is slightly lower-fidelity than the
+    model-based :func:`gen_plugin_args_docs` but available without a runtime.
+    """
+    rows = []
+    for spec in arg_specs:
+        type_name = spec.type or "any"
+        if spec.required or spec.default is None:
+            default = ""
+        elif spec.default[0] == "literal":
+            default = "`" + gen_docs_yaml_dump(spec.default[1]) + "`"
+        else:  # ("src", "<source text>")
+            default = "`" + spec.default[1] + "`"
+        rows.append((spec.name, type_name, default, spec.required, spec.description or ""))
+    return _render_plugin_args_section(name, rows, deprecation_note, level)
+
+
+def _render_plugin_args_section(name, rows, deprecation_note, level):
+    """
+    Render a plugin's argument ``rows`` as a markdown section. Each row is
+    ``(arg, type_str, default_str, required_bool, description)`` with cells
+    already formatted. Shared by the model-based and AST-based renderers.
+    """
+    heading = "#" * level
+    out = [f"{heading} Plugin `{name}` arguments", ""]
+    if not rows:
+        out.append("This plugin declares an `Args` schema with no fields.")
+        return "\n".join(out) + "\n"
+    out.append("|Argument|Type|Default|Required|Description|")
+    out.append("|-|-|-|-|-|")
+    for arg, type_name, default, required, desc in rows:
+        out.append(f"|`{arg}`|{type_name}|{default}|{'yes' if required else ''}|{desc}|")
     out.append("")
     out.append("Configure under `plugins:`:")
     out.append("```yaml")
@@ -429,31 +462,46 @@ def gen_plugin_args_docs(name, args_model, deprecation_note=True, level=1):
     return "\n".join(out) + "\n"
 
 
-def gen_all_plugin_args_docs(plugin_path=None, manager=None, panda=None):
+def gen_all_plugin_args_docs(plugin_path=None, manager=None, panda=None,
+                             level=1, show_skipped=False, static=False):
     """
     Render a single markdown reference for every plugin that declares an ``Args``
     schema under ``plugin_path`` (default: the schema's ``core.plugin_path``).
 
-    Completeness depends on the runtime: many plugins only import with a live
-    ``plugins`` manager bound (e.g. kernel-FFI enums). Pass ``manager``/``panda``
-    (the live singletons, as the docgen plugin does) for full coverage; without
-    them this is best-effort and runtime-dependent plugins are skipped.
+    With ``static=True`` the declared ``Args`` are read via ``ast`` without
+    importing the plugins, so coverage is complete even outside a live emulator —
+    this is what the CLI uses. Otherwise plugins are imported: pass
+    ``manager``/``panda`` (the live singletons, as the docgen plugin does) for
+    full, high-fidelity coverage; without them import-based discovery is
+    best-effort and runtime-dependent plugins are skipped.
+
+    ``level`` sets the heading depth of the page title (and shifts each plugin's
+    sub-heading to ``level + 1``) so this can nest under another section. When
+    ``show_skipped`` is true, the count of plugins that could not be introspected
+    is rendered as a visible note (rather than an HTML comment).
     """
-    from penguin.plugin_manager import discover_declaring_plugins
+    from penguin.plugin_manager import (
+        discover_declaring_plugins, discover_declaring_plugins_static)
 
     if plugin_path is None:
         plugin_path = structure.Core.model_fields["plugin_path"].default
 
-    found, skipped = discover_declaring_plugins(plugin_path, manager=manager, panda=panda)
+    if static:
+        found, skipped = discover_declaring_plugins_static(plugin_path)
+        render_one = gen_plugin_args_docs_from_specs
+    else:
+        found, skipped = discover_declaring_plugins(plugin_path, manager=manager, panda=panda)
+        render_one = gen_plugin_args_docs
 
+    heading = "#" * level
     out = [
-        "# Plugin arguments",
+        f"{heading} Plugin arguments",
         "",
         "Plugins that declare an `Args` schema validate their arguments and "
         "document them here. Configure them under the top-level `plugins:` "
         "section, keyed by the plugin name. This page is generated from the "
-        "plugins' declared `Args`; run `penguin schema <plugin>` for the same "
-        "information at the CLI.",
+        "plugins' declared `Args`; run `penguin schema <plugin>` for a single "
+        "plugin at the CLI.",
         "",
         "> The first-class top-level form (writing `<plugin>:` at the config "
         "root instead of under `plugins:`) is **deprecated**: it still loads "
@@ -468,12 +516,20 @@ def gen_all_plugin_args_docs(plugin_path=None, manager=None, panda=None):
     out.append("**Plugins:** " + ", ".join(f"[`{n}`](#plugin-{n}-arguments)"
                                            for n, _ in found))
     out.append("")
-    for name, model in found:
-        out.append(gen_plugin_args_docs(name, model, deprecation_note=False, level=2))
+    for name, payload in found:
+        out.append(
+            render_one(name, payload, deprecation_note=False, level=level + 1)
+        )
     if skipped:
         out.append("")
-        out.append(f"<!-- {len(skipped)} plugin file(s) could not be imported "
-                   "for introspection and were skipped. -->")
+        if show_skipped:
+            out.append(f"> _{len(skipped)} plugin(s) could not be introspected "
+                       "statically and are omitted; many plugins only import "
+                       "with a live emulator bound. The generated documentation "
+                       "(built during a real run) covers them._")
+        else:
+            out.append(f"<!-- {len(skipped)} plugin file(s) could not be imported "
+                       "for introspection and were skipped. -->")
     return "\n".join(out) + "\n"
 
 

--- a/src/penguin/plugin_manager.py
+++ b/src/penguin/plugin_manager.py
@@ -35,6 +35,7 @@ Penguin emulation environment, enabling modular analysis, automation, and extens
 """
 
 import ast
+import collections
 import os
 import sys
 from os.path import join, isfile, basename, splitext, isdir
@@ -686,6 +687,181 @@ def plugin_declared_arg_fields(name: str, proj_dir: str,
         # model_config / dunders are pydantic machinery, not user-facing fields.
         return {f for f in fields if f != "model_config" and not f.startswith("_")}
     return None
+
+
+# A statically-extracted plugin argument. ``default`` is one of:
+#   None                      -> required (no default), or default unknown
+#   ("literal", value)        -> a literal default we could evaluate (e.g. 3, [], False)
+#   ("src", "source text")    -> a non-literal default, kept as source (e.g. a factory)
+# ``required`` is True when the field has no usable default. ``type`` is the
+# annotation rendered back to source (e.g. "Optional[List[str]]"), or None.
+ArgSpec = collections.namedtuple("ArgSpec", "name type default required description")
+
+
+def _ast_field_default(node):
+    """Classify a default-value AST node into the ``ArgSpec.default`` form."""
+    try:
+        return ("literal", ast.literal_eval(node))
+    except (ValueError, SyntaxError, TypeError):
+        return ("src", ast.unparse(node))
+
+
+def _ast_is_field_call(node) -> bool:
+    """True if ``node`` is a pydantic ``Field(...)`` call (``Field`` or ``x.Field``)."""
+    return isinstance(node, ast.Call) and (
+        (isinstance(node.func, ast.Name) and node.func.id == "Field")
+        or (isinstance(node.func, ast.Attribute) and node.func.attr == "Field")
+    )
+
+
+def _ast_parse_field_call(call):
+    """
+    Extract ``(default, required, description)`` from a ``Field(...)`` call node.
+
+    Mirrors pydantic's rules closely enough for docs: a positional first arg or a
+    ``default=`` keyword sets the default (``...`` means required); ``default_factory``
+    means not-required with a non-literal default; a bare ``Field()`` is required.
+    """
+    default = None
+    required = False
+    description = None
+    has_default = has_factory = False
+
+    if call.args:  # Field(<default>, ...)
+        default_node = call.args[0]
+        has_default = True
+    else:
+        default_node = None
+    for kw in call.keywords:
+        if kw.arg == "default":
+            default_node = kw.value
+            has_default = True
+        elif kw.arg == "default_factory":
+            has_factory = True
+            factory_node = kw.value
+        elif kw.arg == "description" and isinstance(kw.value, ast.Constant) \
+                and isinstance(kw.value.value, str):
+            description = kw.value.value
+
+    if has_default:
+        if isinstance(default_node, ast.Constant) and default_node.value is Ellipsis:
+            required = True
+        else:
+            default = _ast_field_default(default_node)
+    elif has_factory:
+        # Not required; the value comes from a factory we can't evaluate statically.
+        default = ("src", f"{ast.unparse(factory_node)}()")
+    else:
+        required = True  # bare Field() with no default is required
+    return default, required, description
+
+
+def _ast_arg_specs_from_classdef(node) -> List[ArgSpec]:
+    """Build the list of :data:`ArgSpec` for an ``class Args(PluginArgs)`` node."""
+    specs = []
+    for stmt in node.body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            name = stmt.target.id
+            annotation = stmt.annotation
+            value = stmt.value
+        elif isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 \
+                and isinstance(stmt.targets[0], ast.Name):
+            name = stmt.targets[0].id
+            annotation = None
+            value = stmt.value
+        else:
+            continue
+        if name == "model_config" or name.startswith("_"):
+            continue
+
+        type_str = ast.unparse(annotation) if annotation is not None else None
+        default = None
+        required = False
+        description = None
+        if value is None:
+            required = True  # annotation-only (`x: int`) -> required
+        elif _ast_is_field_call(value):
+            default, required, description = _ast_parse_field_call(value)
+        elif isinstance(value, ast.Constant) and value.value is Ellipsis:
+            required = True
+        else:
+            default = _ast_field_default(value)
+        specs.append(ArgSpec(name, type_str, default, required, description))
+    return specs
+
+
+def _ast_find_args_classdef(tree):
+    """Return the first ``class Args(PluginArgs)`` ClassDef node in ``tree``, or None."""
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.ClassDef) and node.name == "Args"):
+            continue
+        if any(
+            (isinstance(b, ast.Name) and b.id == "PluginArgs")
+            or (isinstance(b, ast.Attribute) and b.attr == "PluginArgs")
+            for b in node.bases
+        ):
+            return node
+    return None
+
+
+def plugin_declared_arg_specs(name: str, proj_dir: str,
+                              plugin_path: str) -> Optional[List[ArgSpec]]:
+    """
+    Return the declared :data:`ArgSpec`s for plugin ``name`` via ``ast``, without
+    importing it — the rich counterpart to :func:`plugin_declared_arg_fields`.
+
+    Returns the (possibly empty) spec list if the plugin declares an ``Args``
+    schema, else ``None`` (plugin not found, unparseable, or no ``Args``).
+    """
+    try:
+        path, _ = find_plugin_by_name(name, proj_dir, plugin_path)
+    except ValueError:
+        return None
+    try:
+        with open(path, "r") as f:
+            tree = ast.parse(f.read(), filename=path)
+    except (OSError, SyntaxError):
+        return None
+    node = _ast_find_args_classdef(tree)
+    return _ast_arg_specs_from_classdef(node) if node is not None else None
+
+
+def discover_declaring_plugins_static(plugin_path: str
+                                      ) -> Tuple[List[Tuple[str, List[ArgSpec]]], List[str]]:
+    """
+    Like :func:`discover_declaring_plugins`, but reads each plugin's declared
+    ``Args`` via ``ast`` **without importing** — so runtime-dependent plugins
+    (kernel-FFI enums, sibling imports, a live emulator) are covered too, exactly
+    as config-load arg validation already does.
+
+    :return: ``(found, skipped)`` where ``found`` is a sorted list of
+        ``(config_name, [ArgSpec])`` and ``skipped`` lists files that failed to
+        parse. Lower-fidelity than the imported model (types/defaults are rendered
+        from source, not pydantic), but complete without a runtime.
+    """
+    found: List[Tuple[str, List[ArgSpec]]] = []
+    skipped: List[str] = []
+    for path in sorted(glob.glob(join(plugin_path, "**", "*.py"), recursive=True)):
+        if "__pycache__" in path or basename(path).startswith("_"):
+            continue
+        try:
+            with open(path, "r") as f:
+                tree = ast.parse(f.read(), filename=path)
+        except (OSError, SyntaxError):
+            skipped.append(path)
+            continue
+        args_node = _ast_find_args_classdef(tree)
+        if args_node is not None:
+            found.append((splitext(basename(path))[0], _ast_arg_specs_from_classdef(args_node)))
+    # De-dup by config name (first wins) and sort for stable output.
+    seen = set()
+    deduped = []
+    for name, specs in sorted(found, key=lambda x: x[0]):
+        if name in seen:
+            continue
+        seen.add(name)
+        deduped.append((name, specs))
+    return deduped, sorted(skipped)
 
 
 def get_plugin_class(name: str, proj_dir: str, plugin_path: str) -> Optional[type]:

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -255,6 +255,29 @@ def test_gen_docs_runs_without_error():
     assert isinstance(out, str) and len(out) > 0
 
 
+def test_resolve_section_docs_field_carries_field_title():
+    # `plugins` is a bare `dict[str, Plugin]` whose title lives on its Field,
+    # not its type. Resolving via DocsField.from_type alone dropped the title
+    # and made `penguin schema plugins` raise; resolve_section_docs_field must
+    # carry the field-level title so rendering succeeds.
+    df = gen_docs.resolve_section_docs_field("plugins")
+    assert df is not None and df.title == "Plugins"
+    md = gen_docs.gen_docs(path=["plugins"], docs_field=df)
+    assert "Plugins" in md and "Plugin" in md
+
+
+def test_resolve_section_docs_field_every_top_level_section_renders():
+    # `penguin schema <section>` must not error for any top-level section.
+    for name, _title in gen_docs.list_sections():
+        df = gen_docs.resolve_section_docs_field(name)
+        assert df is not None, name
+        assert gen_docs.gen_docs(path=[name], docs_field=df)
+
+
+def test_resolve_section_docs_field_unknown_returns_none():
+    assert gen_docs.resolve_section_docs_field("does.not.exist") is None
+
+
 # --------------------------------------------------------------------------- #
 # PR3: plugin Args declaration + defaults + validation
 # --------------------------------------------------------------------------- #
@@ -460,8 +483,12 @@ def test_discover_live_manager_recovers_runtime_plugin(plugin_dir):
 
 def test_gen_all_plugin_args_docs(plugin_dir):
     md = gen_docs.gen_all_plugin_args_docs(plugin_dir)
-    assert "# Plugin arguments" in md
-    assert "# Plugin `widget` arguments" in md
+    # The aggregate page has exactly one H1 (its title); per-plugin sections
+    # nest under it as H2 so the docs toctree shows one page with subsections
+    # instead of one top-level entry per plugin.
+    h1s = [ln for ln in md.splitlines() if ln.startswith("# ")]
+    assert h1s == ["# Plugin arguments"]
+    assert "## Plugin `widget` arguments" in md
     assert "`names`" in md and "`count`" in md
 
 

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -492,6 +492,84 @@ def test_gen_all_plugin_args_docs(plugin_dir):
     assert "`names`" in md and "`count`" in md
 
 
+def test_gen_all_plugin_args_docs_nested_level(plugin_dir):
+    # When nested under another section (as `penguin schema plugins` does), the
+    # page title shifts to the given level and each plugin one deeper.
+    md = gen_docs.gen_all_plugin_args_docs(plugin_dir, level=2)
+    assert "## Plugin arguments" in md
+    assert "### Plugin `widget` arguments" in md
+    # No H1 is emitted at level 2.
+    assert not any(ln == "# Plugin arguments" for ln in md.splitlines())
+
+
+def test_gen_all_plugin_args_docs_show_skipped(plugin_dir):
+    # The legacy plugin (gadget) doesn't declare Args so it's not "skipped"
+    # (skipped == couldn't import); use a plugin that fails to import.
+    write_plugin(plugin_dir, "broken.py", "import nonexistent_module_xyz\n")
+    plugin_manager._import_plugin_classes.cache_clear()
+    md = gen_docs.gen_all_plugin_args_docs(plugin_dir, show_skipped=True)
+    # The skipped note is visible (a blockquote), not an HTML comment.
+    assert "could not be introspected statically" in md
+    assert "<!--" not in md
+
+
+# --------------------------------------------------------------------------- #
+# Static (AST-based) plugin Args extraction — covers plugins that can't be
+# imported outside a live emulator, exactly as config-load validation does.
+# --------------------------------------------------------------------------- #
+def test_discover_declaring_plugins_static_covers_unimportable(plugin_dir):
+    # IMPORTING_PLUGIN imports a sibling and RUNTIME_PLUGIN reads live state at
+    # import; both are skipped by import-based discovery without a manager, but
+    # the AST path reads their declared Args regardless.
+    write_plugin(plugin_dir, "importer.py", IMPORTING_PLUGIN)
+    write_plugin(plugin_dir, "runtime.py", RUNTIME_PLUGIN)
+
+    imported, _ = plugin_manager.discover_declaring_plugins(plugin_dir)
+    assert "runtime" not in [n for n, _ in imported]  # import path skips it
+
+    found, skipped = plugin_manager.discover_declaring_plugins_static(plugin_dir)
+    names = {n for n, _ in found}
+    assert {"widget", "sproket", "importer", "runtime"} <= names
+    assert "gadget" not in names          # declares no Args
+    assert skipped == []                  # AST never needs to import
+
+
+def test_static_arg_specs_capture_type_default_description(plugin_dir):
+    found = dict(plugin_manager.discover_declaring_plugins_static(plugin_dir)[0])
+    specs = {s.name: s for s in found["widget"]}
+    assert specs["names"].type == "List[str]"
+    assert specs["names"].default == ("literal", [])
+    assert specs["names"].description == "names"
+    assert specs["count"].default == ("literal", 3)
+    # bare literal default (no Field) is captured too
+    assert specs["quiet"].default == ("literal", False)
+    assert specs["quiet"].required is False
+
+
+def test_gen_all_plugin_args_docs_static(plugin_dir):
+    write_plugin(plugin_dir, "runtime.py", RUNTIME_PLUGIN)
+    md = gen_docs.gen_all_plugin_args_docs(plugin_dir, static=True)
+    # The unimportable plugin's args are rendered from source.
+    assert "## Plugin `runtime` arguments" in md
+    assert "## Plugin `widget` arguments" in md
+    assert "`names`" in md and "List[str]" in md
+
+
+def test_plugin_declared_arg_specs_by_name(plugin_dir):
+    # Single-plugin AST lookup (backs `schema <plugin>` / `schema plugins.<plugin>`),
+    # including a plugin that can't be imported without a live manager.
+    write_plugin(plugin_dir, "runtime.py", RUNTIME_PLUGIN)
+    specs = plugin_manager.plugin_declared_arg_specs("widget", "/tmp", plugin_dir)
+    assert {s.name for s in specs} == {"names", "count", "quiet"}
+    # unimportable plugin still resolves via AST
+    rspecs = plugin_manager.plugin_declared_arg_specs("runtime", "/tmp", plugin_dir)
+    assert [s.name for s in rspecs] == ["level"]
+    # legacy plugin declares no Args -> None
+    assert plugin_manager.plugin_declared_arg_specs("gadget", "/tmp", plugin_dir) is None
+    # unknown plugin -> None
+    assert plugin_manager.plugin_declared_arg_specs("nope", "/tmp", plugin_dir) is None
+
+
 # --------------------------------------------------------------------------- #
 # PR3: AST <-> imported-model equivalence guard
 #


### PR DESCRIPTION
Fixes a batch of schema/docs issues and a couple of local-build hiccups in the Penguin Docker build. Five focused commits.

## Schema & plugin docs

- **Fix `penguin schema <section>` for field-titled sections.** `penguin schema plugins` (and any section whose metadata lives on its `Field` rather than its model — e.g. the bare `dict[str, Plugin]`) raised an `AssertionError`: section resolution returned only the bare type, so the field-level title was dropped. Added `resolve_section_docs_field()`, which resolves a section through its owning field so title/description/examples are preserved.
- **Nest the generated plugin-arguments page under one heading.** The aggregate page emitted an H1 per plugin, so the docs toctree showed every plugin as a separate top-level entry. It now renders a single `# Plugin arguments` title with each plugin as an `##` subsection.
- **Show declared plugin arguments in `penguin schema plugins`.** The section's type is only `dict[str, Plugin]` (the generic per-plugin keys), so it said nothing about the arguments any plugin actually accepts. It now surfaces every plugin's declared `Args`, read via **AST without importing** — the same static approach config-load arg validation already uses — so plugins that only import with a live emulator bound are covered too. Import-based discovery skips ~70% of declaring plugins outside a real run; the AST path covers 100% with zero skips (16/16 in this tree).
  - `--json` emits a `name → args-schema` mapping.
  - `penguin schema <plugin>` and the dotted `penguin schema plugins.<plugin>` render a single plugin, preferring the imported model (richer types) and falling back to AST specs so unimportable plugins still render.
  - The published docs (built during a live run) keep using the higher-fidelity model-based path.

## Local Docker build

- **Pin the unblob fork to `main-pre-26.6.4`.** Upstream unblob's `main` now pulls `pyfatfs` in a way poetry's solver rejects against our `>=3.10` constraint, breaking `poetry install --only main`. Pin to the branch that predates the bump.
- **Default to a dev version when `setuptools_scm` yields nothing.** In a git worktree, `.git` is a pointer file whose target is absent from the build context, so `setuptools_scm` produced no output and `version.txt` became just `v` (`InvalidVersion: 'v'`), failing `pip install -e /pkg`. Now falls back to `0.0.0.dev0`. Real builds with a normal `.git` and tags are unchanged.

## Wrapper

- **Only warn about the moving `:latest` image when none was specified.** The reproducibility nudge fired even for an explicit `--image peng` (which resolves to `peng:latest`). It now warns only when the image falls through to the built-in `rehosting/penguin:latest` default; `--image`, `PENGUIN_IMAGE`, and `.penguin-image` are deliberate choices.

## Testing

- Added unit tests covering section resolution, heading levels, AST spec extraction (incl. plugins that fail to import), the static aggregate page, and single-plugin/dotted lookup.
- `test_config.py`: 98 passed (+10 new). The 13 failing tests in that file are pre-existing arch/dylib/templating failures unrelated to this branch (confirmed failing on a clean checkout).
- Verified `penguin schema plugins`, `schema plugins.vpn`, `schema plugins.mtd` (unimportable), and `--json` end-to-end inside the built `penguin` image; confirmed the Docker build completes from a worktree.
