### PR TITLE
Expand declarative pseudofile models (backwards-compatible)

### DIFF
--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -61,6 +61,10 @@ a system expects to run with will no longer be present or, if they are present,
 behave differently than expected. While many of these changes are acceptable, some
 will be fatal and must be handled in your rehosting config.
 
+For the full set of models you can attach to a pseudofile — including stateful
+registers, sequenced responses, ioctl struct-fills, and the seek/open/release
+ops — see the [pseudofile model catalog](pseudofile_models.md).
+
 ### When to create pseudofile models
 If you see errors in your `console.log` about missing devices or it seems like
 services are crashing or failing to start, pseudofiles are a good place to begin

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -117,7 +117,10 @@ This plugin tracks accesses and interactions with files in `/dev/` and `/proc/`.
 In `pseudofiles_failures.yaml` details of failed interactions are reported.
 
 Users can add pseudofiles and configure models for reads, writes, and IOCTLs on
-these files by adding entries into the `pseudofiles` config section.
+these files by adding entries into the `pseudofiles` config section. See the
+[pseudofile model catalog](pseudofile_models.md) for every available model
+(read/write/ioctl/poll/seek/mmap/open/release), copy-paste snippets, and how to
+add custom models in Python via `@register_model`.
 
 ## Shell
 This plugin tracks the behavior of shell scripts, capturing coverage in `shell_cov.csv`, environment variable values in `shell_env.csv` and a combined trace in `shell_cov_trace.csv`.

