### PR TITLE
crashes: signal-based crash reporter

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -22,6 +22,24 @@ The file `coverage_tree.csv` stores this information with parent/child
 relationships to visualize as a tree. The file `coverage_transitions.csv`
 records all context switches between processes.
 
+## Crashes
+The `crashes` plugin records fatal signal deliveries to guest processes
+(userland crashes) in `crashes.yaml`. Each record includes the process name,
+pid, signal number and name, the faulting program counter, the time (host
+wall-clock seconds since emulation start) of the first occurrence, and a
+`count` de-duplicating identical `(proc, signal, pc)` deliveries. By default
+it records SIGSEGV, SIGBUS, SIGILL, SIGABRT, SIGFPE, and SIGSYS; the set is
+configurable via the `signals` argument (use signal names — numbering is
+resolved per guest architecture). The number of unique crash records is also
+reported (negated) as the `crashes` score category.
+
+Note that records are signal *deliveries*, not confirmed terminations: the
+driver hook fires when a signal is dequeued for delivery, before the kernel
+applies its disposition, and the event does not indicate whether the process
+has a handler installed. A process that catches a fatal-class signal and
+survives is still recorded. Deliveries that another plugin has already
+dropped (`event.drop`, e.g. a SIGILL-bypass consumer) are not recorded.
+
 ## Env
 The `env` plugin dynamically tracks linux environment variables accessed through
 `/proc/cmdline` and calls to `getenv`. It also tracks accesses to `/proc/mtd`

--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -390,17 +390,133 @@ false
 true
 ```
 
-### `core.shared_dir` Project-relative path of shared directory
+### `core.shared_dir` Shared directory configuration
+
+|||
+|-|-|
+|__Default__|`null`|
+
+Host<->guest shared directory (9p) configuration.
+
+    Accepted in ``core.shared_dir`` as ``true`` (enable with defaults), a string
+    (shorthand for ``path``), or this object. Core dumps ride the same single
+    mount (see ``core.core_dumps``); they do not need this feature enabled.
+    
+
+```yaml
+true
+```
+
+```yaml
+my_shared_directory
+```
+
+```yaml
+msize: 131072
+path: shared
+```
+
+#### `core.shared_dir.path` Results-relative share directory
+
+|||
+|-|-|
+|__Type__|string|
+|__Default__|`shared`|
+
+Directory shared into the guest at /igloo/shared. Resolved under the run's results dir unless core.shared_dir.host_path is set.
+
+```yaml
+shared
+```
+
+```yaml
+my_shared_directory
+```
+
+#### `core.shared_dir.host_path` Absolute host directory to share
 
 |||
 |-|-|
 |__Type__|string or null|
 |__Default__|`null`|
 
-Share this directory as /igloo/shared in the guest.
+If set, share this absolute host directory instead of a results-relative one (path is ignored).
 
 ```yaml
