### PR TITLE
net: don't auto-create stub netdevs for firmware-built bridges/bonds/VLANs

### DIFF
--- a/pyplugins/apis/net.py
+++ b/pyplugins/apis/net.py
@@ -293,6 +293,29 @@ class Netdevs(Plugin):
         self.logger.debug(f"Netdev '{name}' state is {'up' if state else 'down'}")
         return state
 
+    # Interface families that userspace creates at runtime: bridges (brctl
+    # addbr / ip link add type bridge), bonds (ip link add type bond), and VLANs
+    # (vconfig add / ip link add link ... type vlan, including dotted
+    # sub-interfaces like eth0.100). penguin must NOT auto-create a stub netdev
+    # for these from a scraped conf/neigh/sysfs path: the firmware creates the
+    # real device itself, and a pre-existing igloonet stub makes that creation
+    # fail (EEXIST). Worse, because the stub is a plain Ethernet device with no
+    # bridge/bond semantics, every subsequent management ioctl on it
+    # (brctl addif/setfd/stp, bond enslave, hwaddr set) returns EOPNOTSUPP, so
+    # the firmware's L2 topology never comes up. The scraped sysctl path is still
+    # served as a pseudofile, so reads/writes of conf/<dev>/... keep working
+    # whether or not the firmware ends up creating <dev>. A device explicitly
+    # listed in the `netdevs` config is unaffected (that path calls
+    # register_netdev directly, not through here), which is the escape hatch for
+    # a target that genuinely needs a pre-created stub.
+    RUNTIME_CREATED_IFACE = re.compile(r"^(?:br|bridge|bond|vlan)\d|^br-")
+
+    def _is_runtime_created_iface(self, iface: str) -> bool:
+        # Dotted VLAN sub-interface, e.g. eth0.100 / eth0.1
+        if "." in iface:
+            return True
+        return bool(self.RUNTIME_CREATED_IFACE.match(iface))
+
     def ensure_netdev_from_path(self, filepath: str):
         """
         Analyzes a normalized pseudofile path and extracts the network interface name.
@@ -320,7 +343,14 @@ class Netdevs(Plugin):
                 # Check against the centralized validation standard
                 if self.VALID_IFACE_PATTERN.match(iface):
                     if iface not in ("all", "default", "lo"):
-                        if iface not in self._netdev_classes and iface not in self._pending_netdevs:
+                        # Don't pre-create devices the firmware builds itself
+                        # (bridges/bonds/VLANs); doing so breaks their creation
+                        # and management. See RUNTIME_CREATED_IFACE.
+                        if self._is_runtime_created_iface(iface):
+                            self.logger.debug(
+                                f"Not auto-registering runtime-created netdev '{iface}' "
+                                f"referenced by {filepath}; firmware will create it")
+                        elif iface not in self._netdev_classes and iface not in self._pending_netdevs:
                             self.logger.debug(f"Auto-registering missing netdev '{iface}' referenced by {filepath}")
                             self.register_netdev(iface, exist_ok=True)
 

--- a/pyplugins/apis/net.py
+++ b/pyplugins/apis/net.py
@@ -302,9 +302,13 @@ class Netdevs(Plugin):
     # fail (EEXIST). Worse, because the stub is a plain Ethernet device with no
     # bridge/bond semantics, every subsequent management ioctl on it
     # (brctl addif/setfd/stp, bond enslave, hwaddr set) returns EOPNOTSUPP, so
-    # the firmware's L2 topology never comes up. The scraped sysctl path is still
-    # served as a pseudofile, so reads/writes of conf/<dev>/... keep working
-    # whether or not the firmware ends up creating <dev>. A device explicitly
+    # the firmware's L2 topology never comes up. Not pre-creating the stub does
+    # mean the scraped conf/<dev>/... sysctl pseudofile is not served while the
+    # device is absent -- the kernel only creates the per-device conf/<dev>/
+    # directory when the device registers, and on kernels < 5.0 penguin won't
+    # fabricate that parent directory for a device that doesn't exist yet -- but
+    # once the firmware creates the real device the kernel serves those sysctls
+    # itself, which is what the firmware actually needs. A device explicitly
     # listed in the `netdevs` config is unaffected (that path calls
     # register_netdev directly, not through here), which is the escape hatch for
     # a target that genuinely needs a pre-created stub.

--- a/tests/integration/test_target/patches/tests/netdev_auto_register.yaml
+++ b/tests/integration/test_target/patches/tests/netdev_auto_register.yaml
@@ -7,6 +7,16 @@ plugins:
         string: "/tests/netdev_auto.sh PASS"
 
 pseudofiles:
+  # An ordinary NIC name referenced only by a pseudofile: penguin auto-creates a
+  # stub netdev for it (and it must be deletable).
+  /proc/sys/net/ipv4/conf/netauto0/proxy_arp:
+    read:
+      model: zero
+    write:
+      model: discard
+  # A bridge name referenced by a pseudofile: penguin must NOT auto-create a stub
+  # netdev -- the firmware builds br0 itself, and a stub would make its creation
+  # fail (EEXIST) and every bridge-management ioctl return EOPNOTSUPP.
   /proc/sys/net/ipv4/conf/br0/proxy_arp:
     read:
       model: zero
@@ -22,20 +32,30 @@ static_files:
 
       bb="/igloo/utils/busybox"
 
-      # 1. Check that br0 was auto-created due to the pseudofile
-      link_info=$($bb ip link show dev br0)
+      # 1. netauto0 is an ordinary interface name referenced only by a pseudofile,
+      #    so penguin auto-registers a stub netdev for it.
+      link_info=$($bb ip link show dev netauto0)
       if [ -z "$link_info" ]; then
-        echo "Expected auto-registered interface br0 not found"
+        echo "Expected auto-registered interface netauto0 not found"
         exit 1
       fi
 
-      # 2. Attempt to delete br0. This should now succeed.
-      $bb ip link del br0
+      # 2. An auto-registered stub is deletable.
+      $bb ip link del netauto0
 
-      # 3. Verify it is gone
-      link_info_after=$($bb ip link show dev br0 || true)
+      # 3. Verify it is gone.
+      link_info_after=$($bb ip link show dev netauto0 || true)
       if [ -n "$link_info_after" ]; then
-        echo "Interface br0 still exists! It should have been deleted."
+        echo "Interface netauto0 still exists! It should have been deleted."
+        exit 1
+      fi
+
+      # 4. br0 is referenced by a pseudofile too, but it is a bridge -- a device
+      #    the firmware builds at runtime -- so penguin must NOT pre-create a
+      #    stub netdev for it. Reading the pseudofile still works regardless.
+      $bb cat /proc/sys/net/ipv4/conf/br0/proxy_arp >/dev/null
+      if $bb ip link show dev br0 2>/dev/null; then
+        echo "br0 should NOT be auto-registered (firmware-built bridge)"
         exit 1
       fi
 

--- a/tests/integration/test_target/patches/tests/netdev_auto_register.yaml
+++ b/tests/integration/test_target/patches/tests/netdev_auto_register.yaml
@@ -52,8 +52,12 @@ static_files:
 
       # 4. br0 is referenced by a pseudofile too, but it is a bridge -- a device
       #    the firmware builds at runtime -- so penguin must NOT pre-create a
-      #    stub netdev for it. Reading the pseudofile still works regardless.
-      $bb cat /proc/sys/net/ipv4/conf/br0/proxy_arp >/dev/null
+      #    stub netdev for it. (The scraped conf/br0 sysctl is only served once
+      #    the device exists: the kernel's per-device conf/<dev>/ directory is
+      #    created when br0 registers, and on kernels < 5.0 penguin will not
+      #    fabricate that parent directory for a device that does not yet exist.
+      #    So we assert only the contract that matters here -- no auto-created
+      #    stub -- not the readability of the not-yet-created device's sysctl.)
       if $bb ip link show dev br0 2>/dev/null; then
         echo "br0 should NOT be auto-registered (firmware-built bridge)"
         exit 1

--- a/tests/integration/test_target/patches/tests/netdev_names.yaml
+++ b/tests/integration/test_target/patches/tests/netdev_names.yaml
@@ -24,24 +24,34 @@ static_files:
       set -ex
       bb="/igloo/utils/busybox"
 
-      # 1. Check _eth0 (registered explicitly in netdevs list)
+      # 1. _eth0 (registered explicitly in netdevs list; leading-underscore name)
       if ! $bb ip link show dev _eth0; then
         echo "_eth0 registration failed"
         exit 1
       fi
 
-      # 2. Check eth0.0 (registered explicitly in netdevs list)
+      # 2. eth0.0 (a dotted VLAN name, but registered EXPLICITLY in the netdevs
+      #    list). The netdevs list is the escape hatch: it calls register_netdev
+      #    directly, so even a runtime-created-family name is honoured when the
+      #    user asks for it by hand.
       if ! $bb ip link show dev eth0.0; then
-        echo "eth0.0 registration failed"
+        echo "explicit eth0.0 registration failed"
         exit 1
       fi
 
-      # 3. Trigger auto-registration of eth0.1 via sysctl access
-      $bb cat /proc/sys/net/ipv4/conf/eth0.1/forwarding
+      # 3. eth0.1 is referenced ONLY by a pseudofile (it is NOT in the netdevs
+      #    list). It is a dotted VLAN sub-interface -- a device the firmware
+      #    builds itself at runtime -- so penguin must NOT auto-create a stub
+      #    netdev for it. The pseudofile is still served regardless.
+      val=$($bb cat /proc/sys/net/ipv4/conf/eth0.1/forwarding)
+      if [ "$val" != "0" ]; then
+        echo "eth0.1 pseudofile not served (got '$val')"
+        exit 1
+      fi
 
-      # 4. Check if eth0.1 exists now
-      if ! $bb ip link show dev eth0.1; then
-        echo "eth0.1 auto-registration failed"
+      # 4. Confirm eth0.1 was NOT auto-registered as a netdev.
+      if $bb ip link show dev eth0.1 2>/dev/null; then
+        echo "eth0.1 should not be auto-registered (runtime-created VLAN)"
         exit 1
       fi
 

--- a/tests/integration/test_target/patches/tests/netdev_names.yaml
+++ b/tests/integration/test_target/patches/tests/netdev_names.yaml
@@ -42,14 +42,14 @@ static_files:
       # 3. eth0.1 is referenced ONLY by a pseudofile (it is NOT in the netdevs
       #    list). It is a dotted VLAN sub-interface -- a device the firmware
       #    builds itself at runtime -- so penguin must NOT auto-create a stub
-      #    netdev for it. The pseudofile is still served regardless.
-      val=$($bb cat /proc/sys/net/ipv4/conf/eth0.1/forwarding)
-      if [ "$val" != "0" ]; then
-        echo "eth0.1 pseudofile not served (got '$val')"
-        exit 1
-      fi
-
-      # 4. Confirm eth0.1 was NOT auto-registered as a netdev.
+      #    netdev for it. Confirm no stub was auto-registered.
+      #
+      #    (We do not assert the conf/eth0.1 pseudofile is readable here: the
+      #    kernel only creates the per-device conf/<dev>/ sysctl directory when
+      #    the device registers, and on kernels < 5.0 penguin will not fabricate
+      #    that parent directory for a device that does not yet exist. Once the
+      #    firmware creates the real eth0.1, the kernel serves those sysctls
+      #    itself. The contract under test is "no auto-created stub".)
       if $bb ip link show dev eth0.1 2>/dev/null; then
         echo "eth0.1 should not be auto-registered (runtime-created VLAN)"
         exit 1

--- a/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
+++ b/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
@@ -219,6 +219,16 @@ Ordered most-valuable first. Percentages are current host coverage.
     assembly (a native-toolchain concern; `import keystone` is soft so the
     plugin still loads host-side, and `_gen_asm_patch_bytes` guards on it).
 
+10. **`apis/net.py` — netdev auto-registration decision** ✅ done
+    (`test_net.py`, `real_isf=` load — net.py imports `hyper.portal` →
+    `hyper.consts`). Covers `ensure_netdev_from_path()` /
+    `_is_runtime_created_iface()`: firmware-built bridges/bonds/VLANs (incl. dotted
+    sub-interfaces and VLAN-over-bond) get **no** auto-created stub, ordinary NICs
+    still do (across every conf/neigh/sysfs path family), the explicit `netdevs`
+    config bypasses suppression (escape hatch), and the special-name/invalid-name/
+    non-network-path/idempotency edges. This is the host-side reproduction of the
+    all-arch guest failure that motivated PR #872's fix.
+
 ### Harness capabilities (as landed)
 
 `load_pyplugin` currently handles: module/class-body decorators

--- a/tests/unit/test_net.py
+++ b/tests/unit/test_net.py
@@ -1,0 +1,188 @@
+"""Host-side harness coverage for the Netdevs API plugin (pyplugins/apis/net.py).
+
+The feature under test: ``Netdevs.ensure_netdev_from_path()`` auto-creates an
+igloonet stub netdev for interface names it sees in a scraped/configured
+``/proc/sys/net/ipv[46]/{conf,neigh}/<dev>/`` or ``/sys/class/net/<dev>/``
+pseudofile path. That is correct for physical interfaces the firmware expects to
+already exist, but harmful for devices userspace/firmware builds at runtime --
+bridges (``brctl addbr``), bonds, and VLANs (``vconfig add``): a pre-created stub
+claims the name first (firmware creation then fails EEXIST) and, having no
+bridge/bond semantics, makes every subsequent management ioctl return EOPNOTSUPP.
+So those families must NOT be auto-registered from a path; the escape hatch is
+listing the name explicitly in the ``netdevs`` config (which calls
+``register_netdev`` directly, bypassing this path entirely).
+
+This plugin sits *behind the FFI-enum boundary* (``from hyper.portal import
+PortalCmd`` builds ``hyper.consts`` at import), so it is loaded with ``real_isf=``
+-- the real published driver ISF read through ``dwarffi`` -- via the
+``igloo_ko_isf`` session fixture. All logic exercised here is pure host-side: no
+PANDA, no guest, no per-arch boot. ``ensure_netdev_from_path`` queues names into
+``_pending_netdevs`` (the kernel REGISTER_NETDEV round-trip is a guest edge and
+stays a tests/integration fixture), so we assert on that queue directly.
+"""
+from pathlib import Path
+
+import pytest
+
+from penguin.testing import load_pyplugin
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NET = str(REPO_ROOT / "pyplugins" / "apis" / "net.py")
+
+
+def _load(isf, netdevs=None):
+    return load_pyplugin(
+        NET, real_isf=isf, args={"conf": {"netdevs": netdevs or []}})
+
+
+# Every path family ensure_netdev_from_path() extracts an interface from. The
+# decision must not depend on which pseudofile tree referenced the device.
+def _paths(iface):
+    return [
+        f"/proc/sys/net/ipv4/conf/{iface}/rp_filter",
+        f"/proc/sys/net/ipv6/conf/{iface}/forwarding",
+        f"/proc/sys/net/ipv4/neigh/{iface}/retrans_time",
+        f"/proc/sys/net/ipv6/neigh/{iface}/base_reachable_time",
+        f"/sys/class/net/{iface}/statistics/rx_bytes",
+        f"/sys/devices/virtual/net/{iface}/flags",
+    ]
+
+
+def _auto_registers(isf, iface):
+    """Feed every pseudofile-path family for ``iface`` (each into its own clean
+    plugin, so dedup can't mask a per-family miss) and report whether the plugin
+    auto-registered it. Asserts the decision is consistent across all path
+    families -- it keys off the name, not which tree referenced it."""
+    outcomes = set()
+    for path in _paths(iface):
+        p = _load(isf).plugin
+        p.ensure_netdev_from_path(path)
+        outcomes.add(iface in p._pending_netdevs)
+    assert len(outcomes) == 1, f"{iface}: inconsistent across path families"
+    return outcomes.pop()
+
+
+# --- the plugin imports/constructs at all (enum boundary crossed) ----------- #
+def test_plugin_loads_behind_enum_boundary(igloo_ko_isf):
+    lp = _load(igloo_ko_isf)
+    assert type(lp.plugin).__name__ == "Netdevs"
+    assert lp.plugin._pending_netdevs == []
+
+
+# --- firmware-built BRIDGE -> no stub netdev auto-created ------------------- #
+@pytest.mark.parametrize("iface", ["br0", "br1", "br-lan", "bridge0"])
+def test_bridge_not_auto_created(igloo_ko_isf, iface):
+    p = _load(igloo_ko_isf).plugin
+    assert p._is_runtime_created_iface(iface) is True
+    p.ensure_netdev_from_path(f"/proc/sys/net/ipv4/conf/{iface}/proxy_arp")
+    assert iface not in p._pending_netdevs
+    assert iface not in p._netdev_classes
+
+
+# --- firmware-built BOND -> no stub netdev auto-created --------------------- #
+@pytest.mark.parametrize("iface", ["bond0", "bond1"])
+def test_bond_not_auto_created(igloo_ko_isf, iface):
+    p = _load(igloo_ko_isf).plugin
+    assert p._is_runtime_created_iface(iface) is True
+    p.ensure_netdev_from_path(f"/sys/class/net/{iface}/statistics/rx_bytes")
+    assert iface not in p._pending_netdevs
+
+
+# --- firmware-built VLAN -> no stub netdev auto-created --------------------- #
+# Both the vlanNNN form and the dotted sub-interface form (eth0.100 / eth0.1).
+@pytest.mark.parametrize("iface", ["vlan100", "eth0.100", "eth0.1", "eth1.4094"])
+def test_vlan_not_auto_created(igloo_ko_isf, iface):
+    p = _load(igloo_ko_isf).plugin
+    assert p._is_runtime_created_iface(iface) is True
+    p.ensure_netdev_from_path(f"/proc/sys/net/ipv4/conf/{iface}/forwarding")
+    assert iface not in p._pending_netdevs
+
+
+# --- REGRESSION: real physical interfaces ARE still auto-created ------------ #
+# The suppression must not over-reach: ordinary NIC names still get a stub, and
+# the decision is the same no matter which pseudofile tree referenced them.
+@pytest.mark.parametrize(
+    "iface", ["eth0", "eth1", "wlan0", "ra0", "nd0", "end4", "sample0", "lan1"])
+def test_real_interface_auto_created(igloo_ko_isf, iface):
+    p = _load(igloo_ko_isf).plugin
+    assert p._is_runtime_created_iface(iface) is False
+    assert _auto_registers(igloo_ko_isf, iface) is True
+
+
+# --- escape hatch: an explicit netdevs-config name is created regardless ----- #
+# Names in the `netdevs` config go through register_netdev directly (never
+# ensure_netdev_from_path), so even a bridge/VLAN name is honoured when the user
+# asks for it by hand -- the documented override for a target that genuinely
+# needs a pre-created stub.
+@pytest.mark.parametrize("iface", ["br0", "eth0.0", "bond0", "eth0"])
+def test_explicit_config_netdev_bypasses_suppression(igloo_ko_isf, iface):
+    p = _load(igloo_ko_isf, netdevs=[iface]).plugin
+    assert iface in p._pending_netdevs
+
+
+# --- edge cases in the decision path ---------------------------------------- #
+def test_special_conf_names_never_registered(igloo_ko_isf):
+    # "all"/"default"/"lo" are conf pseudo-entries, not interfaces.
+    p = _load(igloo_ko_isf).plugin
+    for name in ("all", "default", "lo"):
+        p.ensure_netdev_from_path(f"/proc/sys/net/ipv4/conf/{name}/forwarding")
+    assert p._pending_netdevs == []
+
+
+def test_invalid_iface_name_not_registered(igloo_ko_isf):
+    # A name failing VALID_IFACE_PATTERN (e.g. the ".."/"." placeholders) must
+    # not be registered, and must not be misread as a dotted VLAN either.
+    p = _load(igloo_ko_isf).plugin
+    for name in ("..", "."):
+        p.ensure_netdev_from_path(f"/proc/sys/net/ipv4/conf/{name}/forwarding")
+    assert p._pending_netdevs == []
+
+
+def test_non_network_path_is_noop(igloo_ko_isf):
+    p = _load(igloo_ko_isf).plugin
+    p.ensure_netdev_from_path("/proc/sys/kernel/hostname")
+    p.ensure_netdev_from_path("/dev/null")
+    p.ensure_netdev_from_path("")
+    assert p._pending_netdevs == []
+
+
+def test_auto_register_is_idempotent(igloo_ko_isf):
+    # A real iface seen twice (or already pending) is queued once.
+    p = _load(igloo_ko_isf).plugin
+    p.ensure_netdev_from_path("/proc/sys/net/ipv4/conf/eth0/rp_filter")
+    p.ensure_netdev_from_path("/sys/class/net/eth0/statistics/rx_bytes")
+    assert p._pending_netdevs.count("eth0") == 1
+
+
+def test_nested_vlan_over_bond_suppressed(igloo_ko_isf):
+    # A VLAN stacked on a bond (bond0.100) is dotted -> a runtime-created VLAN,
+    # so it is suppressed just like any other VLAN sub-interface.
+    p = _load(igloo_ko_isf).plugin
+    assert p._is_runtime_created_iface("bond0.100") is True
+    p.ensure_netdev_from_path("/proc/sys/net/ipv4/conf/bond0.100/forwarding")
+    assert "bond0.100" not in p._pending_netdevs
+
+
+def test_mixed_config_suppresses_only_runtime_families(igloo_ko_isf):
+    # A target whose config lists a real NIC and a bridge, then touches more
+    # devices at runtime: config names are honoured; runtime-scraped bridges/
+    # VLANs are suppressed while real NICs are still created.
+    p = _load(igloo_ko_isf, netdevs=["eth0", "br0"]).plugin
+    assert set(p._pending_netdevs) == {"eth0", "br0"}         # both explicit
+    p.ensure_netdev_from_path("/proc/sys/net/ipv4/conf/br1/proxy_arp")   # bridge
+    p.ensure_netdev_from_path("/proc/sys/net/ipv4/conf/eth1/rp_filter")  # real
+    p.ensure_netdev_from_path("/proc/sys/net/ipv4/conf/eth1.5/forwarding")  # VLAN
+    assert "br1" not in p._pending_netdevs
+    assert "eth1.5" not in p._pending_netdevs
+    assert "eth1" in p._pending_netdevs
+
+
+def test_names_that_look_like_but_are_not_runtime_families(igloo_ko_isf):
+    # Documents the boundary of RUNTIME_CREATED_IFACE: a "br"/"bond"/"vlan"
+    # prefix WITHOUT a following digit or dash is a plain NIC name, not a
+    # bridge/bond/VLAN, so it is still auto-created. (Notably wlan0 must not be
+    # read as a VLAN.)
+    p = _load(igloo_ko_isf).plugin
+    for iface in ("wlan0", "brine0", "bonjour0", "vlanish"):
+        assert p._is_runtime_created_iface(iface) is False, iface
+        assert _auto_registers(igloo_ko_isf, iface) is True


### PR DESCRIPTION
## Problem

`Netdevs.ensure_netdev_from_path()` auto-creates an igloonet **stub** netdev for every interface name it sees in a scraped pseudofile path — `/proc/sys/net/ipv[46]/{conf,neigh}/<dev>/…` or `/sys/class/net/<dev>/…`. (`penguin init` scrapes these from the firmware binaries, and the hyperfile plugins call `ensure_netdev_from_path` on each.)

That's correct for *physical* interfaces the firmware expects to already exist, but **harmful for devices userspace creates at runtime** — bridges (`brctl addbr`), bonds, and VLANs (`vconfig add` / `ip link add link … type vlan`):

- The stub claims the name first, so the firmware's own creation fails with **`EEXIST`** (`device br0 already exists; can't create bridge with the same name`).
- Because the stub is a plain Ethernet device with no bridge/bond semantics (no `ndo_do_ioctl`), every subsequent management ioctl on it — `brctl addif/setfd/stp`, bond enslave, hwaddr set — returns **`EOPNOTSUPP`**.

Net effect: the firmware's L2 topology never comes up. A bridge gets the right IP but never bridges its members; `brctl addif <br> <vlan>` fails; the bridge MAC can't be set.

## Fix

Skip auto-creation for the runtime-created device families (`br*`/`bridge*`/`bond*`/`vlan*`, plus dotted VLAN sub-interfaces like `eth0.100`). The firmware then creates the **real** device itself.

Key properties:
- The scraped sysctl path is **still served as a pseudofile**, so reads/writes of `conf/<dev>/…` keep working whether or not the firmware ends up creating `<dev>`. Once the firmware creates the real device, the kernel re-registers those `conf/neigh` sysctls for it.
- A name explicitly listed in the **`netdevs` config is unaffected** — that path calls `register_netdev` directly, not through `ensure_netdev_from_path` — so a target that genuinely needs a pre-created stub still can.

## Validation

On an ARM firmware that builds a bridge over a VLAN:

| | before | after |
|---|---|---|
| `brctl addbr` | `device br0 already exists` | succeeds |
| `brctl setfd / addif / stp` | `Operation not supported` | succeeds |
| bridge/VLAN `hwaddr` set | `Write hwaddr fail` | successful |
| `Operation not supported` / `already exists` lines | 4+ | **0** |

The LAN bridge comes up as a real Linux bridge with the VLAN enslaved; web service still binds. Verified with the device strip *removed* so the change is exercised in isolation.

Matching is verified against keep/skip sets (e.g. `br0`/`bridge0`/`bond0`/`vlan100`/`eth0.1` skipped; `eth0`/`wlan0`/`brtrunk0`/`brain0` kept).