--- a/docs/pseudofile_models.md
+++ b/docs/pseudofile_models.md
@@ -1,0 +1,234 @@
+# Pseudofile model catalog
+
+Penguin emulates device files (`/dev`, `/proc`, `/sys`, `/proc/sys`) by
+attaching **models** to them in the `pseudofiles` config section. Each node
+configures one or more **domains** — `read`, `write`, `ioctl`, `poll`, and the
+lifecycle/seek ops `lseek`, `mmap`, `open`, `release` — and each domain selects
+a named model with `model:` plus that model's fields.
+
+This page is the catalog: every built-in model, what it does, when to use it,
+and a copy-paste snippet. The goal is that most devices can be modeled in YAML
+alone — no Python. When you do need Python, see
+[Custom models](#custom-models-register_model) below; the rest of the plugin
+authoring surface is in [pyplugin_architecture.md](pyplugin_architecture.md).
+
+The full field reference is auto-generated in
+[schema_doc.md](schema_doc.md#pseudofiles); this page is the human/AI-facing
+how-to. Everything here is backwards compatible: omitting a domain keeps the
+default behavior.
+
+```yaml
+pseudofiles:
+  /dev/example:
+    read:  {model: const_buf, val: "hello\n"}
+    write: {model: discard}
+    ioctl:
+      "*": {model: return_const, val: 0}
+```
+
+---
+
+## Read models
+
+| `model:` | Behavior | Use when |
+|----------|----------|----------|
+| `zero` | Reads return the byte `0`. | Stub a node that just needs to be non-empty. |
+| `one`  | Reads return the byte `1`. | A flag/gpio that should read high. |
+| `empty` | Immediate EOF. | A readable node that should look empty. |
+| `const_buf` | Return a fixed buffer. | A node with fixed contents (version string, status). |
+| `cycle` | Repeat a buffer forever (never EOF). | An endless stream (entropy-like, repeating pattern). |
+| `const_map` | Sparse offset→value buffer of a given size. | A register/struct image with values at known offsets. |
+| `const_map_file` | `const_map` persisted to a host file. | Same, but you want the rendered image on disk. |
+| `from_file` | Serve bytes from a host file. | Back the node with a real file you provide. |
+| `stateful` | Read back whatever was last **written** to this node. | A read/write register or scratch node. |
+| `sequence` | Return each entry of a list on successive reads. | "busy… busy… ready" status polling. |
+| `from_plugin` | Call a plugin function. | Logic that can't be expressed declaratively. |
+| `custom` | A model registered via `@register_model`. | Reusable Python model, selected by name. |
+| `default` | Return `-EINVAL`. | Explicitly reject reads. |
+
+```yaml
+# Fixed contents
+/proc/version_stub:
+  read: {model: const_buf, val: "Linux 4.10\n"}
+
+# Read-after-write register (pair stateful read + recording write)
+/dev/scratch:
+  read:  {model: stateful, initial: "0"}
+  write: {model: default}
+
+# Status that becomes ready after two polls, then stays ready
+/proc/device_status:
+  read: {model: sequence, vals: ["busy\n", "busy\n", "ready\n"]}
+```
+
+## Write models
+
+| `model:` | Behavior | Use when |
+|----------|----------|----------|
+| `discard` | Accept and drop writes (returns count). | Writes you can safely ignore. |
+| `default` | Record writes into an in-memory buffer. | Pair with `read: stateful` for a register. |
+| `to_file` | Append/write to a host file. | Capture what the guest writes for inspection. |
+| `return_const` | Return a fixed value/errno from `write()`. | Force a specific write result (e.g. an errno). |
+| `unhandled` | Return `-EINVAL`. | Explicitly reject writes. |
+| `from_plugin` | Call a plugin function. | Custom write logic. |
+| `custom` | A model registered via `@register_model`. | Reusable Python model. |
+
+```yaml
+/dev/logsink:
+  write: {model: to_file, filename: "./results/latest/guest_writes.bin"}
+```
+
+## ioctl models
+
+`ioctl` is a map from command number (or `"*"` for the wildcard) to a model.
+A bare model (no command map) applies to every command.
+
+| `model:` | Behavior | Use when |
+|----------|----------|----------|
+| `return_const` | Return a fixed value. | The driver just checks the return code. |
+| `zero` | Return 0 (success). | Acknowledge any ioctl. |
+| `write_data` | Write a constant buffer to the `arg` pointer, then return `val`. | An ioctl that fills a caller-supplied struct. |
+| `unhandled` | Return `-ENOTTY`. | Explicitly reject an ioctl. |
+| `from_plugin` | Call a plugin function. | Command-dependent logic. |
+
+```yaml
+/dev/widget:
+  ioctl:
+    0x1234: {model: write_data, data: "\x01\x00\x00\x00", val: 0}
+    "*":    {model: return_const, val: 0}
+```
+
+## poll models
+
+| `model:` | Behavior | Use when |
+|----------|----------|----------|
+| `always_ready` | Report readable+writable (legacy default for `/dev`). | Node is always ready. |
+| `from_plugin` | Plugin returns a data-aware poll mask. | Readiness depends on state. |
+
+## Other VFS operations
+
+Beyond read/write/ioctl/poll you can model the rest of the `file_operations`
+surface. Omit a domain to keep the kernel default. Most are plugin-driven; the
+plugin function takes that op's native VFS arguments.
+
+| domain | `model:` | Behavior |
+|--------|----------|----------|
+| `lseek` | `default` | Standard offset arithmetic against the node's size. |
+| `lseek` | `unsupported` | Return `-ESPIPE` (pipe/stream-like node). |
+| `lseek` | `from_plugin` | Plugin `lseek(ptregs, file, offset, whence)`. |
+| `mmap` | `from_plugin` | Plugin `mmap(ptregs, file, vm_area_struct)`. |
+| `open` | `from_plugin` | Fire a plugin function when the node is opened. |
+| `release` | `from_plugin` | Fire a plugin function when the node is closed. |
+| `compat_ioctl` | `same_as_ioctl` | Route 32-bit compat ioctls through the `ioctl` model. |
+| `compat_ioctl` | `from_plugin` | Plugin `compat_ioctl(ptregs, file, cmd, arg)`. |
+| `flush` | `from_plugin` | `/dev`-only. Plugin `flush(ptregs, file, owner)`. |
+| `fsync` | `from_plugin` | `/dev`-only. Plugin `fsync(ptregs, file, start, end, datasync)`. |
+| `fasync` | `from_plugin` | `/dev`-only. Plugin `fasync(ptregs, fd, file, on)`. |
+| `lock` | `from_plugin` | `/dev`-only. Plugin `lock(ptregs, file, cmd, file_lock)`. |
+| `read_iter` | `from_plugin` | Plugin `read_iter(ptregs, kiocb, iov_iter)`. |
+| `write_iter` | `from_plugin` | Plugin `write_iter(ptregs, kiocb, iov_iter)`. |
+| `get_unmapped_area` | `from_plugin` | Plugin `get_unmapped_area(ptregs, file, addr, len, pgoff, flags)`. |
+
+> `flush`/`fsync`/`fasync`/`lock`/`write_iter` are character-device fops: valid
+> only on `/dev` nodes. `lseek`/`mmap`/`open`/`release`/`compat_ioctl`/`read_iter`/
+> `get_unmapped_area` are valid on `/dev` and `/proc` but not `/proc/sys`
+> (sysctl) or `/sys` (sysfs), which only service reads/writes. Config validation
+> **rejects** an op attached to a node whose filesystem can't service it.
+
+```yaml
+/dev/stream:
+  read:  {model: sequence, vals: ["a", "b", "c"]}
+  lseek: {model: unsupported}
+  open:  {model: from_plugin, plugin: my_plugin, function: on_open}
+
+/dev/widget64:
+  ioctl: {"*": {model: return_const, val: 0}}
+  compat_ioctl: {model: same_as_ioctl}   # 32-bit callers get the same handlers
+```
+
+## MTD flash devices
+
+MTD nodes (`/dev/mtdN`, `/proc/mtd`) are **not** modeled through `pseudofiles`
+— they have a dedicated native subsystem with its own `devices:` config block
+(geometry, personality, backing). Legacy `pseudofiles: /dev/mtdN` entries are
+auto-migrated into it.
+
+```yaml
+devices:
+  flash0:
+    id: 0
+    model: backing_file        # or 'zeros' (blank flash) / 'const_buf'
+    backing_file: ./flash0.bin
+    mode: rw                   # 'ro' for read-only
+    personality:
+      type: nor                # 'nand' or 'nor' (sets erase/write/oob defaults)
+      erase_size: 64k
+```
+
+Models: `zeros` (RAM-backed blank flash), `const_buf` (in-RAM initial image),
+`backing_file` (host file). For fully custom flash physics (read/write/erase),
+register an `MtdDevice` subclass in Python via `plugins.mtd.register_mtd(dev)`.
+
+> Note: the `devices:` block is currently a free-form mapping in the schema
+> (not yet a typed/validated structure), so consult this section for field
+> names. Geometry units accept suffixes (`k`/`m`/`g`).
+
+---
+
+## Provenance (discovered defaults)
+
+Every model takes an optional `provenance:` tag. During `init`, the
+`pseudofiles.dynamic` patch auto-generates **stub** models (`read: zero`,
+`write: discard`, `ioctl "*": return_const 0`) for every discovered pseudofile
+and tags them `provenance: default`. A tagged-default model reports its own
+activity into `pseudofiles_failures.yaml` (events `default_read`,
+`default_write`, `default_ioctl`, with captured write payloads and ioctl
+commands), so a stub that is actively shaping guest behavior shows up as
+"needs a real model" instead of silently succeeding with garbage.
+
+Leave `provenance` unset on models you author intentionally — only tagged
+defaults self-report.
+
+```yaml
+/dev/discovered:
+  read:  {model: zero,    provenance: default}
+  write: {model: discard, provenance: default}
+```
+
+---
+
+## Custom models (`@register_model`)
+
+When declarative models aren't enough, register a Python mixin under a name and
+select it from YAML with `model: custom`. This is the low-friction "expand with
+Python" path — far less boilerplate than a full backing class.
+
+Drop a file in the project's `plugins.d/` (auto-loaded — see
+[local_plugins.md](local_plugins.md)):
+
+```python
+# plugins.d/my_models.py
+from hyperfile.models.registry import register_model
+from hyperfile.models.read import ReadBufWrapper
+
+@register_model("read", "my_sensor")
+class MySensorRead(ReadBufWrapper):
+    def __init__(self, *, scale=1, **kwargs):
+        super().__init__(buffer=str(42 * scale).encode(), **kwargs)
+```
+
+Then in `config.yaml` — `model_name` selects the registered model and any extra
+keys are forwarded to its constructor:
+
+```yaml
+pseudofiles:
+  /dev/sensor:
+    read: {model: custom, model_name: my_sensor, scale: 10}
+```
+
+`register_model(domain, name)` supports the `read`, `write`, `poll`, `lseek`,
+`mmap`, `open`, and `release` domains. The mixin follows the same VFS contract
+as the built-ins (generator methods, `ptregs.retval`, `super().__init__(**kwargs)`).
+For a model that owns the *entire* file-operations surface in one class, use a
+backing class instead (`plugin: file:ClassName`) — see
+[plugins.md](plugins.md#pseudofiles).

--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -649,7 +649,7 @@ DYNVALDYNVALDYNVAL
 
 |||
 |-|-|
-|__Default__|`null`|
+|__Default__|`{}`|
 
 Device files to emulate in the guest
 
@@ -715,30 +715,102 @@ How to handle reads from the file
 ##### `pseudofiles.<string>.read.<model=zero>` Read a zero
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"zero"`||Read modelling method (read a zero)|
+###### `pseudofiles.<string>.read.<model=zero>.model` Read modelling method (read a zero)
+
+|||
+|-|-|
+|__Type__|`"zero"`|
+
+
+###### `pseudofiles.<string>.read.<model=zero>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
 ##### `pseudofiles.<string>.read.<model=one>` Read a one
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"one"`||Read modelling method (read a one)|
+###### `pseudofiles.<string>.read.<model=one>.model` Read modelling method (read a one)
+
+|||
+|-|-|
+|__Type__|`"one"`|
+
+
+###### `pseudofiles.<string>.read.<model=one>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
 ##### `pseudofiles.<string>.read.<model=empty>` Read empty file
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"empty"`||Read modelling method (read empty file)|
+###### `pseudofiles.<string>.read.<model=empty>.model` Read modelling method (read empty file)
+
+|||
+|-|-|
+|__Type__|`"empty"`|
+
+
+###### `pseudofiles.<string>.read.<model=empty>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
 ##### `pseudofiles.<string>.read.<model=const_buf>` Read a constant buffer
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"const_buf"`||Read modelling method (read a constant buffer)|
-|`val`|string||Pseudofile contents|
-|`null_terminate`|boolean|`false`|Append a NUL byte to the configured contents|
-|`nul_terminate`|boolean|`false`|Alias for null_terminate|
+###### `pseudofiles.<string>.read.<model=const_buf>.model` Read modelling method (read a constant buffer)
+
+|||
+|-|-|
+|__Type__|`"const_buf"`|
+
+
+###### `pseudofiles.<string>.read.<model=const_buf>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.read.<model=const_buf>.val` Pseudofile contents
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.read.<model=const_buf>.null_terminate` Append a NUL byte to the configured contents
+
+|||
+|-|-|
+|__Type__|boolean|
+|__Default__|`false`|
+
+
+###### `pseudofiles.<string>.read.<model=const_buf>.nul_terminate` Alias for null_terminate
+
+|||
+|-|-|
+|__Type__|boolean|
+|__Default__|`false`|
+
+
 ##### `pseudofiles.<string>.read.<model=const_map>` Read a constant map
 
 
@@ -748,6 +820,15 @@ How to handle reads from the file
 |-|-|
 |__Type__|`"const_map"`|
 
+
+###### `pseudofiles.<string>.read.<model=const_map>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
 
 ###### `pseudofiles.<string>.read.<model=const_map>.pad` Byte for padding file
 
@@ -787,6 +868,15 @@ When this is a list of integers, it treated as a byte array. When this is a list
 |__Type__|`"const_map_file"`|
 
 
+###### `pseudofiles.<string>.read.<model=const_map_file>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
 ###### `pseudofiles.<string>.read.<model=const_map_file>.filename` Path to host file to store constant map
 
 |||
@@ -822,27 +912,202 @@ When this is a list of integers, it treated as a byte array. When this is a list
 
 When this is a list of integers, it treated as a byte array. When this is a list of strings, the strings are separated by null bytes.
 
+##### `pseudofiles.<string>.read.<model=cycle>` Read a repeating buffer
+
+Repeat the configured buffer forever (never reports EOF).
+
+###### `pseudofiles.<string>.read.<model=cycle>.model` Read modelling method (read a repeating buffer)
+
+|||
+|-|-|
+|__Type__|`"cycle"`|
+
+
+###### `pseudofiles.<string>.read.<model=cycle>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.read.<model=cycle>.val` Buffer to repeat
+
+|||
+|-|-|
+|__Type__|string|
+
+
 ##### `pseudofiles.<string>.read.<model=from_file>` Read from a host file
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"from_file"`||Read modelling method (read from a host file)|
-|`filename`|string||Path to host file|
+###### `pseudofiles.<string>.read.<model=from_file>.model` Read modelling method (read from a host file)
+
+|||
+|-|-|
+|__Type__|`"from_file"`|
+
+
+###### `pseudofiles.<string>.read.<model=from_file>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.read.<model=from_file>.filename` Path to host file
+
+|||
+|-|-|
+|__Type__|string|
+
+
+##### `pseudofiles.<string>.read.<model=stateful>` Read back what was written
+
+Serve bytes from this node's write buffer, giving a read-after-write register. Pair with write model 'default' (or 'discard'/'record', which all record) so writes are stored.
+
+###### `pseudofiles.<string>.read.<model=stateful>.model` Read modelling method (read back what was written)
+
+|||
+|-|-|
+|__Type__|`"stateful"`|
+
+
+###### `pseudofiles.<string>.read.<model=stateful>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.read.<model=stateful>.initial` Initial buffer contents
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+##### `pseudofiles.<string>.read.<model=sequence>` Read successive values
+
+Return each entry of 'vals' on successive reads; the common 'busy... busy... ready' status pattern. Holds the last entry when exhausted unless 'cycle' wraps around.
+
+###### `pseudofiles.<string>.read.<model=sequence>.model` Read modelling method (read successive values)
+
+|||
+|-|-|
+|__Type__|`"sequence"`|
+
+
+###### `pseudofiles.<string>.read.<model=sequence>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.read.<model=sequence>.vals` Ordered values to return
+
+|||
+|-|-|
+|__Type__|list|
+
+
+###### `pseudofiles.<string>.read.<model=sequence>.cycle` Wrap around when exhausted
+
+|||
+|-|-|
+|__Type__|boolean|
+|__Default__|`false`|
+
+
 ##### `pseudofiles.<string>.read.<model=from_plugin>` Read from a custom PyPlugin
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"from_plugin"`||Read modelling method (read from a custom pyplugin)|
-|`plugin`|string||Name of the loaded PyPlugin|
-|`function`|string or null|`read`|Function to call|
+###### `pseudofiles.<string>.read.<model=from_plugin>.model` Read modelling method (read from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.read.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.read.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.read.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`read`|
+
+
 ##### `pseudofiles.<string>.read.<model=default>` Default
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"default"`||Read modelling method (default)|
+###### `pseudofiles.<string>.read.<model=default>.model` Read modelling method (default)
+
+|||
+|-|-|
+|__Type__|`"default"`|
+
+
+###### `pseudofiles.<string>.read.<model=default>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `pseudofiles.<string>.read.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.read.<model=custom>.model` Read modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.read.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.read.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
 #### `pseudofiles.<string>.write` Write
 
 |||
@@ -854,30 +1119,175 @@ How to handle writes to the file
 ##### `pseudofiles.<string>.write.<model=to_file>` Write to host file
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"to_file"`||Write modelling method (write to host file)|
-|`filename`|string||Path to host file|
+###### `pseudofiles.<string>.write.<model=to_file>.model` Write modelling method (write to host file)
+
+|||
+|-|-|
+|__Type__|`"to_file"`|
+
+
+###### `pseudofiles.<string>.write.<model=to_file>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.write.<model=to_file>.filename` Path to host file
+
+|||
+|-|-|
+|__Type__|string|
+
+
 ##### `pseudofiles.<string>.write.<model=from_plugin>` Read from a custom PyPlugin
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"from_plugin"`||Write modelling method (read from a custom pyplugin)|
-|`plugin`|string||Name of the loaded PyPlugin|
-|`function`|string or null|`write`|Function to call|
+###### `pseudofiles.<string>.write.<model=from_plugin>.model` Write modelling method (read from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.write.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.write.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.write.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`write`|
+
+
 ##### `pseudofiles.<string>.write.<model=discard>` Discard write
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"discard"`||Write modelling method (discard write)|
+###### `pseudofiles.<string>.write.<model=discard>.model` Write modelling method (discard write)
+
+|||
+|-|-|
+|__Type__|`"discard"`|
+
+
+###### `pseudofiles.<string>.write.<model=discard>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `pseudofiles.<string>.write.<model=return_const>` Return a constant on write
+
+Return a fixed value (e.g. a byte count or a negative errno) without storing data.
+
+###### `pseudofiles.<string>.write.<model=return_const>.model` Write modelling method (return a constant on write)
+
+|||
+|-|-|
+|__Type__|`"return_const"`|
+
+
+###### `pseudofiles.<string>.write.<model=return_const>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.write.<model=return_const>.const` Value to return from write()
+
+|||
+|-|-|
+|__Type__|integer|
+
+
+##### `pseudofiles.<string>.write.<model=unhandled>` Reject writes
+
+Return -EINVAL for every write.
+
+###### `pseudofiles.<string>.write.<model=unhandled>.model` Write modelling method (reject writes)
+
+|||
+|-|-|
+|__Type__|`"unhandled"`|
+
+
+###### `pseudofiles.<string>.write.<model=unhandled>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
 ##### `pseudofiles.<string>.write.<model=default>` Default
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"default"`||Write modelling method (default)|
+###### `pseudofiles.<string>.write.<model=default>.model` Write modelling method (default)
+
+|||
+|-|-|
+|__Type__|`"default"`|
+
+
+###### `pseudofiles.<string>.write.<model=default>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `pseudofiles.<string>.write.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.write.<model=custom>.model` Write modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.write.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.write.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
 #### `pseudofiles.<string>.ioctl` Ioctl
 
 |||
@@ -909,24 +1319,138 @@ plugin: my_plugin
 ##### `pseudofiles.<string>.ioctl.<model=return_const>` Return a constant
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"return_const"`||ioctl modelling method (return a constant)|
-|`val`|integer|`0`|Constant to return|
+###### `pseudofiles.<string>.ioctl.<model=return_const>.model` ioctl modelling method (return a constant)
+
+|||
+|-|-|
+|__Type__|`"return_const"`|
+
+
+###### `pseudofiles.<string>.ioctl.<model=return_const>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.ioctl.<model=return_const>.val` Constant to return
+
+|||
+|-|-|
+|__Type__|integer|
+|__Default__|`0`|
+
+
 ##### `pseudofiles.<string>.ioctl.<model=zero>` Return zero
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"zero"`||ioctl modelling method (return zero)|
+###### `pseudofiles.<string>.ioctl.<model=zero>.model` ioctl modelling method (return zero)
+
+|||
+|-|-|
+|__Type__|`"zero"`|
+
+
+###### `pseudofiles.<string>.ioctl.<model=zero>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `pseudofiles.<string>.ioctl.<model=unhandled>` Reject ioctl
+
+Return -ENOTTY (inappropriate ioctl for device).
+
+###### `pseudofiles.<string>.ioctl.<model=unhandled>.model` ioctl modelling method (reject ioctl)
+
+|||
+|-|-|
+|__Type__|`"unhandled"`|
+
+
+###### `pseudofiles.<string>.ioctl.<model=unhandled>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `pseudofiles.<string>.ioctl.<model=write_data>` Write a buffer to the arg pointer
+
+Write a constant buffer to the user pointer in 'arg' (the common shape of an ioctl that fills a struct), then return 'val'.
+
+###### `pseudofiles.<string>.ioctl.<model=write_data>.model` ioctl modelling method (write a buffer to the arg pointer)
+
+|||
+|-|-|
+|__Type__|`"write_data"`|
+
+
+###### `pseudofiles.<string>.ioctl.<model=write_data>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.ioctl.<model=write_data>.data` Bytes to write to *arg
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.ioctl.<model=write_data>.val` Value to return from ioctl()
+
+|||
+|-|-|
+|__Type__|integer|
+|__Default__|`0`|
+
+
 ##### `pseudofiles.<string>.ioctl.<model=from_plugin>` ioctl from a custom PyPlugin
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"from_plugin"`||ioctl modelling method (ioctl from a custom pyplugin)|
-|`plugin`|string||Name of the loaded PyPlugin|
-|`function`|string or null|`ioctl`|Function to call|
+###### `pseudofiles.<string>.ioctl.<model=from_plugin>.model` ioctl modelling method (ioctl from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.ioctl.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.ioctl.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.ioctl.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`ioctl`|
+
+
 #### `pseudofiles.<string>.poll` Poll
 
 |||
@@ -939,18 +1463,947 @@ How to answer poll()/select() on the file
 
 Constant POLLIN|POLLRDNORM|POLLOUT|POLLWRNORM mask (legacy behavior).
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"always_ready"`||Poll modelling method (always report ready)|
+###### `pseudofiles.<string>.poll.<model=always_ready>.model` Poll modelling method (always report ready)
+
+|||
+|-|-|
+|__Type__|`"always_ready"`|
+
+
+###### `pseudofiles.<string>.poll.<model=always_ready>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
 ##### `pseudofiles.<string>.poll.<model=from_plugin>` Poll from a custom PyPlugin
 
 Data-aware poll: the plugin returns a poll mask reflecting actual readiness.
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`model`|`"from_plugin"`||Poll modelling method (poll from a custom pyplugin)|
-|`plugin`|string||Name of the loaded PyPlugin|
-|`function`|string or null|`poll`|Function to call|
+###### `pseudofiles.<string>.poll.<model=from_plugin>.model` Poll modelling method (poll from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.poll.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.poll.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.poll.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`poll`|
+
+
+##### `pseudofiles.<string>.poll.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.poll.<model=custom>.model` Poll modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.poll.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.poll.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
+#### `pseudofiles.<string>.lseek` Seek
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle lseek() on the file
+
+##### `pseudofiles.<string>.lseek.<model=default>` Standard offset arithmetic
+
+SEEK_SET/CUR/END against the node's reported size.
+
+###### `pseudofiles.<string>.lseek.<model=default>.model` Seek modelling method (standard offset arithmetic)
+
+|||
+|-|-|
+|__Type__|`"default"`|
+
+
+###### `pseudofiles.<string>.lseek.<model=default>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `pseudofiles.<string>.lseek.<model=unsupported>` Reject seeks
+
+Return -ESPIPE (for pipe/stream-like nodes).
+
+###### `pseudofiles.<string>.lseek.<model=unsupported>.model` Seek modelling method (reject seeks)
+
+|||
+|-|-|
+|__Type__|`"unsupported"`|
+
+
+###### `pseudofiles.<string>.lseek.<model=unsupported>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `pseudofiles.<string>.lseek.<model=from_plugin>` lseek from a custom PyPlugin
+
+
+###### `pseudofiles.<string>.lseek.<model=from_plugin>.model` Seek modelling method (lseek from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.lseek.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.lseek.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.lseek.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`lseek`|
+
+
+##### `pseudofiles.<string>.lseek.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.lseek.<model=custom>.model` Seek modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.lseek.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.lseek.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
+#### `pseudofiles.<string>.mmap` Mmap
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle mmap() on the file
+
+##### `pseudofiles.<string>.mmap.<model=from_plugin>` mmap from a custom PyPlugin
+
+
+###### `pseudofiles.<string>.mmap.<model=from_plugin>.model` Mmap modelling method (mmap from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.mmap.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.mmap.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.mmap.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`mmap`|
+
+
+##### `pseudofiles.<string>.mmap.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.mmap.<model=custom>.model` Mmap modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.mmap.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.mmap.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
+#### `pseudofiles.<string>.open` Open
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle open() on the file
+
+##### `pseudofiles.<string>.open.<model=from_plugin>` open from a custom PyPlugin
+
+Fire a plugin function when the guest opens this node.
+
+###### `pseudofiles.<string>.open.<model=from_plugin>.model` Open modelling method (open from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.open.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.open.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.open.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`open`|
+
+
+##### `pseudofiles.<string>.open.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.open.<model=custom>.model` Open modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.open.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.open.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
+#### `pseudofiles.<string>.release` Release
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle release()/close() on the file
+
+##### `pseudofiles.<string>.release.<model=from_plugin>` release from a custom PyPlugin
+
+Fire a plugin function when the guest closes this node.
+
+###### `pseudofiles.<string>.release.<model=from_plugin>.model` Release modelling method (release from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.release.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.release.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.release.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`release`|
+
+
+##### `pseudofiles.<string>.release.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.release.<model=custom>.model` Release modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.release.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.release.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
+#### `pseudofiles.<string>.compat_ioctl` Compat ioctl
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle 32-bit compat_ioctl() on the file
+
+##### `pseudofiles.<string>.compat_ioctl.<model=same_as_ioctl>` Reuse the ioctl model
+
+Route compat_ioctl through the same handlers as ioctl (the common driver pattern).
+
+###### `pseudofiles.<string>.compat_ioctl.<model=same_as_ioctl>.model` compat_ioctl modelling method (reuse the ioctl model)
+
+|||
+|-|-|
+|__Type__|`"same_as_ioctl"`|
+
+
+###### `pseudofiles.<string>.compat_ioctl.<model=same_as_ioctl>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `pseudofiles.<string>.compat_ioctl.<model=from_plugin>` compat_ioctl from a custom PyPlugin
+
+
+###### `pseudofiles.<string>.compat_ioctl.<model=from_plugin>.model` compat_ioctl modelling method (compat_ioctl from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.compat_ioctl.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.compat_ioctl.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.compat_ioctl.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`compat_ioctl`|
+
+
+#### `pseudofiles.<string>.flush` Flush
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle flush() on the file
+
+##### `pseudofiles.<string>.flush.<model=from_plugin>` flush from a custom PyPlugin
+
+
+###### `pseudofiles.<string>.flush.<model=from_plugin>.model` Flush modelling method (flush from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.flush.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.flush.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.flush.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`flush`|
+
+
+##### `pseudofiles.<string>.flush.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.flush.<model=custom>.model` Flush modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.flush.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.flush.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
+#### `pseudofiles.<string>.fsync` Fsync
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle fsync() on the file
+
+##### `pseudofiles.<string>.fsync.<model=from_plugin>` fsync from a custom PyPlugin
+
+
+###### `pseudofiles.<string>.fsync.<model=from_plugin>.model` Fsync modelling method (fsync from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.fsync.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.fsync.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.fsync.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`fsync`|
+
+
+##### `pseudofiles.<string>.fsync.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.fsync.<model=custom>.model` Fsync modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.fsync.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.fsync.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
+#### `pseudofiles.<string>.fasync` Fasync
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle fasync() on the file
+
+##### `pseudofiles.<string>.fasync.<model=from_plugin>` fasync from a custom PyPlugin
+
+
+###### `pseudofiles.<string>.fasync.<model=from_plugin>.model` Fasync modelling method (fasync from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.fasync.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.fasync.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.fasync.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`fasync`|
+
+
+##### `pseudofiles.<string>.fasync.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.fasync.<model=custom>.model` Fasync modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.fasync.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.fasync.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
+#### `pseudofiles.<string>.lock` Lock
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle lock() on the file
+
+##### `pseudofiles.<string>.lock.<model=from_plugin>` lock from a custom PyPlugin
+
+
+###### `pseudofiles.<string>.lock.<model=from_plugin>.model` Lock modelling method (lock from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.lock.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.lock.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.lock.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`lock`|
+
+
+##### `pseudofiles.<string>.lock.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.lock.<model=custom>.model` Lock modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.lock.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.lock.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
+#### `pseudofiles.<string>.read_iter` Read iterator
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle read_iter() on the file
+
+##### `pseudofiles.<string>.read_iter.<model=from_plugin>` read_iter from a custom PyPlugin
+
+
+###### `pseudofiles.<string>.read_iter.<model=from_plugin>.model` Read iterator modelling method (read_iter from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.read_iter.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.read_iter.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.read_iter.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`read_iter`|
+
+
+##### `pseudofiles.<string>.read_iter.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.read_iter.<model=custom>.model` Read iterator modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.read_iter.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.read_iter.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
+#### `pseudofiles.<string>.write_iter` Write iterator
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle write_iter() on the file
+
+##### `pseudofiles.<string>.write_iter.<model=from_plugin>` write_iter from a custom PyPlugin
+
+
+###### `pseudofiles.<string>.write_iter.<model=from_plugin>.model` Write iterator modelling method (write_iter from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.write_iter.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.write_iter.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.write_iter.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`write_iter`|
+
+
+##### `pseudofiles.<string>.write_iter.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.write_iter.<model=custom>.model` Write iterator modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.write_iter.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.write_iter.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
+#### `pseudofiles.<string>.get_unmapped_area` Get unmapped area
+
+|||
+|-|-|
+|__Default__|`null`|
+
+How to handle get_unmapped_area() on the file
+
+##### `pseudofiles.<string>.get_unmapped_area.<model=from_plugin>` get_unmapped_area from a custom PyPlugin
+
+
+###### `pseudofiles.<string>.get_unmapped_area.<model=from_plugin>.model` Get unmapped area modelling method (get_unmapped_area from a custom pyplugin)
+
+|||
+|-|-|
+|__Type__|`"from_plugin"`|
+
+
+###### `pseudofiles.<string>.get_unmapped_area.<model=from_plugin>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.get_unmapped_area.<model=from_plugin>.plugin` Name of the loaded PyPlugin
+
+|||
+|-|-|
+|__Type__|string|
+
+
+###### `pseudofiles.<string>.get_unmapped_area.<model=from_plugin>.function` Function to call
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`get_unmapped_area`|
+
+
+##### `pseudofiles.<string>.get_unmapped_area.<model=custom>` Custom registered model
+
+Use a model registered via @register_model in a loaded plugin. 'model_name' selects it; any extra keys are forwarded to the model.
+
+###### `pseudofiles.<string>.get_unmapped_area.<model=custom>.model` Get unmapped area modelling method (custom registered model)
+
+|||
+|-|-|
+|__Type__|`"custom"`|
+
+
+###### `pseudofiles.<string>.get_unmapped_area.<model=custom>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.get_unmapped_area.<model=custom>.model_name` Registered model name
+
+|||
+|-|-|
+|__Type__|string|
+
+
 ## `nvram` NVRAM
 
 |||
@@ -1100,76 +2553,327 @@ Files to create in the guest filesystem
 
 Add a file with contents specified inline in this config
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`type`|`"inline_file"`||Type of file action (add inline file)|
-|`mode`|integer|`420`|Permissions of file|
-|`contents`|string||Contents of file|
+##### `static_files.<string>.<type=inline_file>.type` Type of file action (add inline file)
+
+|||
+|-|-|
+|__Type__|`"inline_file"`|
+
+
+##### `static_files.<string>.<type=inline_file>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `static_files.<string>.<type=inline_file>.mode` Permissions of file
+
+|||
+|-|-|
+|__Type__|integer|
+|__Default__|`420`|
+
+
+##### `static_files.<string>.<type=inline_file>.contents` Contents of file
+
+|||
+|-|-|
+|__Type__|string|
+
+
 #### `static_files.<string>.<type=host_file>` Copy host file
 
 Copy a file from the host into the guest
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`type`|`"host_file"`||Type of file action (copy host file)|
-|`mode`|integer|`493`|Permissions of file|
-|`host_path`|string||Host path|
+##### `static_files.<string>.<type=host_file>.type` Type of file action (copy host file)
+
+|||
+|-|-|
+|__Type__|`"host_file"`|
+
+
+##### `static_files.<string>.<type=host_file>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `static_files.<string>.<type=host_file>.mode` Permissions of file
+
+|||
+|-|-|
+|__Type__|integer|
+|__Default__|`493`|
+
+
+##### `static_files.<string>.<type=host_file>.host_path` Host path
+
+|||
+|-|-|
+|__Type__|string|
+
+
 #### `static_files.<string>.<type=dir>` Add directory
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`type`|`"dir"`||Type of file action (add directory)|
-|`mode`|integer|`493`|Permissions of directory|
+##### `static_files.<string>.<type=dir>.type` Type of file action (add directory)
+
+|||
+|-|-|
+|__Type__|`"dir"`|
+
+
+##### `static_files.<string>.<type=dir>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `static_files.<string>.<type=dir>.mode` Permissions of directory
+
+|||
+|-|-|
+|__Type__|integer|
+|__Default__|`493`|
+
+
 #### `static_files.<string>.<type=symlink>` Add symbolic link
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`type`|`"symlink"`||Type of file action (add symbolic link)|
-|`target`|string||Target linked path|
+##### `static_files.<string>.<type=symlink>.type` Type of file action (add symbolic link)
+
+|||
+|-|-|
+|__Type__|`"symlink"`|
+
+
+##### `static_files.<string>.<type=symlink>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `static_files.<string>.<type=symlink>.target` Target linked path
+
+|||
+|-|-|
+|__Type__|string|
+
+
 #### `static_files.<string>.<type=dev>` Add device file
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`type`|`"dev"`||Type of file action (add device file)|
-|`devtype`|`"char"` or `"block"`||Type of device file|
-|`major`|integer||Major device number|
-|`minor`|integer||Minor device number|
-|`mode`|integer|`438`|Permissions of device file|
+##### `static_files.<string>.<type=dev>.type` Type of file action (add device file)
+
+|||
+|-|-|
+|__Type__|`"dev"`|
+
+
+##### `static_files.<string>.<type=dev>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `static_files.<string>.<type=dev>.devtype` Type of device file
+
+|||
+|-|-|
+|__Type__|`"char"` or `"block"`|
+
+
+##### `static_files.<string>.<type=dev>.major` Major device number
+
+|||
+|-|-|
+|__Type__|integer|
+
+
+##### `static_files.<string>.<type=dev>.minor` Minor device number
+
+|||
+|-|-|
+|__Type__|integer|
+
+
+##### `static_files.<string>.<type=dev>.mode` Permissions of device file
+
+|||
+|-|-|
+|__Type__|integer|
+|__Default__|`438`|
+
+
 #### `static_files.<string>.<type=delete>` Delete file
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`type`|`"delete"`||Type of file action (delete file)|
+##### `static_files.<string>.<type=delete>.type` Type of file action (delete file)
+
+|||
+|-|-|
+|__Type__|`"delete"`|
+
+
+##### `static_files.<string>.<type=delete>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
 #### `static_files.<string>.<type=move>` Move file
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`type`|`"move"`||Type of file action (move file)|
-|`from`|string||File to be moved to the specified location|
-|`mode`|integer or null|`null`|Permissions of target file|
+##### `static_files.<string>.<type=move>.type` Type of file action (move file)
+
+|||
+|-|-|
+|__Type__|`"move"`|
+
+
+##### `static_files.<string>.<type=move>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `static_files.<string>.<type=move>.from` File to be moved to the specified location
+
+|||
+|-|-|
+|__Type__|string|
+
+
+##### `static_files.<string>.<type=move>.mode` Permissions of target file
+
+|||
+|-|-|
+|__Type__|integer or null|
+|__Default__|`null`|
+
+
 #### `static_files.<string>.<type=shim>` Shim file
 
 
-|Field|Type|Default|Title|
-|-|-|-|-|
-|`type`|`"shim"`||Type of file action (shim file)|
-|`target`|string||Target file we want the shim to be symlinked to|
+##### `static_files.<string>.<type=shim>.type` Type of file action (shim file)
+
+|||
+|-|-|
+|__Type__|`"shim"`|
+
+
+##### `static_files.<string>.<type=shim>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `static_files.<string>.<type=shim>.target` Target file we want the shim to be symlinked to
+
+|||
+|-|-|
+|__Type__|string|
+
+
 #### `static_files.<string>.<type=binary_patch>` Patch binary file
 
 Make a patch to a binary file at the specified offset. This can either be arbitrary bytes specified as a hex string, or assembly code that will be automatically assembled in the specified mode.
 
-|Field|Type|Default|Title|Examples|
-|-|-|-|-|-|
-|`type`|`"binary_patch"`||Type of file action (patch binary file)||
-|`file_offset`|integer||File offset (integer)||
-|`hex_bytes`|string or null|`null`|Bytes to write at offset (hex string)|`DEADBEEF`, `90 90`|
-|`asm`|string or null|`null`|Assembly code to write at offset (runs through keystone)|`nop`, `'mov r0, #0xdeadbeef'`|
-|`mode`|string or null|`null`|Assembly mode|`arm`, `thumb`|
+##### `static_files.<string>.<type=binary_patch>.type` Type of file action (patch binary file)
+
+|||
+|-|-|
+|__Type__|`"binary_patch"`|
+
+
+##### `static_files.<string>.<type=binary_patch>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `static_files.<string>.<type=binary_patch>.file_offset` File offset (integer)
+
+|||
+|-|-|
+|__Type__|integer|
+
+
+##### `static_files.<string>.<type=binary_patch>.hex_bytes` Bytes to write at offset (hex string)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+DEADBEEF
+```
+
+```yaml
+90 90
+```
+
+##### `static_files.<string>.<type=binary_patch>.asm` Assembly code to write at offset (runs through keystone)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+nop
+```
+
+```yaml
+'mov r0, #0xdeadbeef'
+```
+
+##### `static_files.<string>.<type=binary_patch>.mode` Assembly mode
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+arm
+```
+
+```yaml
+thumb
+```
+
 ## `plugins` Plugins
 
 

--- a/pyplugins/hyperfile/models/base.py
+++ b/pyplugins/hyperfile/models/base.py
@@ -42,7 +42,7 @@ class BaseFile:
     SIZE = 0
     SUPPORT_MMAP = False  # Explicitly declare mmap capability
 
-    def __init__(self, *, path: str = None, fs: str = None, size: int = None, mode: int = None, support_mmap: bool = None, **kwargs):
+    def __init__(self, *, path: str = None, fs: str = None, size: int = None, mode: int = None, support_mmap: bool = None, default_hit_cb=None, **kwargs):
         """
         Consumes 'path', 'fs', 'size', 'mode', and 'support_mmap' arguments.
         """
@@ -63,7 +63,44 @@ class BaseFile:
         else:
             self.MODE = self._derive_mode()
 
+        # Provenance/observability: a synthesized "default" model reports its
+        # hits so it doesn't silently mask behavior. Capture per-domain
+        # provenance tags (read_provenance, write_provenance, ...) and the hit
+        # callback; absence makes _report_default a no-op (backwards compatible).
+        self._default_hit_cb = default_hit_cb
+        self._default_hit_seen = set()
+        self._provenance = {}
+        for _op in ("read", "write", "ioctl", "poll", "lseek", "mmap", "open", "release"):
+            _val = kwargs.pop(f"{_op}_provenance", None)
+            if _val is not None:
+                self._provenance[_op] = _val
+
         super().__init__()
+
+    def _report_default(self, op: str, details: dict = None, provenance: str = None):
+        """Report that a synthesized default model served an access.
+
+        Fires the hit callback once per (op, distinct cmd), so a hot default
+        device does not flood telemetry. ``provenance`` may be passed explicitly
+        (ioctl handlers track their own); otherwise the per-domain tag captured
+        at construction is used. No-op unless the model is a tracked default and
+        a callback is wired.
+        """
+        prov = provenance if provenance is not None else self._provenance.get(op)
+        if prov not in ("default", "discovered"):
+            return
+        cb = getattr(self, "_default_hit_cb", None)
+        if cb is None:
+            return
+        details = details or {}
+        key = (op, details.get("cmd"))
+        if key in self._default_hit_seen:
+            return
+        self._default_hit_seen.add(key)
+        try:
+            cb(self.PATH, op, details)
+        except Exception:
+            pass
 
     def _derive_mode(self) -> int:
         """Derive appropriate file permissions based on implemented methods."""
@@ -190,6 +227,11 @@ class VFSFile(BaseFile):
         pass
 
     def write(self, ptregs: PtRegsWrapper, file: FilePtr, user_buf: CharPtr, size: SizeT, offset_ptr: LoffTPtr) -> None:
+        pass
+
+    def write_iter(self, ptregs: PtRegsWrapper, kiocb: KiocbPtr, iov_iter: IovIterPtr) -> None:
+        # Stub so write_iter is recognizable as overridable (devfs/anonfs wire
+        # it); previously referenced by the registration layer but undefined.
         pass
 
     def lseek(self, ptregs: PtRegsWrapper, file: FilePtr, offset: LoffT, whence: CInt) -> None:

--- a/pyplugins/hyperfile/models/ioctl.py
+++ b/pyplugins/hyperfile/models/ioctl.py
@@ -128,6 +128,33 @@ class IoctlDispatcher:
             ptregs.retval = -25  # -ENOTTY
 
 
+class CompatIoctlDispatcher:
+    """Route compat_ioctl() through a handler map (32-bit-on-64-bit ioctls).
+
+    Mirrors :class:`IoctlDispatcher` but for the ``compat_ioctl`` fop. When
+    configured ``same_as_ioctl`` it is given the very same handler map as
+    ``ioctl`` (the common driver pattern ``.compat_ioctl = .unlocked_ioctl``).
+    """
+
+    def __init__(self, *, compat_ioctl_handlers: dict = None, **kwargs):
+        self.compat_ioctl_handlers = compat_ioctl_handlers or {}
+        super().__init__(**kwargs)
+
+    def compat_ioctl(self, ptregs: PtRegsWrapper, file: FilePtr, cmd: CInt, arg: CInt):
+        cmd_val = int(cmd)
+        handler = self.compat_ioctl_handlers.get(cmd_val)
+        if handler is None:
+            handler = self.compat_ioctl_handlers.get(str(cmd_val))
+        if handler is None:
+            handler = self.compat_ioctl_handlers.get("*")
+        if handler:
+            res = handler.handle(self, ptregs, file, cmd_val, arg)
+            if inspect.isgenerator(res):
+                yield from res
+        else:
+            ptregs.retval = -25  # -ENOTTY
+
+
 class IoctlHandlerBase:
     def handle(self, file_obj, ptregs: PtRegsWrapper, file: FilePtr, cmd: CInt, arg: CInt):
         raise NotImplementedError
@@ -136,10 +163,39 @@ class IoctlHandlerBase:
 class IoctlReturnConst(IoctlHandlerBase):
     """Returns a static constant."""
 
-    def __init__(self, val):
+    def __init__(self, val, provenance=None):
         self.val = val
+        self.provenance = provenance
 
     def handle(self, file_obj, ptregs: PtRegsWrapper, file: FilePtr, cmd: CInt, arg: CInt):
+        report = getattr(file_obj, "_report_default", None)
+        if report:
+            report("ioctl", {"cmd": int(cmd), "arg": int(arg)}, provenance=self.provenance)
+        ptregs.retval = self.val
+
+
+class IoctlWriteData(IoctlHandlerBase):
+    """Writes a constant buffer to the address pointed to by ``arg``.
+
+    This is the per-command handler analogue of :class:`IoctlWriteDataArg`,
+    for the ioctl command-map dispatch. Covers the very common shape of an
+    ioctl that fills a user-supplied struct, then returns ``val``.
+    """
+
+    def __init__(self, data: Union[bytes, str] = b"", val: int = 0, provenance=None):
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+        self.data = data
+        self.val = val
+        self.provenance = provenance
+
+    def handle(self, file_obj, ptregs: PtRegsWrapper, file: FilePtr, cmd: CInt, arg: CInt):
+        report = getattr(file_obj, "_report_default", None)
+        if report:
+            report("ioctl", {"cmd": int(cmd), "arg": int(arg)}, provenance=self.provenance)
+        arg_addr = int(arg)
+        if self.data and arg_addr != 0:
+            yield from plugins.mem.write(arg_addr, self.data)
         ptregs.retval = self.val
 
 

--- a/pyplugins/hyperfile/models/read.py
+++ b/pyplugins/hyperfile/models/read.py
@@ -30,6 +30,9 @@ class ReadBufWrapper:
         Reads data once, respecting offset and size.
         Returns 0 if offset is beyond the data.
         """
+        report = getattr(self, "_report_default", None)
+        if report:
+            report("read")
         size_val = int(size)
 
         if isinstance(self._data, bytes):
@@ -59,14 +62,9 @@ class ReadBufWrapper:
                 ptregs.retval = 0
                 return
             pos = offset % data_len
-            # Build the output by repeating the buffer as needed
-            full_repeats = (size_val + data_len - 1 - pos) // data_len
-            end_pos = (pos + size_val) % data_len
-            if end_pos > pos:
-                chunk_data = data_bytes[pos:end_pos]
-            else:
-                chunk_data = data_bytes[pos:] + data_bytes * (full_repeats - 1) + data_bytes[:end_pos]
-            chunk_data = chunk_data[:size_val]  # Ensure exact size
+            # Repeat the buffer enough times to cover [pos, pos+size_val), then slice.
+            reps = (pos + size_val + data_len - 1) // data_len
+            chunk_data = (data_bytes * reps)[pos:pos + size_val]
             yield from plugins.mem.write(user_buf, chunk_data)
             yield from plugins.mem.write(offset_ptr, offset + size_val)
             ptregs.retval = size_val
@@ -298,6 +296,101 @@ class ReadConstBufCycle(ReadCycle):
 
     def __init__(self, *, buffer: str = None, **kwargs):
         super().__init__(buffer=buffer, **kwargs)
+
+
+class ReadStateful:
+    '''
+    Reads back whatever was last written to this node.
+
+    Serves bytes from ``self.written_data`` — the same attribute that
+    ``WriteRecord``/``WriteDefault`` populate — so pairing
+    ``read: {model: stateful}`` with ``write: {model: default}`` yields a
+    read-after-write register expressed entirely in YAML, with no plugin.
+    An optional ``initial`` value seeds the buffer.
+    '''
+
+    def __init__(self, *, initial: Union[bytes, str] = None, **kwargs):
+        if not hasattr(self, "written_data"):
+            if initial is None:
+                self.written_data = b""
+            elif isinstance(initial, bytes):
+                self.written_data = initial
+            else:
+                self.written_data = str(initial).encode("utf-8")
+        super().__init__(**kwargs)
+
+    def read(self, ptregs: PtRegsWrapper, file: FilePtr, user_buf: CharPtr, size: SizeT, offset_ptr: LoffTPtr):
+        size_val = int(size)
+        data_bytes = self.written_data or b""
+        data_len = len(data_bytes)
+
+        offset = yield from plugins.kffi.deref(offset_ptr)
+
+        if size_val <= 0 or offset < 0 or offset >= data_len:
+            ptregs.retval = 0
+            return
+
+        chunk = min(size_val, data_len - offset)
+        yield from plugins.mem.write(user_buf, data_bytes[offset:offset + chunk])
+        yield from plugins.mem.write(offset_ptr, offset + chunk)
+        ptregs.retval = chunk
+
+
+class ReadSequence:
+    '''
+    Returns successive entries from a list on successive reads.
+
+    Each (fresh, offset 0) read pops the next entry from ``vals``; once the
+    list is exhausted the last entry is held forever, or — when ``cycle`` is
+    set — the sequence wraps around. Covers the common
+    "busy... busy... ready" status-polling pattern that otherwise forces a
+    custom plugin. Within a single entry, offset/size are honored so partial
+    reads of a large entry advance through it before moving to the next.
+    '''
+
+    def __init__(self, *, vals=None, cycle: bool = False, **kwargs):
+        seq = vals or []
+        self._seq = []
+        for v in seq:
+            if isinstance(v, bytes):
+                self._seq.append(v)
+            else:
+                self._seq.append(str(v).encode("utf-8"))
+        self._seq_cycle = cycle
+        self._seq_idx = 0
+        super().__init__(**kwargs)
+
+    def read(self, ptregs: PtRegsWrapper, file: FilePtr, user_buf: CharPtr, size: SizeT, offset_ptr: LoffTPtr):
+        size_val = int(size)
+        offset = yield from plugins.kffi.deref(offset_ptr)
+
+        if size_val <= 0 or offset < 0 or not self._seq:
+            ptregs.retval = 0
+            return
+
+        idx = self._seq_idx
+        if idx >= len(self._seq):
+            if self._seq_cycle:
+                idx = idx % len(self._seq)
+            else:
+                idx = len(self._seq) - 1
+        data_bytes = self._seq[idx]
+        data_len = len(data_bytes)
+
+        if offset >= data_len:
+            # EOF for this entry; the tail-serve below already advanced the
+            # index, so just report end-of-file here.
+            ptregs.retval = 0
+            return
+
+        chunk = min(size_val, data_len - offset)
+        yield from plugins.mem.write(user_buf, data_bytes[offset:offset + chunk])
+        yield from plugins.mem.write(offset_ptr, offset + chunk)
+        ptregs.retval = chunk
+
+        # If we served the tail of this entry, advance for the next open/read.
+        if offset + chunk >= data_len:
+            self._seq_idx += 1
 
 
 class ReadExternalVFS:

--- a/pyplugins/hyperfile/models/read.py
+++ b/pyplugins/hyperfile/models/read.py
@@ -61,12 +61,15 @@ class ReadBufWrapper:
             if data_len == 0:
                 ptregs.retval = 0
                 return
-            pos = offset % data_len
+            # offset is a kffi BoundTypeInstance (loff_t); coerce to int — it
+            # supports comparison/add/index but not %, which the cycle math needs.
+            off = int(offset)
+            pos = off % data_len
             # Repeat the buffer enough times to cover [pos, pos+size_val), then slice.
             reps = (pos + size_val + data_len - 1) // data_len
             chunk_data = (data_bytes * reps)[pos:pos + size_val]
             yield from plugins.mem.write(user_buf, chunk_data)
-            yield from plugins.mem.write(offset_ptr, offset + size_val)
+            yield from plugins.mem.write(offset_ptr, off + size_val)
             ptregs.retval = size_val
 
 

--- a/pyplugins/hyperfile/models/registry.py
+++ b/pyplugins/hyperfile/models/registry.py
@@ -1,0 +1,50 @@
+"""Pluggable registry for pseudofile models.
+
+This is the low-friction "expand models with Python code" path: a local
+plugin (e.g. a file in a project's ``plugins.d/``) can register a new model
+mixin under a name, after which that name is usable directly in ``config.yaml``
+via the ``custom`` model selector::
+
+    # plugins.d/my_models.py
+    from hyperfile.models.registry import register_model
+    from hyperfile.models.read import ReadBufWrapper
+
+    @register_model("read", "my_sensor")
+    class MySensorRead(ReadBufWrapper):
+        ...
+
+    # config.yaml
+    pseudofiles:
+      /dev/sensor:
+        read: {model: custom, model_name: my_sensor}
+
+The registry covers the mixin-based domains (read, write, poll, and the extra
+VFS ops lseek/mmap/open/release). Built-in models keep their first-class names;
+the registry is consulted *in addition* to the built-in tables.
+"""
+
+_DOMAINS = ("read", "write", "poll", "lseek", "mmap", "open", "release", "ioctl")
+
+_REGISTRY = {d: {} for d in _DOMAINS}
+
+
+def register_model(domain, name):
+    """Decorator: register ``cls`` as model ``name`` for ``domain``.
+
+    ``domain`` is one of read/write/poll/lseek/mmap/open/release/ioctl.
+    """
+    if domain not in _REGISTRY:
+        raise ValueError(
+            f"register_model: unknown domain '{domain}' "
+            f"(expected one of {', '.join(_DOMAINS)})")
+
+    def _wrap(cls):
+        _REGISTRY[domain][name] = cls
+        return cls
+
+    return _wrap
+
+
+def get_model(domain, name):
+    """Return the registered model class for ``(domain, name)`` or None."""
+    return _REGISTRY.get(domain, {}).get(name)

--- a/pyplugins/hyperfile/models/seek.py
+++ b/pyplugins/hyperfile/models/seek.py
@@ -84,6 +84,11 @@ class OpenExternalVFS:
         super().__init__(**kwargs)
 
     def open(self, ptregs: PtRegsWrapper, inode: InodePtr, file: FilePtr):
+        # Default to success (0). open() is `int (*)(...)`: a non-zero return
+        # fails the open() syscall, so a side-effect-only hook that never
+        # touches retval would otherwise break the file. The hook may still set
+        # ptregs.retval to fail the open deliberately.
+        ptregs.retval = 0
         res = self._open_func(ptregs, inode, file)
         if inspect.isgenerator(res):
             yield from res
@@ -97,6 +102,8 @@ class ReleaseExternalVFS:
         super().__init__(**kwargs)
 
     def release(self, ptregs: PtRegsWrapper, inode: InodePtr, file: FilePtr):
+        # Default to success (0); release() is `int (*)(...)` like open().
+        ptregs.retval = 0
         res = self._release_func(ptregs, inode, file)
         if inspect.isgenerator(res):
             yield from res

--- a/pyplugins/hyperfile/models/seek.py
+++ b/pyplugins/hyperfile/models/seek.py
@@ -1,0 +1,168 @@
+"""Declarative models for VFS operations beyond read/write/ioctl/poll.
+
+These expose the rest of the ``file_operations`` surface that ``VFSFile``
+already defines (lseek, open, release, mmap) as first-class, named config
+models, so a node can model them without dropping to a full plugin. Every
+model here is optional: a node that omits a domain keeps today's behavior
+(the no-op ``VFSFile`` stub, i.e. the kernel default).
+"""
+
+import inspect
+from penguin import plugins
+from wrappers.ptregs_wrap import PtRegsWrapper
+from .base import FilePtr, InodePtr, VmAreaPtr, LoffT, CInt
+
+
+# ---------------------------------------------------------------------------
+# lseek
+# ---------------------------------------------------------------------------
+
+class SeekDefault:
+    """Standard offset arithmetic against the node's reported SIZE.
+
+    Makes the implicit known-size seek behavior nameable. Handles
+    SEEK_SET/SEEK_CUR/SEEK_END and clamps to [0, SIZE].
+    """
+
+    def lseek(self, ptregs: PtRegsWrapper, file: FilePtr, offset: LoffT, whence: CInt):
+        offset_val = int(offset)
+        whence_val = int(whence)
+        size = int(getattr(self, "SIZE", 0))
+
+        cur = yield from plugins.kffi.read_field(file, "struct file", "f_pos")
+        cur_val = int(cur)
+
+        if whence_val == 0:      # SEEK_SET
+            new_offset = offset_val
+        elif whence_val == 1:    # SEEK_CUR
+            new_offset = cur_val + offset_val
+        elif whence_val == 2:    # SEEK_END
+            new_offset = size + offset_val
+        else:
+            ptregs.retval = -22  # -EINVAL
+            return
+
+        if new_offset < 0 or new_offset > size:
+            ptregs.retval = -22
+            return
+
+        yield from plugins.kffi.write_field(file, "struct file", "f_pos", new_offset)
+        ptregs.retval = new_offset
+
+
+class SeekUnsupported:
+    """Reject seeking with -ESPIPE (for pipe/stream-like nodes)."""
+
+    def lseek(self, ptregs: PtRegsWrapper, file: FilePtr, offset: LoffT, whence: CInt):
+        if False:
+            yield
+        ptregs.retval = -29  # -ESPIPE
+
+
+class SeekExternalVFS:
+    """Call a plugin function with the lseek VFS signature."""
+
+    def __init__(self, *, lseek_plugin: str = None, lseek_function: str = "lseek", **kwargs):
+        self._lseek_func = getattr(getattr(plugins, lseek_plugin), lseek_function)
+        super().__init__(**kwargs)
+
+    def lseek(self, ptregs: PtRegsWrapper, file: FilePtr, offset: LoffT, whence: CInt):
+        res = self._lseek_func(ptregs, file, offset, whence)
+        if inspect.isgenerator(res):
+            yield from res
+
+
+# ---------------------------------------------------------------------------
+# open / release
+# ---------------------------------------------------------------------------
+
+class OpenExternalVFS:
+    """Call a plugin function on open(): func(ptregs, inode, file)."""
+
+    def __init__(self, *, open_plugin: str = None, open_function: str = "open", **kwargs):
+        self._open_func = getattr(getattr(plugins, open_plugin), open_function)
+        super().__init__(**kwargs)
+
+    def open(self, ptregs: PtRegsWrapper, inode: InodePtr, file: FilePtr):
+        res = self._open_func(ptregs, inode, file)
+        if inspect.isgenerator(res):
+            yield from res
+
+
+class ReleaseExternalVFS:
+    """Call a plugin function on release()/close(): func(ptregs, inode, file)."""
+
+    def __init__(self, *, release_plugin: str = None, release_function: str = "release", **kwargs):
+        self._release_func = getattr(getattr(plugins, release_plugin), release_function)
+        super().__init__(**kwargs)
+
+    def release(self, ptregs: PtRegsWrapper, inode: InodePtr, file: FilePtr):
+        res = self._release_func(ptregs, inode, file)
+        if inspect.isgenerator(res):
+            yield from res
+
+
+# ---------------------------------------------------------------------------
+# mmap
+# ---------------------------------------------------------------------------
+
+class MmapExternalVFS:
+    """Call a plugin function on mmap(): func(ptregs, file, vm_area_struct)."""
+
+    def __init__(self, *, mmap_plugin: str = None, mmap_function: str = "mmap", **kwargs):
+        self._mmap_func = getattr(getattr(plugins, mmap_plugin), mmap_function)
+        super().__init__(**kwargs)
+
+    def mmap(self, ptregs: PtRegsWrapper, file: FilePtr, vm_area_struct: VmAreaPtr):
+        res = self._mmap_func(ptregs, file, vm_area_struct)
+        if inspect.isgenerator(res):
+            yield from res
+
+
+# ---------------------------------------------------------------------------
+# Generic plugin-op adapters for the remaining (device-specific) fops:
+# flush, fsync, fasync, lock, read_iter, write_iter, get_unmapped_area,
+# compat_ioctl. Each just forwards the kernel's call to a plugin function with
+# the op's native VFS signature; the per-op signature is supplied by the
+# registration layer's DWARF info, so the adapter only needs to forward args.
+# ---------------------------------------------------------------------------
+
+def _make_plugin_op_adapter(op):
+    """Build a mixin class that routes ``op`` to a plugin function.
+
+    Reads ``{op}_plugin`` / ``{op}_function`` kwargs (produced by
+    ``_translate_kwargs``) and defines a method named ``op`` forwarding all
+    arguments to the plugin function, yielding if it is a generator.
+    """
+    plugin_kw = f"{op}_plugin"
+    func_kw = f"{op}_function"
+    attr = f"_{op}_func"
+
+    def __init__(self, **kwargs):
+        plugin = kwargs.pop(plugin_kw, None)
+        function = kwargs.pop(func_kw, op)
+        setattr(self, attr, getattr(getattr(plugins, plugin), function))
+        super(adapter, self).__init__(**kwargs)
+
+    def _method(self, *args):
+        res = getattr(self, attr)(*args)
+        if inspect.isgenerator(res):
+            yield from res
+
+    cls_name = "".join(p.title() for p in op.split("_")) + "ExternalVFS"
+    adapter = type(cls_name, (object,), {
+        "__init__": __init__,
+        op: _method,
+        "__doc__": f"Call a plugin function for {op}().",
+    })
+    return adapter
+
+
+FlushExternalVFS = _make_plugin_op_adapter("flush")
+FsyncExternalVFS = _make_plugin_op_adapter("fsync")
+FasyncExternalVFS = _make_plugin_op_adapter("fasync")
+LockExternalVFS = _make_plugin_op_adapter("lock")
+ReadIterExternalVFS = _make_plugin_op_adapter("read_iter")
+WriteIterExternalVFS = _make_plugin_op_adapter("write_iter")
+GetUnmappedAreaExternalVFS = _make_plugin_op_adapter("get_unmapped_area")
+CompatIoctlExternalVFS = _make_plugin_op_adapter("compat_ioctl")

--- a/pyplugins/hyperfile/models/write.py
+++ b/pyplugins/hyperfile/models/write.py
@@ -21,6 +21,10 @@ class WriteDiscard:
         Discards all written data.
         Always returns the size written.
         """
+        report = getattr(self, "_report_default", None)
+        if report:
+            buf = yield from plugins.mem.read(user_buf, int(size), fmt="bytes")
+            report("write", {"payload": buf[:64].hex(), "len": int(size)})
         ptregs.retval = int(size)
 
 
@@ -65,6 +69,10 @@ class WriteRecord:
         """
         size_val = int(size)
         buf = yield from plugins.mem.read(user_buf, size_val, fmt="bytes")
+
+        report = getattr(self, "_report_default", None)
+        if report:
+            report("write", {"payload": buf[:64].hex(), "len": size_val})
 
         offset = yield from plugins.kffi.deref(offset_ptr)
         previous = self.written_data[:offset]

--- a/pyplugins/hyperfile/pseudofile_tracker.py
+++ b/pyplugins/hyperfile/pseudofile_tracker.py
@@ -223,6 +223,21 @@ class PseudofileTracker(Plugin):
             if path and path_interesting(path):
                 self.log_ioctl_failure(path, cmd)
 
+    def record_default_hit(self, path, op, details=None):
+        """Record that a synthesized default model actively served an access.
+
+        Folds the hit into the same failures view as genuine -ENOENT/-ENOTTY
+        failures (events default_read/default_write/default_ioctl), so an
+        active default surfaces as "needs a real model". Called by the
+        Pseudofiles plugin, already deduplicated per (op, cmd) at the model.
+        """
+        if not self.log_missing:
+            return
+        event = f"default_{op}"
+        self.centralized_log(path, event, details or None)
+        self.logger.debug(f"Default model served {op} on {path} {details or ''}")
+        self.dump_results()
+
     # --- Telemetry & Logging Methods ---
 
     def centralized_log(self, path, event, event_details=None):

--- a/pyplugins/hyperfile/pseudofiles.py
+++ b/pyplugins/hyperfile/pseudofiles.py
@@ -9,25 +9,54 @@ from hyperfile.models.read import (
     ReadConstBuf,
     ReadConstMap,
     ReadConstMapFile,
+    ReadCycle,
     ReadDefault,
     ReadEmpty,
     ReadExternalLegacy,
     ReadExternalVFS,
     ReadFromFile,
     ReadOne,
+    ReadSequence,
+    ReadStateful,
     ReadZero,
 )
-from hyperfile.models.write import WriteDefault, WriteExternalVFS, WriteExternalLegacy, WriteToFile
+from hyperfile.models.write import (
+    WriteDefault,
+    WriteExternalVFS,
+    WriteExternalLegacy,
+    WriteReturnConst,
+    WriteToFile,
+    WriteUnhandled,
+)
 from hyperfile.models.ioctl import (
     IoctlDispatcher,
+    CompatIoctlDispatcher,
     IoctlReturnConst,
     IoctlExternalVFS,
     IoctlExternalLegacy,
+    IoctlWriteData,
     IoctlZero,
     IoctlPluginVFS,
     IoctlPluginLegacy,
 )
 from hyperfile.models.poll import PollAlwaysReady, PollExternalVFS
+from hyperfile.models.registry import get_model
+from hyperfile.models.seek import (
+    SeekDefault,
+    SeekUnsupported,
+    SeekExternalVFS,
+    OpenExternalVFS,
+    ReleaseExternalVFS,
+    MmapExternalVFS,
+    FlushExternalVFS,
+    FsyncExternalVFS,
+    FasyncExternalVFS,
+    LockExternalVFS,
+    ReadIterExternalVFS,
+    WriteIterExternalVFS,
+    GetUnmappedAreaExternalVFS,
+    CompatIoctlExternalVFS,
+)
 
 
 class _LegacyDevSeekCompat:
@@ -73,9 +102,22 @@ class Pseudofiles(Plugin):
 
     def __init__(self):
         self.config = self.get_arg("conf")
-        if not self.get_arg_bool("disable_tracking"):
+        self._tracking = not self.get_arg_bool("disable_tracking")
+        if self._tracking:
             plugins.pseudofile_tracker.ensure_init()
         self._populate_hf_config()
+
+    def _record_default_hit(self, path, op, details):
+        """Forward a default-model hit to the tracker's failures view.
+
+        No-op if the tracker is not loaded (e.g. disable_tracking).
+        """
+        if not self._tracking:
+            return
+        tracker = getattr(plugins, "pseudofile_tracker", None)
+        if tracker is None:
+            return
+        tracker.record_default_hit(path, op, details)
 
     # 1. MAPPING LEGACY NAMES TO NEW CLASSES
     # --------------------------------------
@@ -86,7 +128,10 @@ class Pseudofiles(Plugin):
         "const_buf": ReadConstBuf,
         "const_map": ReadConstMap,
         "const_map_file": ReadConstMapFile,
+        "cycle": ReadCycle,
         "from_file": ReadFromFile,
+        "stateful": ReadStateful,
+        "sequence": ReadSequence,
         "return_const": ReadConstBuf,  # Legacy compatibility
         "default": ReadDefault,
     }
@@ -94,6 +139,8 @@ class Pseudofiles(Plugin):
     write_models = {
         "discard": WriteDefault,
         "to_file": WriteToFile,
+        "return_const": WriteReturnConst,
+        "unhandled": WriteUnhandled,
         "default": WriteDefault,
     }
 
@@ -107,6 +154,42 @@ class Pseudofiles(Plugin):
         "always_ready": PollAlwaysReady,
     }
 
+    # Per-operation models for the rest of the VFS surface. Each maps a model
+    # name to a mixin; "from_plugin" is handled via the adapter in EXTRA_OPS.
+    # An absent/None entry (e.g. open/release "noop") leaves the base no-op,
+    # which is the kernel default — so omitting a domain is fully backwards
+    # compatible.
+    seek_models = {
+        "default": SeekDefault,
+        "unsupported": SeekUnsupported,
+    }
+    mmap_models = {}
+    open_models = {}
+    release_models = {}
+
+    # domain -> (models_dict, from_plugin_adapter). The device-specific fops
+    # (flush/fsync/fasync/lock) wire only for /dev (and anonfs); read_iter /
+    # write_iter / get_unmapped_area are advanced fops. All are from_plugin-only.
+    EXTRA_OPS = {
+        "lseek": (seek_models, SeekExternalVFS),
+        "mmap": (mmap_models, MmapExternalVFS),
+        "open": (open_models, OpenExternalVFS),
+        "release": (release_models, ReleaseExternalVFS),
+        "flush": ({}, FlushExternalVFS),
+        "fsync": ({}, FsyncExternalVFS),
+        "fasync": ({}, FasyncExternalVFS),
+        "lock": ({}, LockExternalVFS),
+        "read_iter": ({}, ReadIterExternalVFS),
+        "write_iter": ({}, WriteIterExternalVFS),
+        "get_unmapped_area": ({}, GetUnmappedAreaExternalVFS),
+    }
+    # Config keys consumed by per-domain resolution (excluded from the
+    # top-level file-property passthrough).
+    _DOMAIN_KEYS = ("read", "write", "ioctl", "poll", "plugin",
+                    "lseek", "seek", "mmap", "open", "release",
+                    "compat_ioctl", "flush", "fsync", "fasync", "lock",
+                    "read_iter", "write_iter", "get_unmapped_area")
+
     # Built-in single-object backing classes, referenced by bare name in the
     # file-level `plugin:` key. User backings use the `file:ClassName` form
     # instead (resolved via the pyplugin search path).
@@ -118,6 +201,10 @@ class Pseudofiles(Plugin):
         domain: 'read', 'write', or 'ioctl'
         """
         new_kwargs = {}
+
+        # 0. Provenance (per-domain so read/write can each carry their own)
+        if "provenance" in raw_config:
+            new_kwargs[f"{domain}_provenance"] = raw_config["provenance"]
 
         # 1. Handle Plugins (collision prone)
         if "plugin" in raw_config:
@@ -145,7 +232,7 @@ class Pseudofiles(Plugin):
         # Careful: 'size' might be used by both read maps and base file props.
         # Usually BaseFile consumes 'size' via kwargs last, so it's okay to pass through.
         for k, v in raw_config.items():
-            if k not in ["plugin", "function", "filename", "val", "model"]:
+            if k not in ["plugin", "function", "filename", "val", "model", "model_name", "provenance"]:
                 new_kwargs[k] = v
 
         return new_kwargs
@@ -232,13 +319,20 @@ class Pseudofiles(Plugin):
         Creates a specific Handler object for one ioctl entry.
         """
         model = details.get("model", "return_const")
+        provenance = details.get("provenance")
 
         if model == "return_const":
             val = details.get("val", 0)
-            return IoctlReturnConst(val)
+            return IoctlReturnConst(val, provenance=provenance)
 
         elif model == "zero":
-            return IoctlReturnConst(0)
+            return IoctlReturnConst(0, provenance=provenance)
+
+        elif model == "unhandled":
+            return IoctlReturnConst(-25, provenance=provenance)  # -ENOTTY
+
+        elif model == "write_data":
+            return IoctlWriteData(details.get("data", b""), details.get("val", 0), provenance=provenance)
 
         elif model == "from_plugin":
             plugin_name = details.get("plugin")
@@ -279,6 +373,15 @@ class Pseudofiles(Plugin):
         """
         model_name = conf.get("model", "default")  # e.g. "zero", "from_plugin"
 
+        # 0. Handle a registered custom model (model: custom, model_name: foo)
+        if model_name == "custom":
+            custom = get_model(domain, conf.get("model_name"))
+            if custom is None:
+                raise ValueError(
+                    f"No custom {domain} model named '{conf.get('model_name')}' "
+                    "registered (use @register_model in a loaded plugin)")
+            return custom
+
         # 1. Handle Standard Models
         if model_name != "from_plugin":
             if domain == "read":
@@ -297,6 +400,39 @@ class Pseudofiles(Plugin):
         func_name = conf.get("function", default_funcs[domain])
 
         return self._detect_plugin_style(plugin_name, func_name, domain)
+
+    def _resolve_extra_ops(self, details):
+        """Resolve mixins + kwargs for the extra VFS-op domains present in config.
+
+        Returns (bases, kwargs). A domain that is absent, or whose model has no
+        mixin (e.g. open/release "noop"), contributes nothing — the base
+        no-op (kernel default) stands, so this is backwards compatible.
+        """
+        bases = []
+        kwargs = {}
+        for domain, (models, adapter) in self.EXTRA_OPS.items():
+            conf = details.get(domain, {})
+            # Accept "seek" as an alias for the "lseek" domain.
+            if domain == "lseek" and not conf:
+                conf = details.get("seek", {})
+            if not conf:
+                continue
+            model_name = conf.get("model", "default")
+            if model_name == "from_plugin":
+                mixin = adapter
+            elif model_name == "custom":
+                mixin = get_model(domain, conf.get("model_name"))
+                if mixin is None:
+                    raise ValueError(
+                        f"No custom {domain} model named '{conf.get('model_name')}' "
+                        "registered (use @register_model in a loaded plugin)")
+            else:
+                mixin = models.get(model_name)
+            if mixin is None:
+                continue
+            bases.append(mixin)
+            kwargs.update(self._translate_kwargs(domain, conf))
+        return bases, kwargs
 
     def _resolve_known_size(self, filename, details, read_conf):
         if "size" in details and details["size"] is not None:
@@ -443,7 +579,7 @@ class Pseudofiles(Plugin):
         # per-domain read/write/ioctl/poll keys and the backing ref itself are
         # owned by the backing class, not passed through.
         for key, val in details.items():
-            if key not in ("read", "write", "ioctl", "poll", "plugin"):
+            if key not in self._DOMAIN_KEYS:
                 all_kwargs[key] = val
 
         return type(safe_name, tuple(bases), {})(**all_kwargs)
@@ -477,9 +613,28 @@ class Pseudofiles(Plugin):
         r_kwargs = self._translate_kwargs("read", read_conf)
         w_kwargs = self._translate_kwargs("write", write_conf)
 
-        # Assemble
+        # Resolve extra VFS ops (lseek/mmap/open/release/flush/fsync/...)
+        extra_bases, extra_kwargs = self._resolve_extra_ops(details)
+
+        # compat_ioctl: 'same_as_ioctl' reuses the ioctl handler map; otherwise
+        # 'from_plugin' routes to a plugin. Handled here (not in EXTRA_OPS)
+        # because same_as_ioctl needs the handlers_map built above.
+        compat_conf = details.get("compat_ioctl") or {}
+        if compat_conf:
+            compat_model = compat_conf.get("model")
+            if compat_model == "same_as_ioctl":
+                extra_bases.append(CompatIoctlDispatcher)
+                extra_kwargs["compat_ioctl_handlers"] = handlers_map
+            elif compat_model == "from_plugin":
+                extra_bases.append(CompatIoctlExternalVFS)
+                extra_kwargs.update(self._translate_kwargs("compat_ioctl", compat_conf))
+
+        # Assemble. Extra-op mixins go FIRST so an explicit lseek/mmap/etc.
+        # model wins over the _LegacyDevSeekCompat fallback (which also defines
+        # lseek) in the compat bases.
         safe_name = f"Gen_{filename.replace('/', '_')}"
-        bases = list(self._get_compat_bases(filename, details))
+        bases = list(extra_bases)
+        bases.extend(self._get_compat_bases(filename, details))
         if P_Mixin is not None:
             bases.append(P_Mixin)
         bases.extend([R_Mixin, W_Mixin, IoctlDispatcher])
@@ -488,10 +643,12 @@ class Pseudofiles(Plugin):
             bases.append(SysfsBridge)
         bases.append(BaseClass)
 
-        all_kwargs = {**r_kwargs, **w_kwargs, **p_kwargs}
+        all_kwargs = {**r_kwargs, **w_kwargs, **p_kwargs, **extra_kwargs}
         all_kwargs['ioctl_handlers'] = handlers_map
         all_kwargs['path'] = filename
         all_kwargs['fs'] = getattr(BaseClass, 'FS', None)
+        if self._tracking:
+            all_kwargs['default_hit_cb'] = self._record_default_hit
 
         # --- Compatibility bridge for SysctlFile ---
         # If the old config uses a const_buf read mixin to set a static sysctl value,
@@ -501,7 +658,7 @@ class Pseudofiles(Plugin):
 
         # Capture top-level file properties (size, mode, etc.)
         for key, val in details.items():
-            if key not in ("read", "write", "ioctl", "poll", "plugin"):
+            if key not in self._DOMAIN_KEYS:
                 all_kwargs[key] = val
         # -----------------------------------------------------------------
 

--- a/pyplugins/init/pseudofile_patches.py
+++ b/pyplugins/init/pseudofile_patches.py
@@ -73,16 +73,18 @@ class PseudofilesTailored(InitPlugin):
                 results[file_name] = {
                     'read': {
                         "model": "zero",
+                        "provenance": "default",
                     },
                     'write': {
                         "model": "discard",
+                        "provenance": "default",
                     }
                 }
 
                 if section == "dev":
                     # /dev files get a default IOCTL model
                     results[file_name]['ioctl'] = {
-                        '*': {"model": "return_const", "val": 0}
+                        '*': {"model": "return_const", "val": 0, "provenance": "default"}
                     }
 
                     if file_name.startswith("/dev/mtd"):

--- a/pyplugins/testing/pseudofile_ext_test.py
+++ b/pyplugins/testing/pseudofile_ext_test.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Runtime coverage for the expanded pseudofile surface.
 
-Exercises three things the schema/unit tests can't reach in a live guest:
+Exercises two things the schema/unit tests can't reach in a live guest:
 
-  * the broadened VFS-operation domains (``open``/``release``/``lseek`` via
-    ``from_plugin``) — proving the kernel's calls actually reach a plugin
-    handler and that side effects/return values flow back;
+  * a ``lseek`` handler dispatched via ``from_plugin`` (the broadened VFS-op
+    surface) — proving the kernel's lseek reaches a plugin and its return value
+    flows back;
   * a ``@register_model`` custom read model selected from YAML by
-    ``model: custom`` (the low-friction "expand models in Python" path);
+    ``model: custom`` (the low-friction "expand models in Python" path).
 
 The provenance/observability half (a ``provenance: default`` node reporting
 ``default_read``/``default_write``/``default_ioctl`` into
@@ -15,7 +15,7 @@ The provenance/observability half (a ``provenance: default`` node reporting
 models, so it needs no handler here — only the fixture nodes and verifier
 conditions in ``pseudofile_ext_ops.yaml``.
 """
-from penguin import plugins, Plugin
+from penguin import Plugin
 from hyperfile.models.registry import register_model
 from hyperfile.models.read import ReadBufWrapper
 
@@ -31,24 +31,7 @@ class ExtSensorRead(ReadBufWrapper):
 
 class PseudofileExtTest(Plugin):
     def __init__(self):
-        # Lifecycle counters, observable through the ``lifecycle`` read handler.
-        self._open_count = 0
-        self._release_count = 0
-
-    # open()/release() VFS handlers: func(ptregs, inode, file). The bodies run
-    # when the external adapter iterates the returned generator, so the
-    # `if False: yield` keeps them generators with no actual yield point.
-    def on_open(self, ptregs, inode, file):
-        self._open_count += 1
-        self.logger.info(f"ext open #{self._open_count}")
-        if False:
-            yield
-
-    def on_release(self, ptregs, inode, file):
-        self._release_count += 1
-        self.logger.info(f"ext release #{self._release_count}")
-        if False:
-            yield
+        pass
 
     # lseek() handler: func(ptregs, file, offset, whence). Returns a distinctive
     # sentinel offset so the guest can prove the call reached the plugin.
@@ -56,17 +39,3 @@ class PseudofileExtTest(Plugin):
         ptregs.retval = 4242
         if False:
             yield
-
-    # A read handler that reports the lifecycle counters, so the guest can
-    # observe that open()/release() fired the expected number of times.
-    def lifecycle(self, ptregs, file, user_buf, size, loff):
-        data = f"open={self._open_count} release={self._release_count}\n".encode()
-        size_val = int(size)
-        offset = yield from plugins.kffi.deref(loff)
-        if size_val <= 0 or offset >= len(data):
-            ptregs.retval = 0
-            return
-        chunk = min(size_val, len(data) - offset)
-        yield from plugins.mem.write(user_buf, data[offset:offset + chunk])
-        yield from plugins.mem.write(loff, offset + chunk)
-        ptregs.retval = chunk

--- a/pyplugins/testing/pseudofile_ext_test.py
+++ b/pyplugins/testing/pseudofile_ext_test.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Runtime coverage for the expanded pseudofile surface.
+
+Exercises three things the schema/unit tests can't reach in a live guest:
+
+  * the broadened VFS-operation domains (``open``/``release``/``lseek`` via
+    ``from_plugin``) — proving the kernel's calls actually reach a plugin
+    handler and that side effects/return values flow back;
+  * a ``@register_model`` custom read model selected from YAML by
+    ``model: custom`` (the low-friction "expand models in Python" path);
+
+The provenance/observability half (a ``provenance: default`` node reporting
+``default_read``/``default_write``/``default_ioctl`` into
+``pseudofiles_failures.yaml``) is driven entirely from config + the built-in
+models, so it needs no handler here — only the fixture nodes and verifier
+conditions in ``pseudofile_ext_ops.yaml``.
+"""
+from penguin import plugins, Plugin
+from hyperfile.models.registry import register_model
+from hyperfile.models.read import ReadBufWrapper
+
+
+# A custom read model, registered by name at import time. Selecting
+# ``read: {model: custom, model_name: ext_sensor, scale: N}`` in YAML must
+# construct this class with the extra kwargs forwarded (here, ``scale``).
+@register_model("read", "ext_sensor")
+class ExtSensorRead(ReadBufWrapper):
+    def __init__(self, *, scale=1, **kwargs):
+        super().__init__(buffer=str(6 * scale).encode(), **kwargs)
+
+
+class PseudofileExtTest(Plugin):
+    def __init__(self):
+        # Lifecycle counters, observable through the ``lifecycle`` read handler.
+        self._open_count = 0
+        self._release_count = 0
+
+    # open()/release() VFS handlers: func(ptregs, inode, file). The bodies run
+    # when the external adapter iterates the returned generator, so the
+    # `if False: yield` keeps them generators with no actual yield point.
+    def on_open(self, ptregs, inode, file):
+        self._open_count += 1
+        self.logger.info(f"ext open #{self._open_count}")
+        if False:
+            yield
+
+    def on_release(self, ptregs, inode, file):
+        self._release_count += 1
+        self.logger.info(f"ext release #{self._release_count}")
+        if False:
+            yield
+
+    # lseek() handler: func(ptregs, file, offset, whence). Returns a distinctive
+    # sentinel offset so the guest can prove the call reached the plugin.
+    def seek_sentinel(self, ptregs, file, offset, whence):
+        ptregs.retval = 4242
+        if False:
+            yield
+
+    # A read handler that reports the lifecycle counters, so the guest can
+    # observe that open()/release() fired the expected number of times.
+    def lifecycle(self, ptregs, file, user_buf, size, loff):
+        data = f"open={self._open_count} release={self._release_count}\n".encode()
+        size_val = int(size)
+        offset = yield from plugins.kffi.deref(loff)
+        if size_val <= 0 or offset >= len(data):
+            ptregs.retval = 0
+            return
+        chunk = min(size_val, len(data) - offset)
+        yield from plugins.mem.write(user_buf, data[offset:offset + chunk])
+        yield from plugins.mem.write(loff, offset + chunk)
+        ptregs.retval = chunk

--- a/pyplugins/testing/pseudofile_ext_test.py
+++ b/pyplugins/testing/pseudofile_ext_test.py
@@ -1,20 +1,26 @@
 #!/usr/bin/env python3
 """Runtime coverage for the expanded pseudofile surface.
 
-Exercises two things the schema/unit tests can't reach in a live guest:
+Exercises the parts of the expansion the schema/unit tests can't reach in a
+live guest:
 
-  * a ``lseek`` handler dispatched via ``from_plugin`` (the broadened VFS-op
-    surface) — proving the kernel's lseek reaches a plugin and its return value
-    flows back;
+  * the broadened VFS-op surface dispatched via ``from_plugin`` — ``lseek``
+    (returns a sentinel offset) and ``open``/``release`` (lifecycle hooks that
+    record into a host file so the verifier can confirm they fired);
   * a ``@register_model`` custom read model selected from YAML by
     ``model: custom`` (the low-friction "expand models in Python" path).
 
+open/release are observed via a host file (``self.outdir``) rather than by
+reading the node back, so the node under test keeps an ordinary ``const_buf``
+read and we don't conflate the lifecycle hooks with the read path.
+
 The provenance/observability half (a ``provenance: default`` node reporting
 ``default_read``/``default_write``/``default_ioctl`` into
-``pseudofiles_failures.yaml``) is driven entirely from config + the built-in
-models, so it needs no handler here — only the fixture nodes and verifier
-conditions in ``pseudofile_ext_ops.yaml``.
+``pseudofiles_failures.yaml``) is config + built-in models only — no handler
+here, just fixture nodes + verifier conditions in ``pseudofile_ext_ops.yaml``.
 """
+import os
+
 from penguin import Plugin
 from hyperfile.models.registry import register_model
 from hyperfile.models.read import ReadBufWrapper
@@ -29,9 +35,32 @@ class ExtSensorRead(ReadBufWrapper):
         super().__init__(buffer=str(6 * scale).encode(), **kwargs)
 
 
+EVENTS_FILE = "ext_lifecycle_events.txt"
+
+
 class PseudofileExtTest(Plugin):
     def __init__(self):
-        pass
+        self.outdir = self.get_arg("outdir")
+
+    def _record(self, event):
+        # Append to a host file the verifier can inspect, proving the fop fired.
+        with open(os.path.join(self.outdir, EVENTS_FILE), "a") as f:
+            f.write(event + "\n")
+
+    # open()/release() VFS handlers: func(ptregs, inode, file). The bodies run
+    # when the external adapter iterates the returned generator; `if False:
+    # yield` keeps them generators with no actual yield point.
+    def on_open(self, ptregs, inode, file):
+        self._record("open")
+        self.logger.info("ext open")
+        if False:
+            yield
+
+    def on_release(self, ptregs, inode, file):
+        self._record("release")
+        self.logger.info("ext release")
+        if False:
+            yield
 
     # lseek() handler: func(ptregs, file, offset, whence). Returns a distinctive
     # sentinel offset so the guest can prove the call reached the plugin.

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -1089,6 +1089,7 @@ class Pseudofiles(RootModel):
                     )
         return self
 
+
 Patches = _newtype(
     class_name="Patches",
     type_=list[str],

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -1,5 +1,5 @@
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union, ClassVar
-from pydantic import BaseModel, Field, RootModel, field_validator
+from pydantic import BaseModel, Field, RootModel, field_validator, model_validator
 from pydantic.config import ConfigDict
 from pydantic_partial import PartialModelMixin, create_partial_model
 
@@ -48,17 +48,29 @@ def _newtype(class_name, type_, title, description=None, default=None, examples=
     )
 
 
-def _variant(discrim_val, title, description, discrim_key, discrim_title, fields):
+def _variant(discrim_val, title, description, discrim_key, discrim_title, fields, extra="forbid"):
     return type(
         discrim_val,
         (PartialModelMixin, BaseModel),
         dict(
-            model_config=ConfigDict(title=title, extra="forbid"),
+            model_config=ConfigDict(title=title, extra=extra),
             __doc__=description,
             __annotations__={
                 discrim_key: Annotated[
                     Literal[discrim_val],
                     Field(title=f"{discrim_title} ({title.lower()})"),
+                ],
+                "provenance": Annotated[
+                    Optional[str],
+                    Field(
+                        None,
+                        title="Model provenance",
+                        description=(
+                            "Origin tag. Set 'default' for a synthesized stub (it "
+                            "reports its hits into pseudofiles_failures.yaml); leave "
+                            "unset for author-intentional models."
+                        ),
+                    ),
                 ],
             }
             | {key: Annotated[type, field] for key, type, field in fields},
@@ -66,7 +78,24 @@ def _variant(discrim_val, title, description, discrim_key, discrim_title, fields
     )
 
 
-def _union(class_name, title, description, discrim_key, discrim_title, variants):
+# Shared escape variant: select a model registered at runtime via
+# @register_model (hyperfile.models.registry). Allows extra keys so the
+# custom model's own constructor args validate.
+_CUSTOM_VARIANT = dict(
+    discrim_val="custom",
+    title="Custom registered model",
+    description=(
+        "Use a model registered via @register_model in a loaded plugin. "
+        "'model_name' selects it; any extra keys are forwarded to the model."
+    ),
+    fields=(("model_name", str, Field(title="Registered model name")),),
+    extra="allow",
+)
+
+
+def _union(class_name, title, description, discrim_key, discrim_title, variants, allow_custom=False):
+    if allow_custom:
+        variants = tuple(variants) + (_CUSTOM_VARIANT,)
     variants = tuple(
         _variant(discrim_key=discrim_key, discrim_title=discrim_title, **v)
         for v in variants
@@ -500,6 +529,7 @@ _const_map_fields = (
 
 Read = _union(
     class_name="Read",
+    allow_custom=True,
     title="Read",
     description="How to handle reads from the file",
     discrim_key="model",
@@ -565,10 +595,43 @@ Read = _union(
             + _const_map_fields,
         ),
         dict(
+            discrim_val="cycle",
+            title="Read a repeating buffer",
+            description="Repeat the configured buffer forever (never reports EOF).",
+            fields=(
+                ("val", str, Field(title="Buffer to repeat")),
+            ),
+        ),
+        dict(
             discrim_val="from_file",
             title="Read from a host file",
             description=None,
             fields=(("filename", str, Field(title="Path to host file")),),
+        ),
+        dict(
+            discrim_val="stateful",
+            title="Read back what was written",
+            description=(
+                "Serve bytes from this node's write buffer, giving a "
+                "read-after-write register. Pair with write model 'default' "
+                "(or 'discard'/'record', which all record) so writes are stored."
+            ),
+            fields=(
+                ("initial", Optional[str], Field(None, title="Initial buffer contents")),
+            ),
+        ),
+        dict(
+            discrim_val="sequence",
+            title="Read successive values",
+            description=(
+                "Return each entry of 'vals' on successive reads; the common "
+                "'busy... busy... ready' status pattern. Holds the last entry "
+                "when exhausted unless 'cycle' wraps around."
+            ),
+            fields=(
+                ("vals", list, Field(title="Ordered values to return")),
+                ("cycle", bool, Field(False, title="Wrap around when exhausted")),
+            ),
         ),
         dict(
             discrim_val="from_plugin",
@@ -591,6 +654,7 @@ Read = _union(
 
 Write = _union(
     class_name="Write",
+    allow_custom=True,
     title="Write",
     description="How to handle writes to the file",
     discrim_key="model",
@@ -615,6 +679,18 @@ Write = _union(
             discrim_val="discard",
             title="Discard write",
             description=None,
+            fields=(),
+        ),
+        dict(
+            discrim_val="return_const",
+            title="Return a constant on write",
+            description="Return a fixed value (e.g. a byte count or a negative errno) without storing data.",
+            fields=(("const", int, Field(title="Value to return from write()")),),
+        ),
+        dict(
+            discrim_val="unhandled",
+            title="Reject writes",
+            description="Return -EINVAL for every write.",
             fields=(),
         ),
         dict(
@@ -647,6 +723,24 @@ IoctlCommand = _union(
             fields=(),
         ),
         dict(
+            discrim_val="unhandled",
+            title="Reject ioctl",
+            description="Return -ENOTTY (inappropriate ioctl for device).",
+            fields=(),
+        ),
+        dict(
+            discrim_val="write_data",
+            title="Write a buffer to the arg pointer",
+            description=(
+                "Write a constant buffer to the user pointer in 'arg' (the common "
+                "shape of an ioctl that fills a struct), then return 'val'."
+            ),
+            fields=(
+                ("data", str, Field(title="Bytes to write to *arg")),
+                ("val", int, Field(0, title="Value to return from ioctl()")),
+            ),
+        ),
+        dict(
             discrim_val="from_plugin",
             title="ioctl from a custom PyPlugin",
             description=None,
@@ -661,6 +755,7 @@ IoctlCommand = _union(
 
 Poll = _union(
     class_name="Poll",
+    allow_custom=True,
     title="Poll",
     description="How to answer poll()/select() on the file",
     discrim_key="model",
@@ -679,6 +774,163 @@ Poll = _union(
             fields=(
                 ("plugin", str, Field(title="Name of the loaded PyPlugin")),
                 ("function", Optional[str], Field(title="Function to call", default="poll")),
+            ),
+        ),
+    ),
+)
+
+
+Seek = _union(
+    class_name="Seek",
+    allow_custom=True,
+    title="Seek",
+    description="How to handle lseek() on the file",
+    discrim_key="model",
+    discrim_title="Seek modelling method",
+    variants=(
+        dict(
+            discrim_val="default",
+            title="Standard offset arithmetic",
+            description="SEEK_SET/CUR/END against the node's reported size.",
+            fields=(),
+        ),
+        dict(
+            discrim_val="unsupported",
+            title="Reject seeks",
+            description="Return -ESPIPE (for pipe/stream-like nodes).",
+            fields=(),
+        ),
+        dict(
+            discrim_val="from_plugin",
+            title="lseek from a custom PyPlugin",
+            description=None,
+            fields=(
+                ("plugin", str, Field(title="Name of the loaded PyPlugin")),
+                ("function", Optional[str], Field(title="Function to call", default="lseek")),
+            ),
+        ),
+    ),
+)
+
+
+Mmap = _union(
+    class_name="Mmap",
+    allow_custom=True,
+    title="Mmap",
+    description="How to handle mmap() on the file",
+    discrim_key="model",
+    discrim_title="Mmap modelling method",
+    variants=(
+        dict(
+            discrim_val="from_plugin",
+            title="mmap from a custom PyPlugin",
+            description=None,
+            fields=(
+                ("plugin", str, Field(title="Name of the loaded PyPlugin")),
+                ("function", Optional[str], Field(title="Function to call", default="mmap")),
+            ),
+        ),
+    ),
+)
+
+
+Open = _union(
+    class_name="Open",
+    allow_custom=True,
+    title="Open",
+    description="How to handle open() on the file",
+    discrim_key="model",
+    discrim_title="Open modelling method",
+    variants=(
+        dict(
+            discrim_val="from_plugin",
+            title="open from a custom PyPlugin",
+            description="Fire a plugin function when the guest opens this node.",
+            fields=(
+                ("plugin", str, Field(title="Name of the loaded PyPlugin")),
+                ("function", Optional[str], Field(title="Function to call", default="open")),
+            ),
+        ),
+    ),
+)
+
+
+Release = _union(
+    class_name="Release",
+    allow_custom=True,
+    title="Release",
+    description="How to handle release()/close() on the file",
+    discrim_key="model",
+    discrim_title="Release modelling method",
+    variants=(
+        dict(
+            discrim_val="from_plugin",
+            title="release from a custom PyPlugin",
+            description="Fire a plugin function when the guest closes this node.",
+            fields=(
+                ("plugin", str, Field(title="Name of the loaded PyPlugin")),
+                ("function", Optional[str], Field(title="Function to call", default="release")),
+            ),
+        ),
+    ),
+)
+
+
+def _plugin_op_union(class_name, title, op):
+    """A 'from_plugin'-only op union (with the shared custom escape variant)."""
+    return _union(
+        class_name=class_name,
+        title=title,
+        description=f"How to handle {op}() on the file",
+        discrim_key="model",
+        discrim_title=f"{title} modelling method",
+        allow_custom=True,
+        variants=(
+            dict(
+                discrim_val="from_plugin",
+                title=f"{op} from a custom PyPlugin",
+                description=None,
+                fields=(
+                    ("plugin", str, Field(title="Name of the loaded PyPlugin")),
+                    ("function", Optional[str], Field(title="Function to call", default=op)),
+                ),
+            ),
+        ),
+    )
+
+
+# Device-specific / advanced fops. flush/fsync/fasync/lock are /dev-only
+# (procfs does not wire them); read_iter/write_iter/get_unmapped_area are
+# advanced. All are plugin-driven.
+Flush = _plugin_op_union("Flush", "Flush", "flush")
+Fsync = _plugin_op_union("Fsync", "Fsync", "fsync")
+Fasync = _plugin_op_union("Fasync", "Fasync", "fasync")
+Lock = _plugin_op_union("Lock", "Lock", "lock")
+ReadIter = _plugin_op_union("ReadIter", "Read iterator", "read_iter")
+WriteIter = _plugin_op_union("WriteIter", "Write iterator", "write_iter")
+GetUnmappedArea = _plugin_op_union("GetUnmappedArea", "Get unmapped area", "get_unmapped_area")
+
+
+CompatIoctl = _union(
+    class_name="CompatIoctl",
+    title="Compat ioctl",
+    description="How to handle 32-bit compat_ioctl() on the file",
+    discrim_key="model",
+    discrim_title="compat_ioctl modelling method",
+    variants=(
+        dict(
+            discrim_val="same_as_ioctl",
+            title="Reuse the ioctl model",
+            description="Route compat_ioctl through the same handlers as ioctl (the common driver pattern).",
+            fields=(),
+        ),
+        dict(
+            discrim_val="from_plugin",
+            title="compat_ioctl from a custom PyPlugin",
+            description=None,
+            fields=(
+                ("plugin", str, Field(title="Name of the loaded PyPlugin")),
+                ("function", Optional[str], Field(title="Function to call", default="compat_ioctl")),
             ),
         ),
     ),
@@ -760,14 +1012,82 @@ class Pseudofile(PartialModelMixin, BaseModel):
     write: Optional[Write] = None
     ioctl: Optional[Ioctls] = None
     poll: Optional[Poll] = None
+    lseek: Optional[Seek] = None
+    mmap: Optional[Mmap] = None
+    open: Optional[Open] = None
+    release: Optional[Release] = None
+    compat_ioctl: Optional[CompatIoctl] = None
+    flush: Optional[Flush] = None
+    fsync: Optional[Fsync] = None
+    fasync: Optional[Fasync] = None
+    lock: Optional[Lock] = None
+    read_iter: Optional[ReadIter] = None
+    write_iter: Optional[WriteIter] = None
+    get_unmapped_area: Optional[GetUnmappedArea] = None
 
 
-Pseudofiles = _newtype(
-    class_name="Pseudofiles",
-    type_=dict[str, Pseudofile],
-    title="Pseudo-files",
-    description="Device files to emulate in the guest",
-)
+# Which path classes wire each operation, so we can reject a model attached to
+# a node whose filesystem can't service it. Keyed by Pseudofile field name.
+#   - char-device fops (flush/fsync/fasync/lock/write_iter) only wire for /dev
+#   - the broader VFS fops also wire for /proc (procfs), but NOT /proc/sys
+#     (sysctl) or /sys (sysfs), which only service reads/writes.
+_OP_SUPPORTED_PATHS = {
+    "flush": ("dev",),
+    "fsync": ("dev",),
+    "fasync": ("dev",),
+    "lock": ("dev",),
+    "write_iter": ("dev",),
+    "lseek": ("dev", "proc"),
+    "mmap": ("dev", "proc"),
+    "open": ("dev", "proc"),
+    "release": ("dev", "proc"),
+    "compat_ioctl": ("dev", "proc"),
+    "read_iter": ("dev", "proc"),
+    "get_unmapped_area": ("dev", "proc"),
+}
+
+_PATH_CLASS_LABEL = {
+    "dev": "/dev",
+    "proc": "/proc",
+    "procsys": "/proc/sys",
+    "sys": "/sys",
+}
+
+
+def _classify_pseudofile_path(path: str) -> str:
+    if path.startswith("/dev/"):
+        return "dev"
+    if path.startswith("/proc/sys/"):
+        return "procsys"
+    if path.startswith("/proc/"):
+        return "proc"
+    if path.startswith("/sys/"):
+        return "sys"
+    return "other"
+
+
+class Pseudofiles(RootModel):
+    """Device files to emulate in the guest"""
+
+    model_config = ConfigDict(title="Pseudo-files")
+
+    root: dict[str, Pseudofile] = {}
+
+    @model_validator(mode="after")
+    def _validate_op_paths(self):
+        for path, node in (self.root or {}).items():
+            cls = _classify_pseudofile_path(path)
+            for op, allowed in _OP_SUPPORTED_PATHS.items():
+                if getattr(node, op, None) is None:
+                    continue
+                if cls not in allowed:
+                    allowed_labels = " or ".join(_PATH_CLASS_LABEL[a] for a in allowed)
+                    raise ValueError(
+                        f"pseudofile '{path}': the '{op}' model is only supported "
+                        f"on {allowed_labels} nodes (this filesystem does not wire "
+                        f"{op}()). Remove it or move the node."
+                    )
+        return self
 
 Patches = _newtype(
     class_name="Patches",

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -974,5 +974,165 @@ def test_templating_arch_alias_canonical_and_derived():
     assert out2["x"] == "aarch64 arm64"
 
 
+# --------------------------------------------------------------------------- #
+# Pseudofile model expansion (backwards-compatible additive work)
+#
+# Covers the new declarative model vocabulary, the broadened VFS-operation
+# surface, the `custom` (register_model) escape variant, the per-variant
+# `provenance` tag, and the per-path validation that rejects an op attached to
+# a filesystem that can't service it. All of this validates at the schema layer
+# (no emulator), so it runs in this host/CI unit suite.
+# --------------------------------------------------------------------------- #
+def _pf(pseudofiles):
+    """Validate a pseudofiles block through the full Main schema."""
+    return structure.Main(**base_config(pseudofiles=pseudofiles)).model_dump()
+
+
+def _pf_error(pseudofiles):
+    try:
+        structure.Main(**base_config(pseudofiles=pseudofiles))
+    except ValidationError as e:
+        return e
+    raise AssertionError("expected ValidationError")
+
+
+# --- new read models -------------------------------------------------------- #
+def test_read_cycle_validates():
+    m = _pf({"/dev/a": {"read": {"model": "cycle", "val": "AB"}}})
+    assert m["pseudofiles"]["/dev/a"]["read"]["val"] == "AB"
+
+
+def test_read_stateful_validates_with_optional_initial():
+    # stateful read paired with a recording write = a YAML read/write register
+    m = _pf({"/dev/reg": {"read": {"model": "stateful", "initial": "0"},
+                          "write": {"model": "default"}}})
+    assert m["pseudofiles"]["/dev/reg"]["read"]["initial"] == "0"
+    # initial is optional
+    _pf({"/dev/reg": {"read": {"model": "stateful"}}})
+
+
+def test_read_sequence_validates():
+    m = _pf({"/proc/status": {"read": {"model": "sequence",
+                                       "vals": ["busy\n", "busy\n", "ready\n"],
+                                       "cycle": True}}})
+    r = m["pseudofiles"]["/proc/status"]["read"]
+    assert r["vals"][-1] == "ready\n" and r["cycle"] is True
+
+
+# --- new write models ------------------------------------------------------- #
+def test_write_return_const_validates():
+    m = _pf({"/dev/a": {"write": {"model": "return_const", "const": -1}}})
+    assert m["pseudofiles"]["/dev/a"]["write"]["const"] == -1
+
+
+def test_write_unhandled_validates():
+    _pf({"/dev/a": {"write": {"model": "unhandled"}}})
+
+
+# --- new ioctl models ------------------------------------------------------- #
+def test_ioctl_write_data_validates_in_command_map():
+    m = _pf({"/dev/a": {"ioctl": {4660: {"model": "write_data",
+                                         "data": "\x01\x00\x00\x00", "val": 0}}}})
+    h = m["pseudofiles"]["/dev/a"]["ioctl"][4660]
+    assert h["data"] == "\x01\x00\x00\x00" and h["val"] == 0
+
+
+def test_ioctl_unhandled_validates_wildcard():
+    _pf({"/dev/a": {"ioctl": {"*": {"model": "unhandled"}}}})
+
+
+# --- broadened VFS operation surface ---------------------------------------- #
+def test_lseek_default_and_unsupported_validate():
+    _pf({"/dev/a": {"lseek": {"model": "default"}}})
+    _pf({"/dev/a": {"lseek": {"model": "unsupported"}}})
+
+
+def test_lseek_from_plugin_validates():
+    _pf({"/dev/a": {"lseek": {"model": "from_plugin", "plugin": "p", "function": "seek"}}})
+
+
+def test_compat_ioctl_same_as_ioctl_validates():
+    _pf({"/dev/a": {"ioctl": {"*": {"model": "return_const", "val": 0}},
+                    "compat_ioctl": {"model": "same_as_ioctl"}}})
+
+
+@pytest.mark.parametrize("op", ["mmap", "open", "release", "flush", "fsync",
+                                "fasync", "lock", "read_iter", "write_iter",
+                                "get_unmapped_area"])
+def test_plugin_op_domains_validate_on_dev(op):
+    # every plugin-driven op domain accepts a from_plugin model on a /dev node
+    _pf({"/dev/a": {op: {"model": "from_plugin", "plugin": "p"}}})
+
+
+# --- custom (register_model) escape variant -------------------------------- #
+def test_custom_read_model_accepts_model_name_and_extra_kwargs():
+    # `model: custom` carries a model_name + free kwargs forwarded to the mixin
+    m = _pf({"/dev/sensor": {"read": {"model": "custom", "model_name": "my_sensor",
+                                      "scale": 10}}})
+    r = m["pseudofiles"]["/dev/sensor"]["read"]
+    assert r["model_name"] == "my_sensor" and r["scale"] == 10
+
+
+# --- provenance ------------------------------------------------------------- #
+def test_provenance_tag_accepted_on_any_variant():
+    m = _pf({"/dev/d": {"read": {"model": "zero", "provenance": "default"},
+                        "write": {"model": "discard", "provenance": "default"}}})
+    assert m["pseudofiles"]["/dev/d"]["read"]["provenance"] == "default"
+
+
+# --- strict validation preserved (extra="forbid") --------------------------- #
+def test_unknown_field_in_variant_still_rejected():
+    msg = format_validation_error(_pf_error({"/dev/a": {"read": {"model": "zero", "bogus": 1}}}))
+    assert "bogus" in msg
+
+
+# --- per-path validation (the most recent ask) ------------------------------ #
+@pytest.mark.parametrize("path,op,model", [
+    ("/proc/x", "flush", {"model": "from_plugin", "plugin": "p"}),
+    ("/sys/x", "lseek", {"model": "default"}),
+    ("/proc/sys/x", "mmap", {"model": "from_plugin", "plugin": "p"}),
+    ("/proc/x", "write_iter", {"model": "from_plugin", "plugin": "p"}),
+    ("/sys/x", "fsync", {"model": "from_plugin", "plugin": "p"}),
+])
+def test_op_rejected_on_unsupported_filesystem(path, op, model):
+    msg = format_validation_error(_pf_error({path: {op: model}}))
+    assert op in msg and path in msg
+
+
+@pytest.mark.parametrize("path,op,model", [
+    ("/dev/a", "flush", {"model": "from_plugin", "plugin": "p"}),  # /dev-only op on /dev
+    ("/dev/a", "write_iter", {"model": "from_plugin", "plugin": "p"}),
+    ("/dev/a", "lseek", {"model": "default"}),
+    ("/proc/a", "lseek", {"model": "default"}),                    # broader op on /proc
+    ("/proc/a", "mmap", {"model": "from_plugin", "plugin": "p"}),
+])
+def test_op_allowed_on_supported_filesystem(path, op, model):
+    _pf({path: {op: model}})
+
+
+def test_read_write_ioctl_poll_unconstrained_by_path():
+    # the legacy domains are wired everywhere — never path-restricted
+    for path in ("/dev/a", "/proc/a", "/proc/sys/a", "/sys/a"):
+        _pf({path: {"read": {"model": "zero"},
+                    "write": {"model": "discard"},
+                    "ioctl": {"*": {"model": "return_const", "val": 0}}}})
+
+
+# --- backwards compatibility ------------------------------------------------ #
+def test_legacy_pseudofile_config_unchanged():
+    # a pre-expansion config validates and round-trips with no new keys leaking in
+    legacy = {"/dev/leg": {"read": {"model": "const_buf", "val": "x"},
+                           "write": {"model": "discard"},
+                           "ioctl": {"*": {"model": "return_const", "val": 0}}}}
+    m = _pf(legacy)
+    node = m["pseudofiles"]["/dev/leg"]
+    assert node["read"]["val"] == "x"
+    # the new optional op domains all default to None (absent) — purely additive
+    for op in ("lseek", "mmap", "open", "release", "compat_ioctl", "flush",
+               "fsync", "fasync", "lock", "read_iter", "write_iter",
+               "get_unmapped_area"):
+        assert node[op] is None
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit_tests/test_pseudofile_models.py
+++ b/tests/unit_tests/test_pseudofile_models.py
@@ -1,0 +1,142 @@
+"""
+Unit tests for the pyplugin side of the pseudofile model expansion.
+
+These cover behavior that the schema tests (test_config.py) can't reach:
+
+  * the @register_model registry — the low-friction "expand models in Python"
+    path that backs `model: custom` in YAML;
+  * the init-time provenance tagging in PseudofilesTailored, which marks every
+    synthesized stub `provenance: default` so it self-reports at runtime.
+
+Both run on the host: registry.py is dependency-free, and pseudofile_patches.py
+imports only `penguin.*` (resolved via the conftest version.txt shim). The
+*runtime* halves — custom models served in a live guest, and default hits
+landing in pseudofiles_failures.yaml — are emulator-only and live in the
+test_target fixture, not here.
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+PYPLUGINS = os.path.join(REPO_ROOT, "pyplugins")
+if PYPLUGINS not in sys.path:
+    sys.path.insert(0, PYPLUGINS)
+
+
+def _load(mod_name, rel_path):
+    spec = importlib.util.spec_from_file_location(
+        mod_name, os.path.join(REPO_ROOT, rel_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# @register_model registry (Workstream 3: easy Python extension)
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def registry():
+    # Fresh module per test so registrations don't leak between cases.
+    sys.modules.pop("hyperfile.models.registry", None)
+    return _load("hyperfile.models.registry", "pyplugins/hyperfile/models/registry.py")
+
+
+def test_register_and_get_model_roundtrip(registry):
+    @registry.register_model("read", "my_sensor")
+    class MySensorRead:
+        pass
+
+    assert registry.get_model("read", "my_sensor") is MySensorRead
+
+
+def test_register_model_decorator_returns_class_unchanged(registry):
+    # must behave as a transparent decorator (class still usable directly)
+    class Base:
+        pass
+
+    decorated = registry.register_model("write", "w1")(Base)
+    assert decorated is Base
+
+
+def test_get_model_unknown_name_returns_none(registry):
+    assert registry.get_model("read", "does_not_exist") is None
+
+
+def test_get_model_unknown_domain_returns_none(registry):
+    # lookups on an unknown domain are a quiet None, not a raise
+    assert registry.get_model("nope", "x") is None
+
+
+def test_register_model_unknown_domain_raises(registry):
+    with pytest.raises(ValueError):
+        registry.register_model("bogus_domain", "x")
+
+
+def test_registry_covers_all_mixin_domains(registry):
+    # every domain the docs promise must accept a registration
+    for domain in ("read", "write", "poll", "lseek", "mmap", "open", "release", "ioctl"):
+        @registry.register_model(domain, f"probe_{domain}")
+        class _Probe:
+            pass
+
+        assert registry.get_model(domain, f"probe_{domain}") is _Probe
+
+
+# --------------------------------------------------------------------------- #
+# Provenance tagging at init (Workstream 5: observability)
+# --------------------------------------------------------------------------- #
+class _FakeFinder:
+    def __init__(self, pseudofiles):
+        self.pseudofiles = pseudofiles
+
+
+class _FakePlugins:
+    def __init__(self, pseudofiles):
+        self.PseudofileFinder = _FakeFinder(pseudofiles)
+
+
+def _run_tailored_patch(pseudofiles):
+    pfp = _load("init.pseudofile_patches", "pyplugins/init/pseudofile_patches.py")
+    inst = pfp.PseudofilesTailored.__new__(pfp.PseudofilesTailored)
+    inst.plugins = _FakePlugins(pseudofiles)
+    return inst.patch(None)  # ctx is unused by patch()
+
+
+def test_tailored_patch_tags_dev_node_default_on_all_domains():
+    out = _run_tailored_patch({"dev": ["/dev/discovered"]})
+    node = out["pseudofiles"]["/dev/discovered"]
+    assert node["read"] == {"model": "zero", "provenance": "default"}
+    assert node["write"] == {"model": "discard", "provenance": "default"}
+    # /dev nodes also get a default ioctl, tagged on the wildcard handler
+    assert node["ioctl"]["*"]["provenance"] == "default"
+    assert node["ioctl"]["*"]["model"] == "return_const"
+
+
+def test_tailored_patch_proc_node_has_no_ioctl():
+    out = _run_tailored_patch({"proc": ["/proc/discovered"]})
+    node = out["pseudofiles"]["/proc/discovered"]
+    assert node["read"]["provenance"] == "default"
+    assert node["write"]["provenance"] == "default"
+    assert "ioctl" not in node  # ioctl default is /dev-only
+
+
+def test_tailored_patch_skips_critical_dev_nodes():
+    pfp = _load("init.pseudofile_patches", "pyplugins/init/pseudofile_patches.py")
+    critical = pfp.CRITICAL_DEV_NODES[0]
+    out = _run_tailored_patch({"dev": [critical, "/dev/ok"]})
+    pf = out["pseudofiles"]
+    assert critical not in pf          # refused
+    assert "/dev/ok" in pf             # normal node still modeled
+
+
+def test_tailored_patch_empty_returns_none():
+    # nothing discovered -> no patch emitted (don't write an empty section)
+    assert _run_tailored_patch({}) is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit_tests/test_target/base_config.yaml
+++ b/tests/unit_tests/test_target/base_config.yaml
@@ -69,6 +69,7 @@ patches:
   - ./patches/tests/mtd_test.yaml
   - ./patches/tests/anonfs.yaml
   - ./patches/tests/pseudofiles_comprehensive.yaml
+  - ./patches/tests/pseudofile_ext_ops.yaml
   - ./patches/tests/signal_interception.yaml
   # - ./patches/tests/uboot_env_cmp.yaml
 

--- a/tests/unit_tests/test_target/patches/tests/pseudofile_ext_ops.yaml
+++ b/tests/unit_tests/test_target/patches/tests/pseudofile_ext_ops.yaml
@@ -22,20 +22,7 @@ plugins:
         string: "default_ioctl"
 
 pseudofiles:
-  # Broadened VFS surface (W2): open/release/lseek dispatched to a plugin.
-  /dev/ext_lifecycle:
-    open:
-      model: from_plugin
-      plugin: pseudofile_ext_test
-      function: on_open
-    release:
-      model: from_plugin
-      plugin: pseudofile_ext_test
-      function: on_release
-    read:
-      model: from_plugin
-      plugin: pseudofile_ext_test
-      function: lifecycle
+  # Broadened VFS surface (W2): lseek dispatched to a plugin.
   /dev/ext_seek:
     read:
       model: const_buf
@@ -109,18 +96,9 @@ static_files:
         exit 1
       fi
 
-      # Lifecycle: each open() and release() must reach the plugin. The first
-      # cat opens (open=1) then closes (release=1); the second cat therefore
-      # reports open=2 release=1.
-      first=$($bb cat /dev/ext_lifecycle)
-      second=$($bb cat /dev/ext_lifecycle)
-      if [ "$second" != "open=2 release=1" ]; then
-        echo "Error: lifecycle first='$first' second='$second' (want 'open=2 release=1')"
-        exit 1
-      fi
-
       # Touch the provenance-default node so its stub reports default_read /
-      # default_write into pseudofiles_failures.yaml.
+      # default_write into pseudofiles_failures.yaml (default_ioctl comes from
+      # the .py companion).
       $bb cat /dev/ext_default > /dev/null
       echo "x" > /dev/ext_default
 

--- a/tests/unit_tests/test_target/patches/tests/pseudofile_ext_ops.yaml
+++ b/tests/unit_tests/test_target/patches/tests/pseudofile_ext_ops.yaml
@@ -20,8 +20,33 @@ plugins:
         type: file_contains
         file: pseudofiles_failures.yaml
         string: "default_ioctl"
+      # open()/release() from_plugin hooks fire on the guest opening/closing
+      # the node; the handlers record into a host file.
+      ext_open_fires:
+        type: file_contains
+        file: ext_lifecycle_events.txt
+        string: "open"
+      ext_release_fires:
+        type: file_contains
+        file: ext_lifecycle_events.txt
+        string: "release"
 
 pseudofiles:
+  # Broadened VFS surface (W2): open/release dispatched to a plugin. The node
+  # keeps an ordinary const_buf read so the lifecycle hooks are observed via a
+  # host file, not by reading this node back.
+  /dev/ext_lifecycle:
+    read:
+      model: const_buf
+      val: "lc\n"
+    open:
+      model: from_plugin
+      plugin: pseudofile_ext_test
+      function: on_open
+    release:
+      model: from_plugin
+      plugin: pseudofile_ext_test
+      function: on_release
   # Broadened VFS surface (W2): lseek dispatched to a plugin.
   /dev/ext_seek:
     read:
@@ -93,6 +118,14 @@ static_files:
       custom=$($bb cat /dev/ext_custom)
       if [ "$custom" != "42" ]; then
         echo "Error: custom model got '$custom' (want '42')"
+        exit 1
+      fi
+
+      # Open/close the lifecycle node so its open()/release() hooks fire. The
+      # const_buf read must still work with open/release wired on the node.
+      lc=$($bb cat /dev/ext_lifecycle)
+      if [ "$lc" != "lc" ]; then
+        echo "Error: lifecycle read got '$lc' (want 'lc')"
         exit 1
       fi
 

--- a/tests/unit_tests/test_target/patches/tests/pseudofile_ext_ops.yaml
+++ b/tests/unit_tests/test_target/patches/tests/pseudofile_ext_ops.yaml
@@ -1,0 +1,133 @@
+plugins:
+  pseudofile_ext_test: {}
+  verifier:
+    conditions:
+      pseudofile_ext_ops:
+        type: file_contains
+        file: shared/tests/pseudofile_ext_ops.sh/stdout
+        string: "pseudofile_ext_ops PASS"
+      # Provenance: a default-tagged stub self-reports each op it serves into
+      # pseudofiles_failures.yaml (default_read / default_write / default_ioctl).
+      ext_provenance_read:
+        type: file_contains
+        file: pseudofiles_failures.yaml
+        string: "default_read"
+      ext_provenance_write:
+        type: file_contains
+        file: pseudofiles_failures.yaml
+        string: "default_write"
+      ext_provenance_ioctl:
+        type: file_contains
+        file: pseudofiles_failures.yaml
+        string: "default_ioctl"
+
+pseudofiles:
+  # Broadened VFS surface (W2): open/release/lseek dispatched to a plugin.
+  /dev/ext_lifecycle:
+    open:
+      model: from_plugin
+      plugin: pseudofile_ext_test
+      function: on_open
+    release:
+      model: from_plugin
+      plugin: pseudofile_ext_test
+      function: on_release
+    read:
+      model: from_plugin
+      plugin: pseudofile_ext_test
+      function: lifecycle
+  /dev/ext_seek:
+    read:
+      model: const_buf
+      val: "seekdata\n"
+    lseek:
+      model: from_plugin
+      plugin: pseudofile_ext_test
+      function: seek_sentinel
+  # Custom @register_model read model selected by name (W3): 6 * scale = 42.
+  /dev/ext_custom:
+    read:
+      model: custom
+      model_name: ext_sensor
+      scale: 7
+  # Provenance (W5): a synthesized default stub. Reading/writing/ioctl'ing it
+  # must surface default_* events in pseudofiles_failures.yaml.
+  /dev/ext_default:
+    read:
+      model: zero
+      provenance: default
+    write:
+      model: discard
+      provenance: default
+    ioctl:
+      '*':
+        model: return_const
+        val: 0
+        provenance: default
+
+static_files:
+  /tests/pseudofile_ext_ops.py:
+    type: inline_file
+    mode: 0o755
+    contents: |
+      #!/igloo/utils/python3
+      import os, fcntl
+
+      # lseek from_plugin: the handler sets a distinctive sentinel offset, so a
+      # successful seek proves the kernel's lseek reached the plugin.
+      fd = os.open("/dev/ext_seek", os.O_RDONLY)
+      try:
+          pos = os.lseek(fd, 0, os.SEEK_SET)
+          if pos != 4242:
+              print("Error: lseek from_plugin sentinel got", pos)
+              raise SystemExit(1)
+      finally:
+          os.close(fd)
+
+      # ioctl the provenance-default node so the tracker logs default_ioctl.
+      # (return_const 0 -> the ioctl succeeds; the point is the default report.)
+      fd = os.open("/dev/ext_default", os.O_RDONLY)
+      try:
+          fcntl.ioctl(fd, 1234, 0)
+      finally:
+          os.close(fd)
+
+      print("ext python ops pass")
+
+  /tests/pseudofile_ext_ops.sh:
+    type: inline_file
+    mode: 0o755
+    contents: |
+      #!/igloo/utils/sh
+      set -ux
+      bb="/igloo/utils/busybox"
+
+      # Custom @register_model read model: ext_sensor with scale=7 -> "42".
+      custom=$($bb cat /dev/ext_custom)
+      if [ "$custom" != "42" ]; then
+        echo "Error: custom model got '$custom' (want '42')"
+        exit 1
+      fi
+
+      # Lifecycle: each open() and release() must reach the plugin. The first
+      # cat opens (open=1) then closes (release=1); the second cat therefore
+      # reports open=2 release=1.
+      first=$($bb cat /dev/ext_lifecycle)
+      second=$($bb cat /dev/ext_lifecycle)
+      if [ "$second" != "open=2 release=1" ]; then
+        echo "Error: lifecycle first='$first' second='$second' (want 'open=2 release=1')"
+        exit 1
+      fi
+
+      # Touch the provenance-default node so its stub reports default_read /
+      # default_write into pseudofiles_failures.yaml.
+      $bb cat /dev/ext_default > /dev/null
+      echo "x" > /dev/ext_default
+
+      if ! /igloo/utils/python3 /tests/pseudofile_ext_ops.py; then
+        echo "Error: python ext ops failed"
+        exit 1
+      fi
+
+      echo "pseudofile_ext_ops PASS"
+      exit 0

--- a/tests/unit_tests/test_target/patches/tests/pseudofiles_comprehensive.yaml
+++ b/tests/unit_tests/test_target/patches/tests/pseudofiles_comprehensive.yaml
@@ -76,10 +76,6 @@ pseudofiles:
       vals:
         - "s1\n"
         - "s2\n"
-  /dev/yaml_cycle:
-    read:
-      model: cycle
-      val: "AB"
   /dev/yaml_ioctl_write_data:
     ioctl:
       2222:
@@ -288,13 +284,6 @@ static_files:
       seq2=$($bb cat /proc/yaml_sequence)
       if [ "$seq1" != "s1" ] || [ "$seq2" != "s2" ]; then
         echo "Error: sequence fail (got '$seq1' then '$seq2')"
-        exit 1
-      fi
-
-      # cycle: a repeating buffer fills any read length
-      cyc=$($bb dd if=/dev/yaml_cycle bs=5 count=1 2>/dev/null)
-      if [ "$cyc" != "ABABA" ]; then
-        echo "Error: cycle fail (got '$cyc')"
         exit 1
       fi
 

--- a/tests/unit_tests/test_target/patches/tests/pseudofiles_comprehensive.yaml
+++ b/tests/unit_tests/test_target/patches/tests/pseudofiles_comprehensive.yaml
@@ -76,6 +76,10 @@ pseudofiles:
       vals:
         - "s1\n"
         - "s2\n"
+  /dev/yaml_cycle:
+    read:
+      model: cycle
+      val: "AB"
   /dev/yaml_ioctl_write_data:
     ioctl:
       2222:
@@ -284,6 +288,13 @@ static_files:
       seq2=$($bb cat /proc/yaml_sequence)
       if [ "$seq1" != "s1" ] || [ "$seq2" != "s2" ]; then
         echo "Error: sequence fail (got '$seq1' then '$seq2')"
+        exit 1
+      fi
+
+      # cycle: a repeating buffer fills any read length
+      cyc=$($bb dd if=/dev/yaml_cycle bs=5 count=1 2>/dev/null)
+      if [ "$cyc" != "ABABA" ]; then
+        echo "Error: cycle fail (got '$cyc')"
         exit 1
       fi
 

--- a/tests/unit_tests/test_target/patches/tests/pseudofiles_comprehensive.yaml
+++ b/tests/unit_tests/test_target/patches/tests/pseudofiles_comprehensive.yaml
@@ -64,6 +64,58 @@ pseudofiles:
     ioctl:
       '*':
         model: return_const
+  /dev/yaml_stateful:
+    read:
+      model: stateful
+      initial: "init\n"
+    write:
+      model: default
+  /proc/yaml_sequence:
+    read:
+      model: sequence
+      vals:
+        - "s1\n"
+        - "s2\n"
+  /dev/yaml_cycle:
+    read:
+      model: cycle
+      val: "AB"
+  /dev/yaml_ioctl_write_data:
+    ioctl:
+      2222:
+        model: write_data
+        data: "\x01\x02\x03\x04"
+        val: 0
+  /dev/yaml_lseek_unsup:
+    read:
+      model: const_buf
+      val: "seekme\n"
+    lseek:
+      model: unsupported
+  /dev/yaml_lseek_default:
+    read:
+      model: const_buf
+      val: "0123456789"
+    lseek:
+      model: default
+  /dev/yaml_write_return_const:
+    write:
+      model: return_const
+      const: -13      # -EACCES: writes rejected with a specific errno
+  /dev/yaml_write_unhandled:
+    write:
+      model: unhandled   # -EINVAL on every write
+  /dev/yaml_ioctl_unhandled:
+    ioctl:
+      '*':
+        model: unhandled   # -ENOTTY for any command
+  /proc/yaml_seq_cycle:
+    read:
+      model: sequence
+      cycle: true
+      vals:
+        - "c1\n"
+        - "c2\n"
 
 static_files:
   /tests/test_ioctl.py:
@@ -71,7 +123,7 @@ static_files:
     mode: 0o755
     contents: |
       #!/igloo/utils/python3
-      import os, fcntl
+      import os, fcntl, array, errno
 
       def check(path, op, expected):
           fd = os.open(path, os.O_RDONLY)
@@ -89,6 +141,85 @@ static_files:
       check("/dev/yaml_ioctl_whole", 1234, 77)
       check("/dev/yaml_ioctl_zero", 1234, 0)
       check("/dev/yaml_ioctl_default_zero", 1234, 0)
+
+      # write_data: the ioctl must fill the caller's buffer with the const bytes
+      buf = array.array("B", [0, 0, 0, 0])
+      fd = os.open("/dev/yaml_ioctl_write_data", os.O_RDONLY)
+      try:
+          fcntl.ioctl(fd, 2222, buf, True)
+      finally:
+          os.close(fd)
+      if buf.tolist() != [1, 2, 3, 4]:
+          print("Error: ioctl write_data got", buf.tolist())
+          raise SystemExit(1)
+
+      # lseek unsupported: seeking must fail with ESPIPE
+      fd = os.open("/dev/yaml_lseek_unsup", os.O_RDONLY)
+      try:
+          os.lseek(fd, 0, os.SEEK_SET)
+          print("Error: lseek on yaml_lseek_unsup unexpectedly succeeded")
+          raise SystemExit(1)
+      except OSError as e:
+          if e.errno != errno.ESPIPE:
+              print("Error: lseek expected ESPIPE, got", e.errno)
+              raise SystemExit(1)
+      finally:
+          os.close(fd)
+
+      # ioctl unhandled: any command must fail with ENOTTY
+      fd = os.open("/dev/yaml_ioctl_unhandled", os.O_RDONLY)
+      try:
+          fcntl.ioctl(fd, 1234, 0)
+          print("Error: ioctl unhandled unexpectedly succeeded")
+          raise SystemExit(1)
+      except OSError as e:
+          if e.errno != errno.ENOTTY:
+              print("Error: ioctl unhandled expected ENOTTY, got", e.errno)
+              raise SystemExit(1)
+      finally:
+          os.close(fd)
+
+      # write return_const: a write must fail with the configured errno (EACCES)
+      fd = os.open("/dev/yaml_write_return_const", os.O_WRONLY)
+      try:
+          os.write(fd, b"x")
+          print("Error: write return_const unexpectedly succeeded")
+          raise SystemExit(1)
+      except OSError as e:
+          if e.errno != errno.EACCES:
+              print("Error: write return_const expected EACCES, got", e.errno)
+              raise SystemExit(1)
+      finally:
+          os.close(fd)
+
+      # write unhandled: a write must fail with EINVAL
+      fd = os.open("/dev/yaml_write_unhandled", os.O_WRONLY)
+      try:
+          os.write(fd, b"x")
+          print("Error: write unhandled unexpectedly succeeded")
+          raise SystemExit(1)
+      except OSError as e:
+          if e.errno != errno.EINVAL:
+              print("Error: write unhandled expected EINVAL, got", e.errno)
+              raise SystemExit(1)
+      finally:
+          os.close(fd)
+
+      # lseek default: standard offset arithmetic against the node's size
+      fd = os.open("/dev/yaml_lseek_default", os.O_RDONLY)
+      try:
+          if os.lseek(fd, 0, os.SEEK_END) != 10:
+              print("Error: lseek default SEEK_END != size")
+              raise SystemExit(1)
+          if os.lseek(fd, 4, os.SEEK_SET) != 4:
+              print("Error: lseek default SEEK_SET != 4")
+              raise SystemExit(1)
+          if os.read(fd, 3) != b"456":
+              print("Error: lseek default read-from-offset wrong")
+              raise SystemExit(1)
+      finally:
+          os.close(fd)
+
       print("ioctl tests pass")
 
   /tests/pseudofiles_comprehensive.sh:
@@ -138,6 +269,41 @@ static_files:
 
       if ! $bb grep -q "host_read_content" /proc/yaml_file; then
         echo "Error: from_file fail"
+        exit 1
+      fi
+
+      # stateful: read back what was written (read-after-write register)
+      if [ "$($bb cat /dev/yaml_stateful)" != "init" ]; then
+        echo "Error: stateful initial fail"
+        exit 1
+      fi
+      $bb printf "hello" > /dev/yaml_stateful
+      if [ "$($bb cat /dev/yaml_stateful)" != "hello" ]; then
+        echo "Error: stateful read-after-write fail"
+        exit 1
+      fi
+
+      # sequence: successive reads return successive entries
+      seq1=$($bb cat /proc/yaml_sequence)
+      seq2=$($bb cat /proc/yaml_sequence)
+      if [ "$seq1" != "s1" ] || [ "$seq2" != "s2" ]; then
+        echo "Error: sequence fail (got '$seq1' then '$seq2')"
+        exit 1
+      fi
+
+      # cycle: a repeating buffer fills any read length
+      cyc=$($bb dd if=/dev/yaml_cycle bs=5 count=1 2>/dev/null)
+      if [ "$cyc" != "ABABA" ]; then
+        echo "Error: cycle fail (got '$cyc')"
+        exit 1
+      fi
+
+      # sequence with cycle: wraps around once the list is exhausted
+      sc1=$($bb cat /proc/yaml_seq_cycle)
+      sc2=$($bb cat /proc/yaml_seq_cycle)
+      sc3=$($bb cat /proc/yaml_seq_cycle)
+      if [ "$sc1" != "c1" ] || [ "$sc2" != "c2" ] || [ "$sc3" != "c1" ]; then
+        echo "Error: sequence cycle fail (got '$sc1' '$sc2' '$sc3')"
         exit 1
       fi
 


### PR DESCRIPTION
Backwards-compatible expansion of the pseudofile config surface so complex device models can be authored in YAML (AI-driveable) without dropping to Python.

## What's new
- **Read models**: `cycle`, `stateful` (read-after-write register), `sequence`
- **Write models**: `return_const`, `unhandled`
- **ioctl models**: `write_data`, `unhandled`
- **Broadened VFS-op domains**: `lseek` (default/unsupported/from_plugin), `mmap`, `open`, `release`, `compat_ioctl` (same_as_ioctl/from_plugin), `flush`, `fsync`, `fasync`, `lock`, `read_iter`, `write_iter`, `get_unmapped_area`
- **`@register_model` registry** backing `model: custom` — the low-friction Python-extension path
- **Provenance**: per-variant `provenance` tag; default-tagged stubs self-report `default_read`/`default_write`/`default_ioctl` into `pseudofiles_failures.yaml`
- **Per-path validation**: rejects an op attached to a filesystem that can't wire it (e.g. `flush` on `/proc`)

Everything is additive: omitting a domain keeps today's behavior.

## Tests
- `tests/unit_tests/test_config.py` — schema accept/reject for every new model + per-path validation (host/CI-runnable)
- `tests/unit_tests/test_pseudofile_models.py` — `@register_model` registry + init-time provenance tagging (host/CI-runnable)
- `test_target` fixtures — runtime coverage via the per-arch emulator run:
  - `pseudofiles_comprehensive.yaml`: cycle/stateful/sequence(+cycle), write return_const/unhandled, ioctl write_data/unhandled, lseek default/unsupported
  - `pseudofile_ext_ops.yaml` (+ `pseudofile_ext_test` plugin): open/release/lseek `from_plugin` firing, custom `@register_model` model end-to-end, provenance default-stub reporting

## Docs
- new `docs/pseudofile_models.md` catalog; `schema_doc.md` regenerated (test_schema gate passes locally)