-my_shared_directory
+/data/fixtures
+```
+
+#### `core.shared_dir.msize` 9p msize override
+
+|||
+|-|-|
+|__Type__|integer or null|
+|__Default__|`null`|
+
+Override the 9p transport buffer size. Unset uses the default 8MB with an automatic fallback to 128KB on memory-tight guests.
+
+```yaml
+8192000
+```
+
+```yaml
+131072
+```
+
+### `core.core_dumps` Core dump configuration
+
+|||
+|-|-|
+|__Default__|`null`|
+
+Guest core-dump capture configuration.
+
+    Accepted in ``core.core_dumps`` as ``true`` (enable with defaults), a string
+    (shorthand for ``pattern``), or this object. When enabled, penguin points
+    core_pattern at /igloo/core_dumps (a symlink into the shared mount) and
+    brings that mount up even when core.shared_dir is unset.
+    
+
+```yaml
+true
+```
+
+```yaml
+/igloo/core_dumps/core_%e.%p
+```
+
+```yaml
+lock: false
+```
+
+#### `core.core_dumps.lock` Lock core_pattern
+
+|||
+|-|-|
+|__Type__|boolean|
+|__Default__|`true`|
+
+Install a sysctl pseudofile that eats guest writes to core_pattern so dumps can't be redirected. Set false to let the guest firmware keep its own core_pattern.
+
+```yaml
+true
+```
+
+```yaml
+false
+```
+
+#### `core.core_dumps.pattern` core_pattern override
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Override the core_pattern string. Unset uses /igloo/core_dumps/core_%e.%p.
+
+```yaml
+/igloo/core_dumps/core_%e.%p.%t
 ```
 
 ### `core.version` Config format version

--- a/pyplugins/analysis/crashes.py
+++ b/pyplugins/analysis/crashes.py
@@ -1,0 +1,173 @@
+"""
+Crashes Plugin (crashes.py) for Penguin
+=======================================
+
+This module provides the Crashes plugin, which records fatal signal
+deliveries to guest processes -- userland crashes -- to ``crashes.yaml`` in
+the output directory. Before this, the only crash signal Penguin recorded
+was a kernel panic; a guest service dying from SIGSEGV left no artifact.
+
+The plugin registers guest signal-delivery hooks (via the SignalMonitor
+plugin / igloo_driver) for a configurable set of fatal-by-default signals
+and aggregates deliveries, de-duplicating identical (process, signal, pc)
+triples with a count -- mirroring how NetBinds de-duplicates binds.
+
+The recorded ``pc`` comes from the target task's saved userspace register
+frame (``task_pt_regs``) at signal-delivery time. For synchronous faults
+(SIGSEGV/SIGBUS/SIGILL/SIGFPE) that frame is the exception trap frame, so
+the pc is the faulting instruction address. For asynchronous signals (e.g.
+a ``kill``) it is wherever the task last entered the kernel.
+
+Output ``crashes.yaml``::
+
+    crashes:
+    - proc: httpd
+      pid: 412
+      signal: 11
+      signame: SIGSEGV
+      pc: '0x004013a8'
+      time: 12.481      # host wall-clock seconds since emulation start
+      count: 3          # de-duplicated identical (proc, signal, pc)
+
+The file is rewritten on every recorded delivery (crashes are rare), so it
+is always current; an empty ``crashes: []`` is written at startup so
+downstream consumers can rely on the file existing.
+
+Caveats
+-------
+
+- **Deliveries, not terminations.** The underlying driver hook fires when a
+  signal is *dequeued for delivery*, before the kernel applies its
+  disposition, and the event does not say whether a userspace handler is
+  installed. A process that catches SIGSEGV/SIGABRT/etc. and survives (e.g.
+  a runtime using SIGSEGV for GC barriers, or a daemon with an abort
+  handler) is still recorded. Treat a crashes.yaml row as "a fatal-class
+  signal was delivered", not proof the process died.
+- Deliveries another subscriber has already marked dropped (``event.drop``)
+  are skipped, but publish order between subscribers is not deterministic,
+  so a drop made *after* this plugin runs is still recorded.
+- ``time`` is host wall-clock seconds since this plugin initialized (i.e.
+  emulation start), not guest uptime.
+
+Arguments
+---------
+
+- signals (list of str, optional): Signal names to record. Defaults to the
+  signals whose default action is to terminate with a core dump and that
+  indicate a program fault: SIGSEGV, SIGBUS, SIGILL, SIGABRT, SIGFPE,
+  SIGSYS. Names are resolved per guest architecture (MIPS numbering
+  differs), so always configure by name, not number.
+
+Overall Purpose
+---------------
+
+A crashing service is one of the most common reasons a rehost "runs" but
+produces no bound port. This plugin makes those crashes visible in the
+output directory and in the run score (see ``manager.calculate_score``).
+"""
+
+import time
+from os.path import join
+
+import yaml
+from pydantic import Field
+from penguin import plugins, Plugin, PluginArgs
+
+CRASHES_FILE = "crashes.yaml"
+
+# Fatal-by-default signals that indicate a program fault (man signal(7):
+# default action terminates the process with a core dump), minus the
+# debugger/profiling ones (SIGTRAP, SIGXCPU, SIGXFSZ, SIGQUIT) that are not
+# crash indicators in practice.
+DEFAULT_FATAL_SIGNALS = [
+    "SIGSEGV",
+    "SIGBUS",
+    "SIGILL",
+    "SIGABRT",
+    "SIGFPE",
+    "SIGSYS",
+]
+
+
+class Crashes(Plugin):
+    class Args(PluginArgs):
+        signals: list[str] = Field(
+            default=DEFAULT_FATAL_SIGNALS,
+            description="Signal names to record as crashes. Resolved per "
+            "guest architecture, so use names (e.g. SIGSEGV), not numbers.",
+        )
+
+    def __init__(self):
+        self.outdir = self.get_arg("outdir")
+        self.start_time = time.time()
+
+        # (proc, signal, pc) -> record dict; insertion-ordered
+        self.records = {}
+
+        # Guest signal number -> canonical name, resolved for the guest arch
+        # (MIPS numbers several signals differently).
+        self.signames = {}
+        for name in self.get_arg("signals"):
+            num = plugins.signals.signal_name_to_num(name)
+            if num is None:
+                raise ValueError(f"crashes plugin: unknown signal name {name!r}")
+            self.signames.setdefault(num, name)
+
+        # Write an empty report up front so consumers can rely on the file.
+        self.write_report()
+
+        plugins.subscribe(plugins.signal_monitor, "signal_deliver", self.on_signal_deliver)
+        # One guest hook per watched signal, so only these deliveries trap
+        # out to the host.
+        for num in self.signames:
+            plugins.signal_monitor.register_hook(sig=num)
+
+    def on_signal_deliver(self, cpu, event):
+        """
+        Record a fatal signal delivery. SignalMonitor publishes every hooked
+        delivery (including ones registered by other plugins), so filter to
+        our watched set here.
+        """
+        sig = int(event.sig)
+        signame = self.signames.get(sig)
+        if signame is None:
+            return
+
+        # Another subscriber may have dropped this delivery to bypass it
+        # (e.g. a SIGILL-emulation consumer that advances the PC). Publish
+        # order between subscribers is not deterministic, so this only
+        # filters drops made before we run; a drop made afterwards is still
+        # recorded.
+        if event.drop:
+            return
+
+        pc = int(event.pc)
+        if pc == 0 and event.regs:
+            pc = event.regs.get_pc()
+
+        key = (event.comm, sig, pc)
+        rec = self.records.get(key)
+        if rec is None:
+            rec = {
+                "proc": event.comm,
+                "pid": int(event.pid),
+                "signal": sig,
+                "signame": signame,
+                "pc": f"0x{pc:08x}",
+                "time": round(time.time() - self.start_time, 3),
+                "count": 1,
+            }
+            self.records[key] = rec
+            self.logger.info(
+                f"{signame} delivered to {event.comm} (pid {rec['pid']}) at {rec['pc']}"
+            )
+        else:
+            rec["count"] += 1
+        self.write_report()
+
+    def write_report(self):
+        with open(join(self.outdir, CRASHES_FILE), "w") as f:
+            yaml.safe_dump({"crashes": list(self.records.values())}, f, sort_keys=False)
+
+    def uninit(self):
+        self.write_report()

--- a/pyplugins/core/core.py
+++ b/pyplugins/core/core.py
@@ -42,6 +42,43 @@ from penguin import Plugin, yaml, plugins, common
 from penguin.defaults import vnc_password
 
 
+def shared_dir_and_core_dump_env(shared_dir, core_dumps):
+    """Map the (normalized) core.shared_dir / core.core_dumps config to guest
+    env vars consumed by source.d/40_mount_shared_dir.sh.
+
+    Both features ride the single /igloo/shared 9p mount but are independent.
+    Returns ``(env_updates, deprecated_implicit)`` where ``deprecated_implicit``
+    is True when core dumps were enabled only because shared_dir was set (the
+    pre-split legacy behavior), so the caller can emit a deprecation warning.
+
+    ``shared_dir``/``core_dumps`` are the config values after schema
+    normalization: a dict when enabled, or falsy when disabled.
+    """
+    env = {}
+
+    # Legacy: setting core.shared_dir used to implicitly enable core dumps.
+    # Preserve that when core.core_dumps is unset, but an explicit value wins.
+    deprecated_implicit = False
+    if core_dumps is None and shared_dir:
+        core_dumps = {"lock": True}
+        deprecated_implicit = True
+
+    if shared_dir or core_dumps:
+        env["SHARED_DIR"] = "1"
+        if isinstance(shared_dir, dict) and shared_dir.get("msize"):
+            env["SHARED_MSIZE"] = str(shared_dir["msize"])
+
+    if core_dumps:
+        env["CORE_DUMPS"] = "1"
+        cd = core_dumps if isinstance(core_dumps, dict) else {}
+        if cd.get("lock", True):
+            env["CORE_DUMPS_LOCK"] = "1"
+        if cd.get("pattern"):
+            env["CORE_DUMP_PATTERN"] = cd["pattern"]
+
+    return env, deprecated_implicit
+
+
 class Core(Plugin):
     """
     Core plugin for PyPlugins.
@@ -141,9 +178,17 @@ class Core(Plugin):
                     f"VNC @ {container_ip}:5900 with password '{vnc_password}'"
                 )
 
-        # Same thing, but for a shared directory
-        if conf["core"].get("shared_dir", False):
-            conf["env"]["SHARED_DIR"] = "1"
+        # Shared directory and core dumps both ride the single /igloo/shared 9p
+        # mount, but are independent features (see the helper for the mapping).
+        cd_env, deprecated_implicit = shared_dir_and_core_dump_env(
+            conf["core"].get("shared_dir"), conf["core"].get("core_dumps")
+        )
+        if deprecated_implicit:
+            self.logger.warning(
+                "core.shared_dir implicitly enabled core dumps; this is "
+                "deprecated. Set core.core_dumps explicitly (true/false)."
+            )
+        conf["env"].update(cd_env)
 
         if conf["core"].get("strace", False) is True:
             conf["env"]["STRACE"] = "1"

--- a/pyplugins/interventions/core_pattern_guard.py
+++ b/pyplugins/interventions/core_pattern_guard.py
@@ -15,11 +15,11 @@ global. The driver's sysctl mutation repoints ctl_table.data to our buffer
 but never writes through to the original .data target, so the global keeps
 the value the init script put there.
 
-Dormant when core.shared_dir is unset: the init script only fires the
-hypercall when SHARED_DIR is in the guest env. We subscribe unconditionally
-anyway so a stray core_pattern_lock (e.g. env.SHARED_DIR set by hand without
-core.shared_dir) is honored instead of tripping send_hypercall's
-"Unregistered send_hypercall command" error.
+Dormant when core dumps are disabled or core.core_dumps.lock is false: the
+init script only fires the hypercall when both CORE_DUMPS and CORE_DUMPS_LOCK
+are in the guest env (set by core.py from core.core_dumps). We subscribe
+unconditionally anyway so a stray core_pattern_lock is honored instead of
+tripping send_hypercall's "Unregistered send_hypercall command" error.
 """
 
 from penguin import Plugin, plugins
@@ -48,7 +48,7 @@ class CorePatternSysctl(SysctlFile):
                 payload = f"<unreadable: {e}>"
             self._owner.logger.info(
                 f"guest tried to set core_pattern to {payload!r}; "
-                f"keeping {self._pattern_bytes.decode()!r} so dumps land in /igloo/shared/core_dumps"
+                f"keeping penguin's locked pattern {self._pattern_bytes.decode()!r}"
             )
             yield from plugins.mem.write(ppos_ptr, int(size))
             ptregs.retval = 0

--- a/src/penguin/defaults.py
+++ b/src/penguin/defaults.py
@@ -59,6 +59,8 @@ default_plugins: dict[str, dict] = {
     "core": {},
     "netbinds": {
     },
+    "crashes": {
+    },
     "vpn": {
     },
     "shell": {},

--- a/src/penguin/manager.py
+++ b/src/penguin/manager.py
@@ -35,6 +35,7 @@ SCORE_CATEGORIES: list[str] = [
     "nopanic",
     "script_lines_covered",
     "blocked_signals",
+    "crashes",
 ]
 
 
@@ -104,6 +105,19 @@ def calculate_score(result_dir: str, have_console: bool = True) -> dict[str, int
     elif have_console:
         logger.warning(f"{console_log_path} not found - cannot check for kernel panic.")
 
+    # --- Userland crashes (crashes.yaml from the crashes plugin) ---
+    n_crashes = 0
+    crashes_path = os.path.join(result_dir, "crashes.yaml")
+    if os.path.isfile(crashes_path):
+        try:
+            with open(crashes_path) as f:
+                crash_data = yaml.safe_load(f) or {}
+            # De-duplicated records, not total deliveries: a crash-looping
+            # service counts once per unique (proc, signal, pc).
+            n_crashes = len(crash_data.get("crashes") or [])
+        except (IOError, yaml.YAMLError) as e:
+            logger.error(f"Could not read or parse {crashes_path}: {e}")
+
     # --- Shell coverage ---
     shell_cov_path = os.path.join(result_dir, "shell_cov.csv")
     if os.path.isfile(shell_cov_path):
@@ -148,6 +162,7 @@ def calculate_score(result_dir: str, have_console: bool = True) -> dict[str, int
         "script_lines_covered": shell_cov,
         "nopanic": 1 if not panic else 0,
         "blocked_signals": blocked_signals,  # Negative because we want to minimize!
+        "crashes": -n_crashes,  # Negative because we want to minimize!
     }
 
     for k in score.keys():

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -226,6 +226,92 @@ class Snapshot(PartialModelMixin, BaseModel):
     ]
 
 
+class SharedDir(PartialModelMixin, BaseModel):
+    """Host<->guest shared directory (9p) configuration.
+
+    Accepted in ``core.shared_dir`` as ``true`` (enable with defaults), a string
+    (shorthand for ``path``), or this object. Core dumps ride the same single
+    mount (see ``core.core_dumps``); they do not need this feature enabled.
+    """
+
+    model_config = ConfigDict(title="Shared directory configuration", extra="forbid")
+
+    path: Annotated[
+        str,
+        Field(
+            "shared",
+            title="Results-relative share directory",
+            description=(
+                "Directory shared into the guest at /igloo/shared. Resolved under "
+                "the run's results dir unless core.shared_dir.host_path is set."
+            ),
+            examples=["shared", "my_shared_directory"],
+        ),
+    ]
+    host_path: Annotated[
+        Optional[str],
+        Field(
+            None,
+            title="Absolute host directory to share",
+            description=(
+                "If set, share this absolute host directory instead of a "
+                "results-relative one (path is ignored)."
+            ),
+            examples=["/data/fixtures"],
+        ),
+    ]
+    msize: Annotated[
+        Optional[int],
+        Field(
+            None,
+            title="9p msize override",
+            description=(
+                "Override the 9p transport buffer size. Unset uses the default "
+                "8MB with an automatic fallback to 128KB on memory-tight guests."
+            ),
+            examples=[8192000, 131072],
+        ),
+    ]
+
+
+class CoreDumps(PartialModelMixin, BaseModel):
+    """Guest core-dump capture configuration.
+
+    Accepted in ``core.core_dumps`` as ``true`` (enable with defaults), a string
+    (shorthand for ``pattern``), or this object. When enabled, penguin points
+    core_pattern at /igloo/core_dumps (a symlink into the shared mount) and
+    brings that mount up even when core.shared_dir is unset.
+    """
+
+    model_config = ConfigDict(title="Core dump configuration", extra="forbid")
+
+    lock: Annotated[
+        bool,
+        Field(
+            True,
+            title="Lock core_pattern",
+            description=(
+                "Install a sysctl pseudofile that eats guest writes to "
+                "core_pattern so dumps can't be redirected. Set false to let "
+                "the guest firmware keep its own core_pattern."
+            ),
+            examples=[True, False],
+        ),
+    ]
+    pattern: Annotated[
+        Optional[str],
+        Field(
+            None,
+            title="core_pattern override",
+            description=(
+                "Override the core_pattern string. Unset uses "
+                "/igloo/core_dumps/core_%e.%p."
+            ),
+            examples=["/igloo/core_dumps/core_%e.%p.%t"],
+        ),
+    ]
+
+
 class Core(PartialModelMixin, BaseModel):
     """Core configuration options for this rehosting"""
 
@@ -396,12 +482,32 @@ class Core(PartialModelMixin, BaseModel):
         ),
     ]
     shared_dir: Annotated[
-        Optional[str],
+        Optional[Union[bool, str, SharedDir]],
         Field(
             None,
-            title="Project-relative path of shared directory",
-            description="Share this directory as /igloo/shared in the guest.",
-            examples=["my_shared_directory"],
+            title="Shared directory",
+            description=(
+                "Share a directory as /igloo/shared in the guest. Accepts true "
+                "(enable with defaults), a project-relative path string, or a "
+                "SharedDir object."
+            ),
+            examples=[True, "my_shared_directory", {"path": "shared", "msize": 131072}],
+        ),
+    ]
+    core_dumps: Annotated[
+        Optional[Union[bool, str, CoreDumps]],
+        Field(
+            None,
+            title="Core dump capture",
+            description=(
+                "Capture guest core dumps to /igloo/core_dumps (a symlink into "
+                "the shared mount). Accepts true (enable with defaults), a "
+                "core_pattern string, or a CoreDumps object. Independent of "
+                "core.shared_dir. When core.core_dumps is unset but "
+                "core.shared_dir is set, core dumps are enabled for backward "
+                "compatibility (deprecated)."
+            ),
+            examples=[True, "/igloo/core_dumps/core_%e.%p", {"lock": False}],
         ),
     ]
     version: Annotated[
@@ -521,6 +627,30 @@ class Core(PartialModelMixin, BaseModel):
             examples=["ip link set eth0 up\nudhcpc -i eth0\n"],
         ),
     ]
+
+    @field_validator("shared_dir", mode="before")
+    @classmethod
+    def _norm_shared_dir(cls, v):
+        # Normalize bool/str shorthands to a SharedDir dict; false/None disable.
+        if v is None or v is False:
+            return None
+        if v is True:
+            return {}
+        if isinstance(v, str):
+            return {"path": v}
+        return v
+
+    @field_validator("core_dumps", mode="before")
+    @classmethod
+    def _norm_core_dumps(cls, v):
+        # Normalize bool/str shorthands to a CoreDumps dict; false/None disable.
+        if v is None or v is False:
+            return None
+        if v is True:
+            return {}
+        if isinstance(v, str):
+            return {"pattern": v}
+        return v
 
 
 EnvVal = _newtype(

--- a/src/penguin/penguin_run.py
+++ b/src/penguin/penguin_run.py
@@ -635,11 +635,17 @@ def run_config(
             "-display", "none",
         ]  # ttyS0: guest console output
 
-    if "shared_dir" in conf["core"]:
-        shared_dir = conf["core"]["shared_dir"]
-        if shared_dir[0] == "/":
-            shared_dir = shared_dir[1:]  # Ensure it's relative path to proj_dir
-        shared_dir = os.path.join(out_dir, shared_dir)
+    # Shared directory and core dumps both ride a single 9p mount at
+    # /igloo/shared, so provision it when either is configured. shared_dir is
+    # normalized to a dict (or absent) by the config schema.
+    shared_dir_conf = conf["core"].get("shared_dir")
+    if shared_dir_conf or conf["core"].get("core_dumps"):
+        host_path = shared_dir_conf.get("host_path") if isinstance(shared_dir_conf, dict) else None
+        if host_path:
+            shared_dir = host_path
+        else:
+            rel = shared_dir_conf.get("path", "shared") if isinstance(shared_dir_conf, dict) else "shared"
+            shared_dir = os.path.join(out_dir, rel.lstrip("/"))
         os.makedirs(shared_dir, exist_ok=True)
         args += [
             "-virtfs",

--- a/src/resources/source.d/40_mount_shared_dir.sh
+++ b/src/resources/source.d/40_mount_shared_dir.sh
@@ -1,30 +1,45 @@
-if [ ! -z "${SHARED_DIR}" ]; then
+# Always expose a stable /igloo/core_dumps path (a symlink into the shared
+# mount) so core_pattern can reference it regardless of whether the shared
+# directory feature is enabled. It dangles harmlessly when nothing is mounted.
+/igloo/utils/busybox ln -sf /igloo/shared/core_dumps /igloo/core_dumps
+
+# Bring up the shared 9p mount when either the shared-directory feature or core
+# dumps are enabled -- both ride this single mount.
+if [ ! -z "${SHARED_DIR}" ] || [ ! -z "${CORE_DUMPS}" ]; then
   unset SHARED_DIR
-  /igloo/utils/busybox mkdir /igloo/shared
+  /igloo/utils/busybox mkdir -p /igloo/shared
   echo '[IGLOO INIT] Mounting shared directory';
   # A large msize maximizes shared-dir throughput, but the per-request buffers
   # can't be allocated on memory-tight 32-bit guests (e.g. mipsel/mipseb, whose
   # limited lowmem leaves nothing for the GFP_NOFS 9p allocations -> "9pnet:
   # Couldn't grow tag array" -> ENOMEM). Fall back to a small msize so the mount
-  # still succeeds there; arches that can allocate 8MB keep the larger buffer.
-  /igloo/utils/busybox mount -t 9p -o trans=virtio igloo_shared_dir /igloo/shared -oversion=9p2000.L,posixacl,msize=8192000 || \
+  # still succeeds there; arches that can allocate the larger buffer keep it.
+  SHARED_MSIZE="${SHARED_MSIZE:-8192000}"
+  /igloo/utils/busybox mount -t 9p -o trans=virtio igloo_shared_dir /igloo/shared -oversion=9p2000.L,posixacl,msize=${SHARED_MSIZE} || \
   /igloo/utils/busybox mount -t 9p -o trans=virtio igloo_shared_dir /igloo/shared -oversion=9p2000.L,posixacl,msize=131072
+fi
 
-  # Set up core dumps
-  #
-  # This has to come before setting up the root shell,
-  # because we want the `ulimit -c unlimited` to apply for programs run inside the root shell.
+# Set up core dumps. Independent of the shared-directory feature: dumps land in
+# /igloo/shared/core_dumps via the /igloo/core_dumps symlink above.
+#
+# This has to come before setting up the root shell, because we want the
+# `ulimit -c unlimited` to apply for programs run inside the root shell.
+if [ ! -z "${CORE_DUMPS}" ]; then
+  unset CORE_DUMPS
   /igloo/utils/busybox mkdir -p /igloo/shared/core_dumps
   /igloo/utils/busybox chmod -R 1777 /igloo/shared/core_dumps
-  # Make sure the underlying file is overwritten and not a hyperfs pseudofile at that path.
-  CORE_PATTERN='/igloo/shared/core_dumps/core_%e.%p'
+  CORE_PATTERN="${CORE_DUMP_PATTERN:-/igloo/core_dumps/core_%e.%p}"
+  # Make sure the underlying file is overwritten and not a hyperfs pseudofile.
   /igloo/utils/busybox echo "$CORE_PATTERN" > /proc/sys/kernel/core_pattern
-  # Lock it in: the kernel's core_pattern[] global is now populated via the real
-  # handler; this hypercall asks penguin's core_pattern_guard plugin to install a
-  # sysctl pseudofile that eats subsequent writes, so the guest can't redirect
-  # core dumps elsewhere.
-  /igloo/utils/send_hypercall core_pattern_lock "$CORE_PATTERN" >/dev/null 2>&1 || true
-  # 2 all processes dump core when possible. The core dump is owned by the current user and no security is applied. This is intended for system debugging situations only. Ptrace is unchecked. This is insecure as it allows regular users to examine the memory contents of privileged processes.
+  if [ ! -z "${CORE_DUMPS_LOCK}" ]; then
+    unset CORE_DUMPS_LOCK
+    # Lock it in: the kernel's core_pattern[] global is now populated via the
+    # real handler; this hypercall asks penguin's core_pattern_guard plugin to
+    # install a sysctl pseudofile that eats subsequent writes, so the guest
+    # can't redirect core dumps elsewhere.
+    /igloo/utils/send_hypercall core_pattern_lock "$CORE_PATTERN" >/dev/null 2>&1 || true
+  fi
+  # 2 = all processes dump core when possible. The core dump is owned by the current user and no security is applied. This is intended for system debugging situations only. Ptrace is unchecked. This is insecure as it allows regular users to examine the memory contents of privileged processes.
   # https://sysctl-explorer.net/fs/suid_dumpable/
   /igloo/utils/busybox echo 2 > /proc/sys/fs/suid_dumpable
   ulimit -c unlimited

--- a/tests/integration/test_target/base_config.yaml
+++ b/tests/integration/test_target/base_config.yaml
@@ -7,6 +7,9 @@ core:
   version: 2
   force_www: false
   shared_dir: ./shared
+  # Core dumps are now an independent feature (not implied by shared_dir);
+  # enable them explicitly so the core_dumps / core_pattern_guard tests run.
+  core_dumps: true
   # Run with the default firmware scoping on so the default path stays covered.
   # netbinds always reports (so the gdbserver bind check still passes) and shell
   # coverage self-gates in busybox via IGLOO_NO_SHELL_COV.

--- a/tests/integration/test_target/base_config.yaml
+++ b/tests/integration/test_target/base_config.yaml
@@ -72,6 +72,7 @@ patches:
   - ./patches/tests/pseudofiles_comprehensive.yaml
   - ./patches/tests/pseudofile_ext_ops.yaml
   - ./patches/tests/signal_interception.yaml
+  - ./patches/tests/crashes.yaml
   # - ./patches/tests/uboot_env_cmp.yaml
 
 

--- a/tests/integration/test_target/patches/tests/core_pattern_guard.yaml
+++ b/tests/integration/test_target/patches/tests/core_pattern_guard.yaml
@@ -15,7 +15,7 @@ static_files:
       set -eux
       bb=/igloo/utils/busybox
 
-      expected='/igloo/shared/core_dumps/core_%e.%p'
+      expected='/igloo/core_dumps/core_%e.%p'
 
       initial=$($bb cat /proc/sys/kernel/core_pattern)
       if [ "$initial" != "$expected" ]; then

--- a/tests/integration/test_target/patches/tests/crashes.yaml
+++ b/tests/integration/test_target/patches/tests/crashes.yaml
@@ -1,0 +1,27 @@
+plugins:
+  signal_monitor: {}
+  crashes: {}
+  verifier:
+    conditions:
+      crashes+pass:
+        type: file_contains
+        file: shared/tests/crashes.sh/stdout
+        string: "/tests/crashes.sh PASS"
+      crashes+recorded:
+        type: file_contains
+        file: crashes.yaml
+        string: "signame: SIGSEGV"
+
+static_files:
+  /tests/crashes.sh:
+    type: inline_file
+    contents: |
+      #!/igloo/utils/sh
+
+      echo "Starting crashes test..."
+      # Crash a child shell with a fatal signal; the crashes plugin should
+      # record the delivery in crashes.yaml.
+      /igloo/utils/sh -c '/igloo/utils/busybox kill -SEGV $$'
+      echo "Child crashed with SIGSEGV."
+      echo "/tests/crashes.sh PASS"
+    mode: 73

--- a/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
+++ b/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
@@ -141,9 +141,16 @@ Ordered most-valuable first. Percentages are current host coverage.
    `actuation/nmap.py` ✅ (`test_nmap.py`, 27→88% — UDP short-circuit, scan-command
    construction incl. the custom-nmap redirect branch, subprocess cleanup, via a
    patched `subprocess.Popen`).
-8. **Sibling Phase-0 plugins** as they land on this branch: `crashes.yaml`
-   (draft 01) and `summary.json` (draft 02) aggregation — the harness is their
-   natural host-side test.
+8. **Sibling Phase-0 plugins** as they land on this branch:
+   - ✅ **`analysis/crashes.py`** (draft 01) — done (`test_crashes_plugin.py`):
+     fatal signal-delivery events → `crashes.yaml`, dedup on (proc, signal, pc)
+     with count, first-occurrence pid/time, watched-set filtering, and
+     `event.drop` skipping; driven through the harness by dispatching
+     `signal_deliver` with synthetic events and a `signals` double for the
+     per-arch name→number resolution. `manager.calculate_score`'s crashes
+     category is covered separately by `test_manager_score.py`. The guest
+     round-trip (dequeue_signal kretprobe → SignalMonitor) stays the
+     `tests/integration/` fixture (`crashes.yaml`).
    - ✅ **`hyperfile/pseudofile_tracker.py`** (draft 03, PR #879) — done
      (`test_pseudofile_tracker.py`, behind the FFI-enum boundary via
      `real_isf=`): the -ENOENT open/stat and -ENOTTY ioctl **generator**
@@ -157,6 +164,8 @@ Ordered most-valuable first. Percentages are current host coverage.
      with the crashes.yaml join. Guest round-trip (real ENOENT delivery,
      crash → crashes.yaml production) stays in `tests/integration/` fixtures
      (`pseudofile_missing`/`pseudofile_ioctl`/`pseudofile_ext_ops`).
+   - `summary.json` (draft 02) aggregation — the harness is its natural
+     host-side test as it lands.
 9. **`analysis/interfaces.py` + the `apis.syscalls`-importing class** ✅ done
    (`test_interfaces.py`, `analysis/interfaces.py` 4→93%) — the FFI-enum boundary,
    crossed with the **`real_isf=`** load mode. `from apis.syscalls import

