### PR TITLE
run_summary: aggregate summary.json per run

### DIFF
--- a/docs/compose.md
+++ b/docs/compose.md
@@ -136,6 +136,7 @@ The authoritative schema lives in `src/penguin/compose.py` (`load_compose`,
       server/                       # runner's output dir for this device
         console.log
         netbinds.csv
+        summary.json                # per-device machine-readable run digest
         ...
       client/
         console.log

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -138,6 +138,7 @@ rehosting continues to running.
 
 * Examine the console output by looking at `./projects/stride/results/0/console.log`. To view the output as it is updated you can run `tail -f ./projects/stride/results/0/console.log`.
 * Examine dynamically-traced shell script execution at `./projects/stride/results/0/shell_cov_trace.csv` and note that concrete values for each variable are included in the trace.
+* After the run completes, `./projects/stride/results/0/summary.json` holds a single machine-readable digest of the run (total and per-metric scores, network binds, unmodeled pseudofile count, panic flag, wallclock) aggregated from the other output files — handy for scripting and CI, e.g. `jq .score results/latest/summary.json`.
 
 Note that some files will not be created or populated until the emulation terminates. To learn
 more about the outputs created in this directory, check out [docs/plugins.md](docs/plugins.md).

--- a/src/penguin/__main__.py
+++ b/src/penguin/__main__.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import sys
 import hashlib
 import tempfile
+import time
 import art
 
 from penguin import VERSION, getColoredLogger, yaml
@@ -18,6 +19,7 @@ from penguin import VERSION, getColoredLogger, yaml
 from .common import get_inits_from_proj
 from .gen_config import fakeroot_gen_config, fakeroot_refresh
 from .manager import PandaRunner, calculate_score
+from .run_summary import write_run_summary
 from penguin.penguin_config import load_config
 
 from .plugin_manager import find_local_plugins
@@ -117,6 +119,7 @@ def run_from_config(proj_dir, config_path, output_dir, timeout=None, verbose=Fal
         extra_env["PENGUIN_SNAPSHOT_IGNORE_SAVED_CONFIG"] = "1"
     extra_env = extra_env or None
 
+    run_start = time.time()
     try:
         PandaRunner().run(
             config_path,
@@ -132,6 +135,7 @@ def run_from_config(proj_dir, config_path, output_dir, timeout=None, verbose=Fal
     except RuntimeError:
         logger.error("No post-run analysis since there was no .run file")
         return
+    wallclock_s = time.time() - run_start
 
     # Single iteration: there is no best - don't report that
     # from manager import report_best_results
@@ -152,6 +156,12 @@ def run_from_config(proj_dir, config_path, output_dir, timeout=None, verbose=Fal
     with open(os.path.join(output_dir, "score.txt"), "w") as f:
         total_score = sum(best_scores.values())
         f.write(f"{total_score:.02f}\n")
+
+    try:
+        write_run_summary(output_dir, best_scores, wallclock_s=wallclock_s)
+    except Exception as e:
+        # Never let a summary failure (I/O or serialization) kill run teardown.
+        logger.error(f"Failed to write summary.json: {e}")
 
 
 def get_file_hash(filename):

--- a/src/penguin/compose.py
+++ b/src/penguin/compose.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import shutil
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 
@@ -529,6 +530,7 @@ def _run_device(
     """
     from penguin.penguin_config import load_config
     from .manager import PandaRunner, calculate_score
+    from .run_summary import write_run_summary
     from .common import get_inits_from_proj
 
     os.makedirs(device_meta_dir, exist_ok=True)
@@ -558,6 +560,7 @@ def _run_device(
         endpoints, runtime_metadata_path,
     )
 
+    run_start = time.time()
     try:
         PandaRunner().run(
             derived_config_path,
@@ -579,12 +582,19 @@ def _run_device(
     except RuntimeError as e:
         logger.error(f"Device '{device.name}' run failed: {e}")
         return {}
+    wallclock_s = time.time() - run_start
 
     try:
-        return calculate_score(device_out_dir)
+        scores = calculate_score(device_out_dir)
     except Exception as e:
         logger.warning(f"Device '{device.name}' score calculation failed: {e}")
         return {}
+    if scores:
+        try:
+            write_run_summary(device_out_dir, scores, wallclock_s=wallclock_s)
+        except Exception as e:
+            logger.warning(f"Device '{device.name}': failed to write summary.json: {e}")
+    return scores
 
 
 # ---------------------------------------------------------------------------

--- a/src/penguin/run_summary.py
+++ b/src/penguin/run_summary.py
@@ -18,10 +18,10 @@ Schema (``schema_version`` 1)
   number written to ``score.txt``).
 - ``scores`` (dict): the per-metric dict from ``calculate_score``, verbatim.
 - ``binds`` (list): one entry per working service bind from ``netbinds.csv``:
-  ``{proc, proto, ipvn, ip, port, time}`` plus ``{state, pid, closed_time}``
-  when the CSV carries lifecycle columns. Only ``listening``/``closed``
-  sockets are included — ``pending``/``transient`` binds are not working
-  services and are excluded.
+  ``{proc, proto, ipvn, ip, port, time}`` plus ``pid`` when the CSV carries a
+  pid column and ``{state, closed_time}`` when it carries lifecycle columns.
+  Only ``listening``/``closed`` sockets are included — ``pending``/
+  ``transient`` binds are not working services and are excluded.
 - ``crashes`` (list): entries from ``crashes.yaml`` when present, else ``[]``.
 - ``unmodeled_pseudofiles`` (int|null): number of distinct paths in
   ``pseudofiles_failures.yaml``; ``null`` if the tracker didn't run.
@@ -78,8 +78,8 @@ def _load_yaml(path):
 def _load_binds(result_dir: str) -> list[dict]:
     """Read first-seen binds from netbinds.csv (written by the netbinds plugin).
 
-    Base columns: procname,ipvn,domain,guest_ip,guest_port,time. The lifecycle
-    rework adds pid,state,closed_time, where state is one of
+    Base columns: procname,ipvn,domain,guest_ip,guest_port,[pid,]time. The
+    lifecycle rework adds state,closed_time, where state is one of
     pending|listening|transient|closed. Per the lifecycle contract a
     pending/transient socket must not read as a working service, so those rows
     are excluded from ``binds``; listening and (cleanly) closed sockets are
@@ -102,10 +102,11 @@ def _load_binds(result_dir: str) -> list[dict]:
                         "port": int(row["guest_port"]),
                         "time": float(row["time"]),
                     }
+                    pid = row.get("pid")
+                    if pid:
+                        bind["pid"] = int(pid)
                     if state is not None:
                         bind["state"] = state
-                        pid = row.get("pid")
-                        bind["pid"] = int(pid) if pid else None
                         closed_time = row.get("closed_time")
                         bind["closed_time"] = float(closed_time) if closed_time else None
                     binds.append(bind)

--- a/src/penguin/run_summary.py
+++ b/src/penguin/run_summary.py
@@ -1,0 +1,194 @@
+"""
+penguin.run_summary
+===================
+
+Aggregate a completed run's scattered output artifacts into a single
+machine-readable ``summary.json`` in the result directory.
+
+A run's signal is spread across many output files (``health_final.yaml``,
+``netbinds.csv``, ``pseudofiles_failures.yaml``, ``scores.txt``, ...). This
+module reads the artifacts that already exist — it never recomputes them —
+and writes one digest that humans triaging a run and outer loops
+(explore / CI / escalation) can parse without re-opening everything.
+
+Schema (``schema_version`` 1)
+-----------------------------
+
+- ``score`` (float): total score, the sum of the ``scores`` values (same
+  number written to ``score.txt``).
+- ``scores`` (dict): the per-metric dict from ``calculate_score``, verbatim.
+- ``binds`` (list): one entry per working service bind from ``netbinds.csv``:
+  ``{proc, proto, ipvn, ip, port, time}`` plus ``{state, pid, closed_time}``
+  when the CSV carries lifecycle columns. Only ``listening``/``closed``
+  sockets are included — ``pending``/``transient`` binds are not working
+  services and are excluded.
+- ``crashes`` (list): entries from ``crashes.yaml`` when present, else ``[]``.
+- ``unmodeled_pseudofiles`` (int|null): number of distinct paths in
+  ``pseudofiles_failures.yaml``; ``null`` if the tracker didn't run.
+- ``stalled_threads`` (int|null): number of blocked threads reported in
+  ``waitgraph.yaml``; ``null`` if stall diagnostics didn't run.
+- ``panic`` (bool): kernel panic observed (derived from the ``nopanic``
+  score metric).
+- ``wallclock_s`` (float|null): wallclock duration of the emulation run,
+  measured by the caller; ``null`` if unknown.
+- ``suggest`` (list): remediation suggestions. Always present (stable key
+  for consumers); currently always empty, populated as suggestion/escalation
+  work lands.
+
+Fields sourced from optional artifacts distinguish "producer didn't run"
+(``null``) from "producer ran and found nothing" (``0`` / ``[]``).
+
+``summary.json`` is written only for runs that completed and scored — outer
+loops must treat a missing ``summary.json`` as "run did not complete".
+
+This file is *what happened* in a run. Its sibling ``run_manifest.yaml``
+(what was run: input hashes, config identity) is a separate artifact with a
+different lifecycle — the manifest describes inputs and can be written even
+when a run dies; the summary exists only once a run completed and scored.
+
+Functions
+---------
+- build_run_summary
+- write_run_summary
+"""
+import csv
+import json
+import os
+from penguin import getColoredLogger
+from .common import yaml
+
+logger = getColoredLogger("penguin.run_summary")
+
+SUMMARY_FILE = "summary.json"
+SUMMARY_SCHEMA_VERSION = 1
+
+
+def _load_yaml(path):
+    """Load a YAML artifact, returning None if absent or unparseable."""
+    try:
+        with open(path) as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError:
+        return None
+    except yaml.YAMLError as e:
+        logger.warning(f"Could not parse {path}: {e}")
+        return None
+
+
+def _load_binds(result_dir: str) -> list[dict]:
+    """Read first-seen binds from netbinds.csv (written by the netbinds plugin).
+
+    Base columns: procname,ipvn,domain,guest_ip,guest_port,time. The lifecycle
+    rework adds pid,state,closed_time, where state is one of
+    pending|listening|transient|closed. Per the lifecycle contract a
+    pending/transient socket must not read as a working service, so those rows
+    are excluded from ``binds``; listening and (cleanly) closed sockets are
+    kept. CSVs without a state column are read as before, all rows included.
+    """
+    binds = []
+    path = os.path.join(result_dir, "netbinds.csv")
+    try:
+        with open(path, newline="") as f:
+            for i, row in enumerate(csv.DictReader(f)):
+                state = row.get("state") or None
+                if state is not None and state not in ("listening", "closed"):
+                    continue
+                try:
+                    bind = {
+                        "proc": row["procname"],
+                        "proto": row["domain"],
+                        "ipvn": int(row["ipvn"]),
+                        "ip": row["guest_ip"],
+                        "port": int(row["guest_port"]),
+                        "time": float(row["time"]),
+                    }
+                    if state is not None:
+                        bind["state"] = state
+                        pid = row.get("pid")
+                        bind["pid"] = int(pid) if pid else None
+                        closed_time = row.get("closed_time")
+                        bind["closed_time"] = float(closed_time) if closed_time else None
+                    binds.append(bind)
+                except (KeyError, TypeError, ValueError) as e:
+                    logger.warning(f"Skipping malformed row {i + 1} in {path}: {e}")
+    except FileNotFoundError:
+        pass
+    except (IOError, csv.Error) as e:
+        logger.warning(f"Could not read {path}: {e}")
+    return binds
+
+
+def _load_crashes(result_dir: str) -> list:
+    """Read crash records from crashes.yaml (crash reporter) when present."""
+    data = _load_yaml(os.path.join(result_dir, "crashes.yaml"))
+    if data is None:
+        return []
+    # Written as {"crashes": [...]}; tolerate a bare list too.
+    if isinstance(data, dict):
+        data = data.get("crashes", [])
+    return data if isinstance(data, list) else []
+
+
+def _count_unmodeled_pseudofiles(result_dir: str):
+    """Count distinct failing paths in pseudofiles_failures.yaml.
+
+    Returns None when the pseudofile tracker didn't produce the file, so
+    consumers can tell "tracker off" apart from "no failures".
+    """
+    path = os.path.join(result_dir, "pseudofiles_failures.yaml")
+    if not os.path.isfile(path):
+        return None
+    data = _load_yaml(path)
+    return len(data) if isinstance(data, dict) else 0
+
+
+def _count_stalled_threads(result_dir: str):
+    """Count blocked threads from waitgraph.yaml (stall diagnostics) when present."""
+    path = os.path.join(result_dir, "waitgraph.yaml")
+    if not os.path.isfile(path):
+        return None
+    data = _load_yaml(path)
+    if isinstance(data, dict):
+        threads = data.get("threads", [])
+        return len(threads) if isinstance(threads, list) else 0
+    return 0
+
+
+def build_run_summary(
+    result_dir: str, scores: dict[str, int], wallclock_s: float | None = None
+) -> dict:
+    """
+    Aggregate a completed run's artifacts into the summary dict.
+
+    :param result_dir: Directory containing the run's output artifacts.
+    :param scores: Per-metric score dict from ``calculate_score`` (embedded
+        verbatim; the total is derived from it, matching ``score.txt``).
+    :param wallclock_s: Emulation wallclock seconds, if the caller measured it.
+    :return: The summary dict (see module docstring for the schema).
+    """
+    return {
+        "schema_version": SUMMARY_SCHEMA_VERSION,
+        "score": float(sum(scores.values())),
+        "scores": scores,
+        "binds": _load_binds(result_dir),
+        "crashes": _load_crashes(result_dir),
+        "unmodeled_pseudofiles": _count_unmodeled_pseudofiles(result_dir),
+        "stalled_threads": _count_stalled_threads(result_dir),
+        "panic": scores.get("nopanic", 1) == 0,
+        "wallclock_s": round(wallclock_s, 3) if wallclock_s is not None else None,
+        "suggest": [],
+    }
+
+
+def write_run_summary(
+    result_dir: str, scores: dict[str, int], wallclock_s: float | None = None
+) -> str:
+    """
+    Build and write ``summary.json`` into ``result_dir``. Returns its path.
+    """
+    summary = build_run_summary(result_dir, scores, wallclock_s=wallclock_s)
+    path = os.path.join(result_dir, SUMMARY_FILE)
+    with open(path, "w") as f:
+        json.dump(summary, f, indent=2)
+        f.write("\n")
+    return path

--- a/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
+++ b/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
@@ -164,8 +164,17 @@ Ordered most-valuable first. Percentages are current host coverage.
      with the crashes.yaml join. Guest round-trip (real ENOENT delivery,
      crash → crashes.yaml production) stays in `tests/integration/` fixtures
      (`pseudofile_missing`/`pseudofile_ioctl`/`pseudofile_ext_ops`).
-   - `summary.json` (draft 02) aggregation — the harness is its natural
-     host-side test as it lands.
+   - ✅ **`summary.json`** (draft 02, `src/penguin/run_summary.py`) — done
+     (`test_run_summary.py`). Not a pyplugin — the post-run host aggregator —
+     so the harness's role is the *producer* side: the real
+     `analysis/netbinds.py` is loaded with `load_pyplugin`, driven with bind
+     events, finalized, and `write_run_summary` aggregates the directory the
+     plugin actually wrote (so CSV-shape drift breaks the test, not just the
+     fixture). Direct fixtures cover the artifact shapes (draft 01
+     `crashes.yaml`, draft 03 ranked `pseudofiles_failures.yaml`) and the
+     formats main doesn't produce yet — draft 05 lifecycle columns
+     (transient/pending excluded from `binds`), draft 06 `waitgraph.yaml` —
+     plus absent-producer null semantics and malformed-row tolerance.
 9. **`analysis/interfaces.py` + the `apis.syscalls`-importing class** ✅ done
    (`test_interfaces.py`, `analysis/interfaces.py` 4→93%) — the FFI-enum boundary,
    crossed with the **`real_isf=`** load mode. `from apis.syscalls import

--- a/tests/unit/test_run_summary.py
+++ b/tests/unit/test_run_summary.py
@@ -1,0 +1,204 @@
+import json
+
+import pytest
+
+from penguin.run_summary import (
+    SUMMARY_SCHEMA_VERSION,
+    build_run_summary,
+    write_run_summary,
+)
+
+SCORES = {
+    "execs": 427,
+    "bound_sockets": 5,
+    "devices_accessed": 199,
+    "processes_run": 12,
+    "modules_loaded": 3,
+    "blocks_covered": 1000,
+    "script_lines_covered": 50,
+    "nopanic": 1,
+    "blocked_signals": 0,
+}
+
+# Pre-lifecycle netbinds.csv shape (no pid/state/closed_time columns).
+NETBINDS_CSV = """\
+procname,ipvn,domain,guest_ip,guest_port,time
+docker,6,tcp,[::1],0,113.273
+portmap,4,udp,0.0.0.0,111,114.317
+httpd,4,tcp,0.0.0.0,80,120.5
+"""
+
+# Lifecycle netbinds.csv shape (draft 05): state pending|listening|transient|closed.
+NETBINDS_LIFECYCLE_CSV = """\
+procname,ipvn,domain,guest_ip,guest_port,pid,time,state,closed_time
+httpd,4,tcp,0.0.0.0,80,412,120.5,listening,
+dnsmasq,4,udp,0.0.0.0,53,300,90.1,closed,400.2
+flappy,4,tcp,0.0.0.0,8080,500,95.0,transient,96.0
+young,4,tcp,0.0.0.0,9090,501,119.9,pending,
+"""
+
+# Pre-ranking flat shape: path -> event -> {count}.
+PSEUDOFILES_FAILURES_YAML = """\
+/dev/gpio:
+  open:
+    count: 12
+/proc/simple_config/lan_ip:
+  open:
+    count: 3
+"""
+
+# Ranked shape (draft 03): header comment block + path -> {impact, callers,
+# events, suggest}. The top level is still path-keyed.
+PSEUDOFILES_FAILURES_RANKED_YAML = """\
+# Guest accesses to unmodeled /dev, /proc, and /sys paths, ranked by impact
+# (crashing_callers >> distinct_callers > hits).
+/dev/watchdog:
+  impact: {hits: 243, distinct_callers: 2, crashing_callers: 0}
+  callers: [init:1, watchdogd:412]
+  events:
+    ioctl:
+      2147768064: {count: 240}
+    open: {count: 3}
+  suggest:
+    read: {model: zero}
+    ioctl: {'*': {model: return_const, val: 0}}
+/proc/simple_config/lan_ip:
+  impact: {hits: 3, distinct_callers: 1, crashing_callers: 0}
+  callers: [httpd:300]
+  events:
+    open: {count: 3}
+  suggest:
+    read: {model: zero}
+"""
+
+CRASHES_YAML = """\
+crashes:
+  - proc: httpd
+    pid: 412
+    signal: 11
+    signame: SIGSEGV
+    pc: 0x004013a8
+    time: 12.481
+    count: 3
+"""
+
+WAITGRAPH_YAML = """\
+trigger: timeout
+wallclock_s: 120.0
+threads:
+  - tid: 412
+    comm: httpd
+    state: D
+  - tid: 419
+    comm: httpd
+    state: S
+"""
+
+
+@pytest.fixture
+def full_run_dir(tmp_path):
+    (tmp_path / "netbinds.csv").write_text(NETBINDS_CSV)
+    (tmp_path / "pseudofiles_failures.yaml").write_text(PSEUDOFILES_FAILURES_YAML)
+    (tmp_path / "crashes.yaml").write_text(CRASHES_YAML)
+    (tmp_path / "waitgraph.yaml").write_text(WAITGRAPH_YAML)
+    return tmp_path
+
+
+def test_full_summary(full_run_dir):
+    summary = build_run_summary(str(full_run_dir), SCORES, wallclock_s=41.2345)
+
+    assert summary["schema_version"] == SUMMARY_SCHEMA_VERSION
+    assert summary["score"] == float(sum(SCORES.values()))
+    assert summary["scores"] == SCORES
+
+    # Old-format CSV: no state column, all rows kept, no lifecycle keys.
+    assert summary["binds"] == [
+        {"proc": "docker", "proto": "tcp", "ipvn": 6, "ip": "[::1]", "port": 0, "time": 113.273},
+        {"proc": "portmap", "proto": "udp", "ipvn": 4, "ip": "0.0.0.0", "port": 111, "time": 114.317},
+        {"proc": "httpd", "proto": "tcp", "ipvn": 4, "ip": "0.0.0.0", "port": 80, "time": 120.5},
+    ]
+
+    assert summary["crashes"] == [
+        {
+            "proc": "httpd",
+            "pid": 412,
+            "signal": 11,
+            "signame": "SIGSEGV",
+            "pc": 0x004013A8,
+            "time": 12.481,
+            "count": 3,
+        }
+    ]
+
+    assert summary["unmodeled_pseudofiles"] == 2
+    assert summary["stalled_threads"] == 2
+    assert summary["panic"] is False
+    assert summary["wallclock_s"] == 41.234
+    assert summary["suggest"] == []
+
+
+def test_missing_optional_artifacts(tmp_path):
+    summary = build_run_summary(str(tmp_path), SCORES)
+
+    assert summary["binds"] == []
+    assert summary["crashes"] == []
+    # Absent producer -> null, distinguishable from "ran and found nothing".
+    assert summary["unmodeled_pseudofiles"] is None
+    assert summary["stalled_threads"] is None
+    assert summary["wallclock_s"] is None
+
+
+def test_empty_pseudofiles_failures_is_zero(tmp_path):
+    (tmp_path / "pseudofiles_failures.yaml").write_text("{}\n")
+    summary = build_run_summary(str(tmp_path), SCORES)
+    assert summary["unmodeled_pseudofiles"] == 0
+
+
+def test_ranked_pseudofiles_failures_counts_paths(tmp_path):
+    (tmp_path / "pseudofiles_failures.yaml").write_text(PSEUDOFILES_FAILURES_RANKED_YAML)
+    summary = build_run_summary(str(tmp_path), SCORES)
+    assert summary["unmodeled_pseudofiles"] == 2
+
+
+def test_panic_derived_from_nopanic(tmp_path):
+    scores = dict(SCORES, nopanic=0)
+    summary = build_run_summary(str(tmp_path), scores)
+    assert summary["panic"] is True
+
+
+def test_lifecycle_netbinds_filters_non_working(tmp_path):
+    (tmp_path / "netbinds.csv").write_text(NETBINDS_LIFECYCLE_CSV)
+    summary = build_run_summary(str(tmp_path), SCORES)
+
+    # pending/transient must not read as working services (draft 05 contract).
+    assert summary["binds"] == [
+        {
+            "proc": "httpd", "proto": "tcp", "ipvn": 4, "ip": "0.0.0.0",
+            "port": 80, "time": 120.5,
+            "state": "listening", "pid": 412, "closed_time": None,
+        },
+        {
+            "proc": "dnsmasq", "proto": "udp", "ipvn": 4, "ip": "0.0.0.0",
+            "port": 53, "time": 90.1,
+            "state": "closed", "pid": 300, "closed_time": 400.2,
+        },
+    ]
+
+
+def test_malformed_netbinds_row_skipped(tmp_path):
+    (tmp_path / "netbinds.csv").write_text(
+        "procname,ipvn,domain,guest_ip,guest_port,time\n"
+        "httpd,4,tcp,0.0.0.0,80,120.5\n"
+        "bad,notanint,tcp,0.0.0.0,x,y\n"
+    )
+    summary = build_run_summary(str(tmp_path), SCORES)
+    assert len(summary["binds"]) == 1
+    assert summary["binds"][0]["proc"] == "httpd"
+
+
+def test_write_run_summary_round_trips(full_run_dir):
+    path = write_run_summary(str(full_run_dir), SCORES, wallclock_s=41.2)
+    assert path == str(full_run_dir / "summary.json")
+    with open(path) as f:
+        on_disk = json.load(f)
+    assert on_disk == build_run_summary(str(full_run_dir), SCORES, wallclock_s=41.2)

--- a/tests/unit/test_run_summary.py
+++ b/tests/unit/test_run_summary.py
@@ -1,12 +1,31 @@
-import json
+"""Host-side tests for the summary.json aggregator (penguin.run_summary).
 
-import pytest
+run_summary is not a pyplugin — it's the post-run host aggregator the CLI
+invokes after scoring — so it is exercised in two layers:
+
+- **Producer contract, via the harness**: the real ``analysis/netbinds.py``
+  pyplugin is loaded with ``penguin.testing.load_pyplugin``, driven with bind
+  events, and finalized; ``write_run_summary`` then aggregates the directory
+  the plugin actually wrote. No hand-rolled ``netbinds.csv`` fixture — if the
+  plugin's CSV shape drifts, this test fails.
+- **Format compatibility + optional artifacts, via fixtures**: the artifact
+  shapes main produces (draft 01 ``crashes.yaml``, draft 03 ranked
+  ``pseudofiles_failures.yaml``), the shapes it doesn't yet (draft 05
+  lifecycle columns, draft 06 ``waitgraph.yaml``), and the absent-producer
+  null semantics.
+"""
+import json
+from pathlib import Path
 
 from penguin.run_summary import (
     SUMMARY_SCHEMA_VERSION,
     build_run_summary,
     write_run_summary,
 )
+from penguin.testing import load_pyplugin
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NETBINDS = REPO_ROOT / "pyplugins" / "analysis" / "netbinds.py"
 
 SCORES = {
     "execs": 427,
@@ -18,9 +37,10 @@ SCORES = {
     "script_lines_covered": 50,
     "nopanic": 1,
     "blocked_signals": 0,
+    "crashes": 0,
 }
 
-# Pre-lifecycle netbinds.csv shape (no pid/state/closed_time columns).
+# Pre-pid netbinds.csv shape (no pid/state/closed_time columns).
 NETBINDS_CSV = """\
 procname,ipvn,domain,guest_ip,guest_port,time
 docker,6,tcp,[::1],0,113.273
@@ -71,13 +91,14 @@ PSEUDOFILES_FAILURES_RANKED_YAML = """\
     read: {model: zero}
 """
 
+# Shape written by analysis/crashes.py (pc is a hex string).
 CRASHES_YAML = """\
 crashes:
   - proc: httpd
     pid: 412
     signal: 11
     signame: SIGSEGV
-    pc: 0x004013a8
+    pc: '0x004013a8'
     time: 12.481
     count: 3
 """
@@ -95,28 +116,101 @@ threads:
 """
 
 
-@pytest.fixture
-def full_run_dir(tmp_path):
-    (tmp_path / "netbinds.csv").write_text(NETBINDS_CSV)
-    (tmp_path / "pseudofiles_failures.yaml").write_text(PSEUDOFILES_FAILURES_YAML)
-    (tmp_path / "crashes.yaml").write_text(CRASHES_YAML)
-    (tmp_path / "waitgraph.yaml").write_text(WAITGRAPH_YAML)
-    return tmp_path
+# --------------------------------------------------------------------------- #
+# Producer contract: aggregate what the real netbinds plugin writes
+# --------------------------------------------------------------------------- #
+def test_summary_aggregates_real_netbinds_output(tmp_path):
+    # Drive the real netbinds plugin host-side (see test_pyplugin_harness.py:
+    # endianness="big" keeps the "port:pid" port value un-swapped).
+    lp = load_pyplugin(
+        str(NETBINDS), outdir=tmp_path,
+        args={"shutdown_on_www": False}, endianness="big",
+    )
+    lp.dispatch("igloo_ipv4_setup", None, "httpd", 0)     # sin_addr 0 -> 0.0.0.0
+    lp.dispatch("igloo_ipv4_bind", None, "80:123", True)  # port:pid, TCP
+    lp.dispatch("igloo_ipv4_setup", None, "dnsd", 0)
+    lp.dispatch("igloo_ipv4_bind", None, "53:99", False)  # UDP
+    lp.finalize()
 
-
-def test_full_summary(full_run_dir):
-    summary = build_run_summary(str(full_run_dir), SCORES, wallclock_s=41.2345)
+    path = write_run_summary(str(tmp_path), SCORES, wallclock_s=41.2345)
+    assert path == str(tmp_path / "summary.json")
+    with open(path) as f:
+        summary = json.load(f)
 
     assert summary["schema_version"] == SUMMARY_SCHEMA_VERSION
     assert summary["score"] == float(sum(SCORES.values()))
     assert summary["scores"] == SCORES
 
-    # Old-format CSV: no state column, all rows kept, no lifecycle keys.
+    # The binds come from the CSV the plugin actually wrote.
+    for bind, expected in zip(summary["binds"], [
+        {"proc": "httpd", "proto": "tcp", "ipvn": 4, "ip": "0.0.0.0", "port": 80, "pid": 123},
+        {"proc": "dnsd", "proto": "udp", "ipvn": 4, "ip": "0.0.0.0", "port": 53, "pid": 99},
+    ]):
+        time = bind.pop("time")
+        assert isinstance(time, float)
+        assert bind == expected
+    assert len(summary["binds"]) == 2
+
+    assert summary["crashes"] == []
+    assert summary["unmodeled_pseudofiles"] is None
+    assert summary["stalled_threads"] is None
+    assert summary["panic"] is False
+    assert summary["wallclock_s"] == 41.234
+    assert summary["suggest"] == []
+
+
+# --------------------------------------------------------------------------- #
+# netbinds.csv format compatibility
+# --------------------------------------------------------------------------- #
+def test_old_format_netbinds_all_rows_kept(tmp_path):
+    # Pre-pid CSVs: no state column, all rows kept, no pid/lifecycle keys.
+    (tmp_path / "netbinds.csv").write_text(NETBINDS_CSV)
+    summary = build_run_summary(str(tmp_path), SCORES)
     assert summary["binds"] == [
         {"proc": "docker", "proto": "tcp", "ipvn": 6, "ip": "[::1]", "port": 0, "time": 113.273},
         {"proc": "portmap", "proto": "udp", "ipvn": 4, "ip": "0.0.0.0", "port": 111, "time": 114.317},
         {"proc": "httpd", "proto": "tcp", "ipvn": 4, "ip": "0.0.0.0", "port": 80, "time": 120.5},
     ]
+
+
+def test_lifecycle_netbinds_filters_non_working(tmp_path):
+    (tmp_path / "netbinds.csv").write_text(NETBINDS_LIFECYCLE_CSV)
+    summary = build_run_summary(str(tmp_path), SCORES)
+
+    # pending/transient must not read as working services (draft 05 contract).
+    assert summary["binds"] == [
+        {
+            "proc": "httpd", "proto": "tcp", "ipvn": 4, "ip": "0.0.0.0",
+            "port": 80, "pid": 412, "time": 120.5,
+            "state": "listening", "closed_time": None,
+        },
+        {
+            "proc": "dnsmasq", "proto": "udp", "ipvn": 4, "ip": "0.0.0.0",
+            "port": 53, "pid": 300, "time": 90.1,
+            "state": "closed", "closed_time": 400.2,
+        },
+    ]
+
+
+def test_malformed_netbinds_row_skipped(tmp_path):
+    (tmp_path / "netbinds.csv").write_text(
+        "procname,ipvn,domain,guest_ip,guest_port,time\n"
+        "httpd,4,tcp,0.0.0.0,80,120.5\n"
+        "bad,notanint,tcp,0.0.0.0,x,y\n"
+    )
+    summary = build_run_summary(str(tmp_path), SCORES)
+    assert len(summary["binds"]) == 1
+    assert summary["binds"][0]["proc"] == "httpd"
+
+
+# --------------------------------------------------------------------------- #
+# Optional artifacts and null semantics
+# --------------------------------------------------------------------------- #
+def test_optional_artifacts_aggregated(tmp_path):
+    (tmp_path / "pseudofiles_failures.yaml").write_text(PSEUDOFILES_FAILURES_YAML)
+    (tmp_path / "crashes.yaml").write_text(CRASHES_YAML)
+    (tmp_path / "waitgraph.yaml").write_text(WAITGRAPH_YAML)
+    summary = build_run_summary(str(tmp_path), SCORES)
 
     assert summary["crashes"] == [
         {
@@ -124,17 +218,13 @@ def test_full_summary(full_run_dir):
             "pid": 412,
             "signal": 11,
             "signame": "SIGSEGV",
-            "pc": 0x004013A8,
+            "pc": "0x004013a8",
             "time": 12.481,
             "count": 3,
         }
     ]
-
     assert summary["unmodeled_pseudofiles"] == 2
     assert summary["stalled_threads"] == 2
-    assert summary["panic"] is False
-    assert summary["wallclock_s"] == 41.234
-    assert summary["suggest"] == []
 
 
 def test_missing_optional_artifacts(tmp_path):
@@ -164,41 +254,3 @@ def test_panic_derived_from_nopanic(tmp_path):
     scores = dict(SCORES, nopanic=0)
     summary = build_run_summary(str(tmp_path), scores)
     assert summary["panic"] is True
-
-
-def test_lifecycle_netbinds_filters_non_working(tmp_path):
-    (tmp_path / "netbinds.csv").write_text(NETBINDS_LIFECYCLE_CSV)
-    summary = build_run_summary(str(tmp_path), SCORES)
-
-    # pending/transient must not read as working services (draft 05 contract).
-    assert summary["binds"] == [
-        {
-            "proc": "httpd", "proto": "tcp", "ipvn": 4, "ip": "0.0.0.0",
-            "port": 80, "time": 120.5,
-            "state": "listening", "pid": 412, "closed_time": None,
-        },
-        {
-            "proc": "dnsmasq", "proto": "udp", "ipvn": 4, "ip": "0.0.0.0",
-            "port": 53, "time": 90.1,
-            "state": "closed", "pid": 300, "closed_time": 400.2,
-        },
-    ]
-
-
-def test_malformed_netbinds_row_skipped(tmp_path):
-    (tmp_path / "netbinds.csv").write_text(
-        "procname,ipvn,domain,guest_ip,guest_port,time\n"
-        "httpd,4,tcp,0.0.0.0,80,120.5\n"
-        "bad,notanint,tcp,0.0.0.0,x,y\n"
-    )
-    summary = build_run_summary(str(tmp_path), SCORES)
-    assert len(summary["binds"]) == 1
-    assert summary["binds"][0]["proc"] == "httpd"
-
-
-def test_write_run_summary_round_trips(full_run_dir):
-    path = write_run_summary(str(full_run_dir), SCORES, wallclock_s=41.2)
-    assert path == str(full_run_dir / "summary.json")
-    with open(path) as f:
-        on_disk = json.load(f)
-    assert on_disk == build_run_summary(str(full_run_dir), SCORES, wallclock_s=41.2)


### PR DESCRIPTION
Implements planning draft 02 (run-summary-json): after a run completes and scores, write `results/<N>/summary.json` — a single machine-readable digest of "what happened in this run", aggregated from the artifacts the run already produced (no recomputation, no new instrumentation).

## What's in the file (`schema_version: 1`)

```json
{
  "schema_version": 1,
  "score": 987.0,
  "scores": { "execs": 427, "bound_sockets": 5, "...": "the calculate_score dict verbatim" },
  "binds": [ {"proc": "httpd", "proto": "tcp", "ipvn": 4, "ip": "0.0.0.0", "port": 80, "time": 120.5, "state": "listening", "pid": 412, "closed_time": null} ],
  "crashes": [],
  "unmodeled_pseudofiles": 12,
  "stalled_threads": null,
  "panic": false,
  "wallclock_s": 41.2,
  "suggest": []
}
```

- **JSON, not YAML**: consumers are machines (CI, explore loops, `jq`); JSON is stdlib-parseable and a strict subset of YAML, and avoids the 1.1/1.2 loader pitfalls we already work around for `core_config.yaml`.
- **binds** come from `netbinds.csv` and handle both the pre- and post-lifecycle formats; per the lifecycle contract, `pending`/`transient` sockets are excluded so a flapping bind never reads as a working service.
- **crashes** (`crashes.yaml`) and **stalled_threads** (`waitgraph.yaml`) are read when present. Fields whose producer didn't run are `null`, distinguishable from "ran and found nothing" (`0`/`[]`).
- **`suggest` is intentionally an empty stub** — the key is stable so consumers can rely on it now; it gets populated by the failure-engine / pseudofile-suggest work.
- **Contract**: the summary is written only for completed+scored runs — outer loops must treat a missing `summary.json` as "run did not complete". (Input-side identity belongs to the separate `run_manifest.yaml` idea, not this file.)

## Integration

- `__main__.py run_from_config`: written right after `scores.txt`/`score.txt`, with wallclock measured around the `PandaRunner` run. A summary failure can never kill run teardown.
- `compose.py _run_single_device`: each device gets its own `summary.json`.
- `unmodeled_pseudofiles` counting is tested against both the current flat `pseudofiles_failures.yaml` shape and the new ranked (impact/callers/events/suggest) shape.

## Tests

`tests/unit_tests/test_run_summary.py` — 8 tests: full schema, absent-artifact defaults, empty-vs-missing pseudofiles (both schemas), lifecycle bind filtering, panic derivation, malformed CSV row skipping, disk round-trip. Also dry-run verified against a real device results dir.