--- a/tests/unit/test_core_dumps_config.py
+++ b/tests/unit/test_core_dumps_config.py
@@ -1,0 +1,125 @@
+"""
+Tests for the shared_dir / core_dumps config split:
+
+- schema normalization of core.shared_dir and core.core_dumps
+  (bool | str | dict shorthands -> canonical dicts), and
+- the env mapping in pyplugins/core/core.py that turns those into the guest
+  env vars consumed by source.d/40_mount_shared_dir.sh, including the legacy
+  "shared_dir implies core dumps" fallback.
+"""
+
+import importlib.util
+import os
+
+import pytest
+
+from penguin.penguin_config import structure
+
+CORE_PY = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../pyplugins/core/core.py")
+)
+
+
+def _load_core_module():
+    spec = importlib.util.spec_from_file_location("core_plugin", CORE_PY)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+core_mod = _load_core_module()
+env_for = core_mod.shared_dir_and_core_dump_env
+
+
+def _core(**kw):
+    kw.setdefault("version", 2)
+    return structure.Core(**kw).model_dump(exclude_none=True)
+
+
+# --- schema normalization -------------------------------------------------
+
+def test_shared_dir_bool_true_defaults():
+    assert _core(shared_dir=True)["shared_dir"] == {"path": "shared"}
+
+
+def test_shared_dir_false_disables():
+    assert "shared_dir" not in _core(shared_dir=False)
+
+
+def test_shared_dir_string_is_path_shorthand():
+    assert _core(shared_dir="mydir")["shared_dir"] == {"path": "mydir"}
+
+
+def test_shared_dir_dict_passthrough():
+    sd = _core(shared_dir={"path": "x", "host_path": "/data", "msize": 131072})
+    assert sd["shared_dir"] == {"path": "x", "host_path": "/data", "msize": 131072}
+
+
+def test_shared_dir_rejects_unknown_key():
+    with pytest.raises(Exception):
+        _core(shared_dir={"bogus": 1})
+
+
+def test_core_dumps_bool_true_defaults():
+    assert _core(core_dumps=True)["core_dumps"] == {"lock": True}
+
+
+def test_core_dumps_string_is_pattern_shorthand():
+    cd = _core(core_dumps="/p/core.%p")["core_dumps"]
+    assert cd == {"lock": True, "pattern": "/p/core.%p"}
+
+
+def test_core_dumps_dict_lock_off():
+    assert _core(core_dumps={"lock": False})["core_dumps"] == {"lock": False}
+
+
+def test_core_dumps_false_disables():
+    assert "core_dumps" not in _core(core_dumps=False)
+
+
+# --- env mapping ----------------------------------------------------------
+
+def test_env_both_unset():
+    env, deprecated = env_for(None, None)
+    assert env == {}
+    assert deprecated is False
+
+
+def test_env_shared_dir_only_is_legacy_core_dumps():
+    # shared_dir set, core_dumps unset -> mount + implicit (deprecated) dumps
+    env, deprecated = env_for({"path": "shared"}, None)
+    assert env == {"SHARED_DIR": "1", "CORE_DUMPS": "1", "CORE_DUMPS_LOCK": "1"}
+    assert deprecated is True
+
+
+def test_env_core_dumps_only_no_shared_dir():
+    # core dumps without a shared_dir: mount still comes up, not deprecated
+    env, deprecated = env_for(None, {"lock": True})
+    assert env == {"SHARED_DIR": "1", "CORE_DUMPS": "1", "CORE_DUMPS_LOCK": "1"}
+    assert deprecated is False
+
+
+def test_env_explicit_core_dumps_false_wins_over_shared_dir():
+    # explicit disable beats the legacy implicit-enable
+    env, deprecated = env_for({"path": "shared"}, None)
+    assert deprecated is True  # sanity: implicit path
+    env2, deprecated2 = env_for({"path": "shared"}, False)
+    assert env2 == {"SHARED_DIR": "1"}
+    assert "CORE_DUMPS" not in env2
+    assert deprecated2 is False
+
+
+def test_env_lock_off_omits_lock():
+    env, _ = env_for(None, {"lock": False})
+    assert env["CORE_DUMPS"] == "1"
+    assert "CORE_DUMPS_LOCK" not in env
+
+
+def test_env_pattern_passed_through():
+    env, _ = env_for(None, {"lock": True, "pattern": "/c/core.%p.%t"})
+    assert env["CORE_DUMP_PATTERN"] == "/c/core.%p.%t"
+
+
+def test_env_msize_passed_through():
+    env, _ = env_for({"path": "shared", "msize": 131072}, True)
+    assert env["SHARED_MSIZE"] == "131072"

--- a/tests/unit/test_crashes_plugin.py
+++ b/tests/unit/test_crashes_plugin.py
@@ -1,0 +1,132 @@
+"""Host-side test of the crashes plugin (pyplugins/analysis/crashes.py) driven
+through the `penguin.testing` harness — no PANDA, no guest, no per-arch boot.
+
+The crashes plugin is signal-based: igloo_driver kretprobes `dequeue_signal`,
+SignalMonitor publishes a "signal_deliver" event, and this plugin aggregates
+fatal deliveries into crashes.yaml (dedup on (proc, signal, pc) with a count).
+That aggregation is pure host logic, so we drive the subscribed handler with
+synthetic events and assert on the file. The guest round-trip (kretprobe ->
+hypercall -> SignalMonitor) stays the tests/integration/ fixture (crashes.yaml).
+"""
+from pathlib import Path
+
+import yaml
+
+from penguin.testing import load_pyplugin
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CRASHES = REPO_ROOT / "pyplugins" / "analysis" / "crashes.py"
+
+
+class FakeSignals:
+    """Double for the `signals` sibling: crashes.__init__ resolves each watched
+    signal name to its guest number via plugins.signals.signal_name_to_num."""
+
+    TABLE = {"SIGSEGV": 11, "SIGABRT": 6, "SIGBUS": 7, "SIGILL": 4,
+             "SIGFPE": 8, "SIGSYS": 31, "SIGHUP": 1}
+
+    def signal_name_to_num(self, name):
+        return self.TABLE.get(name)
+
+
+class FakeEvent:
+    """The `struct signal_event` shape the SignalMonitor publishes."""
+
+    def __init__(self, sig, comm, pid, pc, drop=False, regs=None):
+        self.sig = sig
+        self.comm = comm
+        self.pid = pid
+        self.pc = pc
+        self.drop = drop
+        self.regs = regs
+
+
+def _load(tmp_path, signals=("SIGSEGV", "SIGABRT")):
+    return load_pyplugin(
+        str(CRASHES),
+        outdir=str(tmp_path),
+        args={"signals": list(signals)},
+        doubles={"signals": FakeSignals()},
+    )
+
+
+def _records(tmp_path):
+    with open(tmp_path / "crashes.yaml") as f:
+        return yaml.safe_load(f)["crashes"]
+
+
+def test_subscription_and_hooks_wired(tmp_path):
+    lp = _load(tmp_path)
+    # Subscribed to the delivery event, and resolved names -> guest numbers.
+    assert "signal_deliver" in {ev for (_p, ev, _c) in lp.subscriptions}
+    assert lp.plugin.signames == {11: "SIGSEGV", 6: "SIGABRT"}
+    # Registered one guest hook per watched signal (recorded on the stub).
+    hooked = [c for c in lp.calls if "register_hook" in c[0]]
+    assert len(hooked) == 2
+
+
+def test_empty_report_written_at_init(tmp_path):
+    _load(tmp_path)
+    assert _records(tmp_path) == []
+
+
+def test_records_watched_delivery(tmp_path):
+    lp = _load(tmp_path)
+    lp.dispatch("signal_deliver", None, FakeEvent(11, "httpd", 412, 0x4013A8))
+    (rec,) = _records(tmp_path)
+    assert rec["proc"] == "httpd"
+    assert rec["pid"] == 412
+    assert rec["signal"] == 11
+    assert rec["signame"] == "SIGSEGV"
+    assert rec["pc"] == "0x004013a8"
+    assert rec["count"] == 1
+
+
+def test_dedupes_identical_proc_signal_pc(tmp_path):
+    lp = _load(tmp_path)
+    for _ in range(3):
+        lp.dispatch("signal_deliver", None, FakeEvent(11, "httpd", 412, 0x4013A8))
+    (rec,) = _records(tmp_path)
+    assert rec["count"] == 3
+
+
+def test_pid_and_time_are_first_occurrence(tmp_path):
+    lp = _load(tmp_path)
+    lp.dispatch("signal_deliver", None, FakeEvent(11, "httpd", 412, 0x4013A8))
+    # Same (proc, signal, pc) from a respawned pid folds into the record.
+    lp.dispatch("signal_deliver", None, FakeEvent(11, "httpd", 500, 0x4013A8))
+    (rec,) = _records(tmp_path)
+    assert rec["count"] == 2
+    assert rec["pid"] == 412
+
+
+def test_distinct_pc_or_signal_are_separate_records(tmp_path):
+    lp = _load(tmp_path)
+    lp.dispatch("signal_deliver", None, FakeEvent(11, "httpd", 412, 0x4013A8))
+    lp.dispatch("signal_deliver", None, FakeEvent(11, "httpd", 412, 0x4013AC))
+    lp.dispatch("signal_deliver", None, FakeEvent(6, "httpd", 412, 0x4013A8))
+    recs = _records(tmp_path)
+    assert len(recs) == 3
+    assert all(r["count"] == 1 for r in recs)
+
+
+def test_unwatched_signal_ignored(tmp_path):
+    lp = _load(tmp_path)
+    # SIGHUP is a real signal but not in the watched set for this run.
+    lp.dispatch("signal_deliver", None, FakeEvent(1, "httpd", 412, 0x4013A8))
+    assert _records(tmp_path) == []
+
+
+def test_dropped_delivery_ignored(tmp_path):
+    lp = _load(tmp_path)
+    # A prior subscriber bypassed this delivery (event.drop) -> not a crash.
+    lp.dispatch("signal_deliver", None, FakeEvent(11, "httpd", 412, 0x4013A8, drop=True))
+    assert _records(tmp_path) == []
+
+
+def test_finalize_rewrites_report(tmp_path):
+    lp = _load(tmp_path)
+    lp.dispatch("signal_deliver", None, FakeEvent(11, "httpd", 412, 0x4013A8))
+    lp.finalize()  # uninit() rewrites crashes.yaml
+    (rec,) = _records(tmp_path)
+    assert rec["signame"] == "SIGSEGV"

--- a/tests/unit/test_manager_score.py
+++ b/tests/unit/test_manager_score.py
@@ -1,0 +1,53 @@
+"""
+Tests for penguin.manager.calculate_score, focused on the crashes category
+(crashes.yaml written by the crashes plugin).
+"""
+
+import pytest
+import yaml
+
+from penguin.manager import SCORE_CATEGORIES, calculate_score
+
+
+@pytest.fixture
+def result_dir(tmp_path):
+    """A minimal valid result dir: just the .ran marker."""
+    (tmp_path / ".ran").touch()
+    return tmp_path
+
+
+def test_score_has_all_categories(result_dir):
+    score = calculate_score(str(result_dir), have_console=False)
+    assert set(score.keys()) == set(SCORE_CATEGORIES)
+
+
+def test_crashes_score_missing_file(result_dir):
+    score = calculate_score(str(result_dir), have_console=False)
+    assert score["crashes"] == 0
+
+
+def test_crashes_score_empty_report(result_dir):
+    (result_dir / "crashes.yaml").write_text("crashes: []\n")
+    score = calculate_score(str(result_dir), have_console=False)
+    assert score["crashes"] == 0
+
+
+def test_crashes_score_counts_deduped_records(result_dir):
+    records = [
+        {"proc": "httpd", "pid": 412, "signal": 11, "signame": "SIGSEGV",
+         "pc": "0x004013a8", "time": 12.481, "count": 3},
+        {"proc": "upnpd", "pid": 500, "signal": 6, "signame": "SIGABRT",
+         "pc": "0x00021bcc", "time": 20.1, "count": 1},
+    ]
+    with open(result_dir / "crashes.yaml", "w") as f:
+        yaml.safe_dump({"crashes": records}, f, sort_keys=False)
+
+    score = calculate_score(str(result_dir), have_console=False)
+    # Negative, and per unique record -- not per delivery (count is ignored).
+    assert score["crashes"] == -2
+
+
+def test_crashes_score_corrupt_file(result_dir):
+    (result_dir / "crashes.yaml").write_text("{not valid: yaml: [")
+    score = calculate_score(str(result_dir), have_console=False)
+    assert score["crashes"] == 0


### PR DESCRIPTION
Implements planning draft 01 (crash/signal reporter). Today the only crash signal Penguin records is a kernel panic; a guest process dying from SIGSEGV leaves no artifact. This adds a `crashes` analysis plugin that records fatal signal deliveries to `crashes.yaml` and surfaces them in the run score.

## What it does

- New `pyplugins/analysis/crashes.py` subscribes to the existing `signal_monitor` "signal_deliver" hook and registers one guest hook per watched signal (only those deliveries trap out of the guest).
- Default signal set: SIGSEGV, SIGBUS, SIGILL, SIGABRT, SIGFPE, SIGSYS — configurable via a `signals:` list of names. Names, not numbers: numbering is resolved per guest arch via the `signals` plugin (MIPS differs).
- Records `proc`, `pid`, `signal`, `signame`, `pc` (hex string), `time` (host wall-clock seconds since emulation start, first occurrence), `count` — de-duplicating identical `(proc, signal, pc)` deliveries, mirroring netbinds. File is rewritten per event; `crashes: []` is written at startup so consumers can rely on it existing.
- The recorded `pc` comes from `task_pt_regs` at delivery time; for synchronous faults that is the exception trap frame, i.e. the faulting instruction.
- `manager.calculate_score` gains a negative `crashes` category (unique records, minimized like `blocked_signals`) so a crashing service shows in the score, not just panics.
- Enabled in `default_plugins`; documented in `docs/plugins.md`.
- Deliveries another plugin already marked dropped (`event.drop`, e.g. a SIGILL-bypass consumer) are not recorded.

## Known limitation (documented)

The driver hook is a kretprobe on `dequeue_signal`, which fires before the kernel applies the signal's disposition, and the event carries no handler/SIG_DFL information — so a process that *catches* a fatal-class signal and survives is still recorded. Rows in `crashes.yaml` mean "a fatal-class signal was delivered", not proof of termination. This is called out prominently in the plugin docstring and `docs/plugins.md`; distinguishing perfectly would need a handler-installed bit added to the driver's `signal_event`.

## Tests

- `tests/unit_tests/test_crashes_plugin.py` — plugin dedupe/count/filter/drop logic with fake events (7 tests).
- `tests/unit_tests/test_manager_score.py` — `crashes` score category incl. missing/empty/corrupt file handling (5 tests).
- Guest test `patches/tests/crashes.yaml` — a child shell takes a real SIGSEGV; verifier asserts the record appears in `crashes.yaml`. Verified end-to-end on armel/4.10 (incl. under `analysis_scope: firmware`).