### PR TITLE
pseudofile_tracker: rank failures by impact + suggest starting models

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -114,7 +114,10 @@ Logs are written to `nmap_{protocol}_{port}.log`
 
 ## Pseudofiles
 This plugin tracks accesses and interactions with files in `/dev/` and `/proc/`.
-In `pseudofiles_failures.yaml` details of failed interactions are reported.
+In `pseudofiles_failures.yaml` details of failed interactions are reported,
+ranked by impact (`crashing_callers` >> `distinct_callers` > `hits`), with the
+observed calling processes and a suggested starting model per path that can be
+pasted directly into the `pseudofiles` config section.
 
 Users can add pseudofiles and configure models for reads, writes, and IOCTLs on
 these files by adding entries into the `pseudofiles` config section. See the

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -288,10 +288,20 @@ see that some `ioctl` errors are reported instead for ioctl number 1074029569 (0
 
 ```yaml
 /dev/dsa:
-  ioctl:
-    1074029569:
-      count: 40
+  impact: {hits: 40, distinct_callers: 1, crashing_callers: 0}
+  callers: [dsad:412]
+  events:
+    ioctl:
+      1074029569:
+        count: 40
+  suggest:
+    ioctl:
+      '*': {model: return_const, val: 0}
 ```
+
+Entries are ranked by impact (crashing callers, then distinct callers, then raw
+hits), and each comes with a `suggest` block: a heuristic starting model you can
+paste directly under the path in your config's `pseudofiles:` section.
 
 We can update our `/dev/dsa` pseudofile to simply return 0 or "success" on this ioctl:
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -288,7 +288,7 @@ see that some `ioctl` errors are reported instead for ioctl number 1074029569 (0
 
 ```yaml
 /dev/dsa:
-  impact: {hits: 40, distinct_callers: 1, crashing_callers: 0}
+  impact: {hits: 40, distinct_callers: 1, crashing_callers: 0, crashing_callers_by_name: 0}
   callers: [dsad:412]
   events:
     ioctl:

--- a/pyplugins/hyperfile/pseudofile_tracker.py
+++ b/pyplugins/hyperfile/pseudofile_tracker.py
@@ -9,8 +9,31 @@ Purpose
 -------
 
 - Monitors syscalls for -ENOENT and -ENOTTY to track missing pseudofile accesses.
-- Logs access attempts to missing files in `pseudofiles_failures.yaml`.
+- Logs access attempts to missing files in `pseudofiles_failures.yaml`, ranked
+  by impact and annotated with a suggested starting model per path.
 - Exports the currently configured pseudofile models to `pseudofiles_modeled.yaml`.
+
+Output format
+-------------
+
+Entries in `pseudofiles_failures.yaml` are ranked by impact
+(crashing_callers >> distinct_callers > hits):
+
+```yaml
+/dev/watchdog:
+  impact: {hits: 243, distinct_callers: 2, crashing_callers: 0}
+  callers: [init:1, watchdogd:412]
+  events:
+    ioctl:
+      2147768064: {count: 240}
+    open: {count: 3}
+  suggest:
+    read: {model: zero}
+    ioctl: {'*': {model: return_const, val: 0}}
+```
+
+`suggest` is a valid `pseudofiles:` value: paste it into your config as
+`pseudofiles: {<path>: <suggest block>}` and refine from there.
 
 Usage
 -----
@@ -36,6 +59,29 @@ outfile_missing = "pseudofiles_failures.yaml"
 outfile_models = "pseudofiles_modeled.yaml"
 
 AT_FDCWD = -100
+
+O_ACCMODE = 0o3
+O_WRONLY = 0o1
+O_RDWR = 0o2
+
+# Impact-score weights: any crashing caller outranks any realistic number of
+# distinct callers, which in turn outrank any raw hit count.
+SCORE_CRASHING_CALLER = 1_000_000
+SCORE_DISTINCT_CALLER = 1_000
+
+failures_header = """\
+# Guest accesses to unmodeled /dev, /proc, and /sys paths, ranked by impact
+# (crashing_callers >> distinct_callers > hits).
+#
+# Each entry's `suggest` block is a heuristic starting model and is a valid
+# `pseudofiles:` value -- paste it into your config as:
+#   pseudofiles:
+#     <path>:
+#       <suggest block>
+# then refine: swap a `zero` read for `const_buf` with real contents when a
+# parser consumes the file, and confirm ioctl return values against the real
+# driver's semantics.
+"""
 
 mem = plugins.mem
 syscalls = plugins.syscalls
@@ -91,6 +137,48 @@ def sort_file_failures(d):
         )
         if isinstance(d, dict) else d
     )
+
+
+def open_access_intents(flags: int) -> set:
+    """Map open(2) flags to the access intents implied by O_ACCMODE."""
+    acc = flags & O_ACCMODE
+    if acc == O_WRONLY:
+        return {"write"}
+    if acc == O_RDWR:
+        return {"read", "write"}
+    return {"read"}
+
+
+def impact_score(impact: dict) -> int:
+    return (
+        impact["crashing_callers"] * SCORE_CRASHING_CALLER
+        + impact["distinct_callers"] * SCORE_DISTINCT_CALLER
+        + impact["hits"]
+    )
+
+
+def suggest_models(events: dict, intents: set) -> dict:
+    """
+    Heuristic starting model for a failing path, shaped as a valid
+    `pseudofiles:` value so it pastes straight into a config.
+
+    - open/stat ENOENT with read intent (or unknown intent) -> read: zero.
+      The failure happens at open time, before any read size is observable,
+      so small vs. large reads can't be distinguished here; `zero` (a
+      one-byte "0" then EOF) is the safe default and the file header points
+      users at const_buf when real contents matter.
+    - open ENOENT with write intent -> write: discard.
+    - ioctl ENOTTY -> catch-all return_const 0.
+    """
+    suggest = {}
+    if "open" in events:
+        if not intents or "read" in intents:
+            suggest["read"] = {"model": "zero"}
+        if "write" in intents:
+            suggest["write"] = {"model": "discard"}
+    if "ioctl" in events:
+        suggest["ioctl"] = {"*": {"model": "return_const", "val": 0}}
+    return suggest
 
 
 class PseudofileTracker(Plugin):
@@ -202,7 +290,7 @@ class PseudofileTracker(Plugin):
             filename = yield from mem.read_str(filename_ptr)
             if filename:
                 path = yield from self._resolve_absolute_path(AT_FDCWD, filename)
-                self.centralized_log(path, "open")
+                yield from self._log_open_failure(proto, path, args)
 
     def _handle_enoent_arg1(self, regs, proto, syscall, dfd_raw, filename_ptr, *args):
         """Triggered when arg1 syscalls fail with -ENOENT."""
@@ -213,15 +301,47 @@ class PseudofileTracker(Plugin):
             filename = yield from mem.read_str(filename_ptr)
             if filename:
                 path = yield from self._resolve_absolute_path(dfd, filename)
-                self.centralized_log(path, "open")
+                yield from self._log_open_failure(proto, path, args)
 
     def _handle_ioctl_enotty(self, regs, proto, syscall, fd_arg, cmd, arg):
         """Triggered when ioctl returns -ENOTTY (-25)."""
         ret = self.panda.from_unsigned_guest(syscall.retval)
         if ret == -25:
             path = yield from osi.get_fd_name(fd_arg)
-            if path and path_interesting(path):
-                self.log_ioctl_failure(path, cmd)
+            if not path or not path_interesting(path):
+                return
+            if ignore_ioctl_path(path) or ignore_cmd(cmd):
+                return
+            caller = yield from self._get_caller()
+            self.log_ioctl_failure(path, cmd, caller=caller)
+
+    def _log_open_failure(self, proto, path, args):
+        """Filter, attribute, and record an -ENOENT path failure."""
+        path = self._normalize_path(path)
+        if path is None:
+            return
+        caller = yield from self._get_caller()
+        self.centralized_log(path, "open", caller=caller,
+                             intents=self._open_intents(proto, args))
+
+    def _open_intents(self, proto, args) -> set:
+        """Access intents from the failing syscall, when it exposes them."""
+        if proto.name in ("sys_open", "sys_openat") and args:
+            return open_access_intents(args[0])
+        if proto.name == "sys_creat":
+            return {"write"}
+        # stat/access/readlink and openat2 carry no O_ACCMODE flags
+        return set()
+
+    def _get_caller(self):
+        """Identify the current process as 'name:pid' (one portal round-trip)."""
+        try:
+            proc = yield from osi.get_proc()
+            if proc is not None:
+                return f"{proc.name}:{proc.pid}"
+        except Exception as e:
+            self.logger.debug(f"Failed to resolve calling process: {e}")
+        return None
 
     def record_default_hit(self, path, op, details=None):
         """Record that a synthesized default model actively served an access.
@@ -240,46 +360,46 @@ class PseudofileTracker(Plugin):
 
     # --- Telemetry & Logging Methods ---
 
-    def centralized_log(self, path, event, event_details=None):
+    def _normalize_path(self, path):
+        """Filter to pseudofile candidates; collapse PID paths to prevent log explosion."""
         if not path_interesting(path):
-            return
+            return None
+        return re.sub(r"/proc/\d+", "/proc/PID", path)
 
-        if path.startswith("/proc/"):
-            # Collapse PID paths to prevent log explosion
-            path = re.sub(r"/proc/\d+", "/proc/PID", path)
+    def _record_for(self, path):
+        return self.file_failures.setdefault(
+            path, {"events": {}, "callers": set(), "intents": set()}
+        )
 
-        if path not in self.file_failures:
-            self.file_failures[path] = {}
+    def centralized_log(self, path, event, caller=None, intents=None, event_details=None):
+        record = self._record_for(path)
 
-        if event not in self.file_failures[path]:
-            self.file_failures[path][event] = {"count": 0}
+        first = event not in record["events"]
+        ev = record["events"].setdefault(event, {"count": 0})
+        ev["count"] += 1
 
-        if "count" not in self.file_failures[path][event]:
-            self.file_failures[path][event]["count"] = 0
-
-        self.file_failures[path][event]["count"] += 1
+        if caller:
+            record["callers"].add(caller)
+        if intents:
+            record["intents"].update(intents)
 
         if event_details is not None:
-            if "details" not in self.file_failures[path][event]:
-                self.file_failures[path][event]["details"] = []
-            self.file_failures[path][event]["details"].append(event_details)
+            ev.setdefault("details", []).append(event_details)
 
-    def log_ioctl_failure(self, path, cmd):
-        if ignore_ioctl_path(path) or ignore_cmd(cmd):
-            return
+        if first and self.log_missing:
+            # Flush eagerly so results survive runs that never reach uninit
+            # (SIGKILL, emulator crash) -- see rehosting/penguin#175.
+            self.dump_results()
 
-        if path not in self.file_failures:
-            self.file_failures[path] = {}
+    def log_ioctl_failure(self, path, cmd, caller=None):
+        record = self._record_for(path)
+        ioctls = record["events"].setdefault("ioctl", {})
 
-        if "ioctl" not in self.file_failures[path]:
-            self.file_failures[path]["ioctl"] = {}
+        first = cmd not in ioctls
+        ioctls.setdefault(cmd, {"count": 0})["count"] += 1
 
-        first = False
-        if cmd not in self.file_failures[path]["ioctl"]:
-            self.file_failures[path]["ioctl"][cmd] = {"count": 0}
-            first = True
-
-        self.file_failures[path]["ioctl"][cmd]["count"] += 1
+        if caller:
+            record["callers"].add(caller)
 
         if first:
             # Output intermediate results when a new missing IOCTL is detected
@@ -287,13 +407,50 @@ class PseudofileTracker(Plugin):
                 self.dump_results()
             self.logger.debug(f"New ioctl failure observed: {cmd:x} on {path}")
 
+    def _render_failures(self):
+        """Shape internal state into the impact-ranked on-disk format."""
+        rendered = {}
+        for path, record in self.file_failures.items():
+            events = sort_file_failures(record["events"])
+            impact = {
+                "hits": get_total_counts(events),
+                "distinct_callers": len(record["callers"]),
+                # Joined against crashes.yaml once crash tracking lands;
+                # always emitted so consumers (summary.json) can rely on it.
+                "crashing_callers": 0,
+            }
+            entry = {"impact": impact}
+            if record["callers"]:
+                entry["callers"] = sorted(record["callers"])
+            entry["events"] = events
+            suggest = suggest_models(record["events"], record["intents"])
+            if suggest:
+                entry["suggest"] = suggest
+            rendered[path] = entry
+
+        return dict(
+            sorted(
+                rendered.items(),
+                key=lambda pair: impact_score(pair[1]["impact"]),
+                reverse=True,
+            )
+        )
+
     def dump_results(self):
-        """Flushes the sorted failures telemetry to disk."""
+        """Flushes the impact-ranked failures telemetry to disk."""
         if not self.outdir:
             return
+        text = yaml.dump(self._render_failures(), sort_keys=False)
+        # PyYAML can't emit comments, so annotate the suggest keys post-hoc.
+        text = re.sub(
+            r"^(\s+suggest:)$",
+            r"\1  # TODO: heuristic starting point -- verify before relying on it",
+            text,
+            flags=re.MULTILINE,
+        )
         with open(pjoin(self.outdir, outfile_missing), "w") as f:
-            out = sort_file_failures(self.file_failures)
-            yaml.dump(out, f, sort_keys=False)
+            f.write(failures_header)
+            f.write(text)
 
     def uninit(self):
         """Plugin teardown logic ensures final metrics are written."""

--- a/pyplugins/hyperfile/pseudofile_tracker.py
+++ b/pyplugins/hyperfile/pseudofile_tracker.py
@@ -21,7 +21,7 @@ Entries in `pseudofiles_failures.yaml` are ranked by impact
 
 ```yaml
 /dev/watchdog:
-  impact: {hits: 243, distinct_callers: 2, crashing_callers: 0}
+  impact: {hits: 243, distinct_callers: 2, crashing_callers: 1, crashing_callers_by_name: 0}
   callers: [init:1, watchdogd:412]
   events:
     ioctl:
@@ -65,14 +65,18 @@ O_ACCMODE = 0o3
 O_WRONLY = 0o1
 O_RDWR = 0o2
 
-# Impact-score weights: any crashing caller outranks any realistic number of
-# distinct callers, which in turn outrank any raw hit count.
+# Impact-score weights: an exactly-matched crashing caller outranks any
+# realistic number of distinct callers, which in turn outrank any raw hit
+# count. Name-only crash matches (pid recycled or comm changed between the
+# access and the fault) are weighted far lower so a single crash of a common
+# name (sh, init, busybox) can't reorder the whole file.
 SCORE_CRASHING_CALLER = 1_000_000
+SCORE_CRASHING_BY_NAME = 10_000
 SCORE_DISTINCT_CALLER = 1_000
 
 failures_header = """\
 # Guest accesses to unmodeled /dev, /proc, and /sys paths, ranked by impact
-# (crashing_callers >> distinct_callers > hits).
+# (crashing_callers >> crashing_callers_by_name >> distinct_callers > hits).
 #
 # Each entry's `suggest` block is a heuristic starting model and is a valid
 # `pseudofiles:` value -- paste it into your config as:
@@ -178,21 +182,27 @@ def load_crashes(path: str):
     return pairs, names
 
 
-def count_crashing_callers(callers: set, crash_pairs: set, crash_names: set) -> int:
+def count_crashing_callers(callers: set, crash_pairs: set, crash_names: set):
     """
-    Distinct callers of a path that later crashed. Prefer the exact
-    (proc, pid) match; fall back to the proc name alone so a crash whose pid
-    was recycled between the access and the fault still joins.
+    Distinct callers of a path that later crashed, as (exact, by_name):
+    callers whose (proc, pid) matches a crash record, and callers matching a
+    crashed proc name only (pid recycled between the access and the fault).
+    Reported and weighted separately -- a name-only match is a much weaker
+    signal.
     """
-    return sum(
-        1 for name, pid in callers
-        if (name, pid) in crash_pairs or name in crash_names
-    )
+    exact = by_name = 0
+    for name, pid in callers:
+        if (name, pid) in crash_pairs:
+            exact += 1
+        elif name in crash_names:
+            by_name += 1
+    return exact, by_name
 
 
 def impact_score(impact: dict) -> int:
     return (
         impact["crashing_callers"] * SCORE_CRASHING_CALLER
+        + impact["crashing_callers_by_name"] * SCORE_CRASHING_BY_NAME
         + impact["distinct_callers"] * SCORE_DISTINCT_CALLER
         + impact["hits"]
     )
@@ -394,8 +404,11 @@ class PseudofileTracker(Plugin):
         """
         if not self.log_missing:
             return
+        path = self._normalize_path(path)
+        if path is None:
+            return
         event = f"default_{op}"
-        self.centralized_log(path, event, details or None)
+        self.centralized_log(path, event, event_details=details or None)
         self.logger.debug(f"Default model served {op} on {path} {details or ''}")
         self.dump_results()
 
@@ -457,12 +470,14 @@ class PseudofileTracker(Plugin):
         rendered = {}
         for path, record in self.file_failures.items():
             events = sort_file_failures(record["events"])
+            crashing, crashing_by_name = count_crashing_callers(
+                record["callers"], crash_pairs, crash_names
+            )
             impact = {
                 "hits": get_total_counts(events),
                 "distinct_callers": len(record["callers"]),
-                "crashing_callers": count_crashing_callers(
-                    record["callers"], crash_pairs, crash_names
-                ),
+                "crashing_callers": crashing,
+                "crashing_callers_by_name": crashing_by_name,
             }
             entry = {"impact": impact}
             if record["callers"]:

--- a/pyplugins/hyperfile/pseudofile_tracker.py
+++ b/pyplugins/hyperfile/pseudofile_tracker.py
@@ -57,6 +57,7 @@ from apis.syscalls import ValueFilter
 
 outfile_missing = "pseudofiles_failures.yaml"
 outfile_models = "pseudofiles_modeled.yaml"
+crashes_file = "crashes.yaml"  # written by the crashes plugin (may be absent)
 
 AT_FDCWD = -100
 
@@ -147,6 +148,46 @@ def open_access_intents(flags: int) -> set:
     if acc == O_RDWR:
         return {"read", "write"}
     return {"read"}
+
+
+def load_crashes(path: str):
+    """
+    Parse the crashes plugin's crashes.yaml into join keys.
+
+    Returns (pairs, names): the set of (proc, pid) tuples and the set of proc
+    names that crashed. Tolerates a missing/empty file (this plugin may run
+    without crash tracking) and both the `{crashes: [...]}` dict and a bare
+    list of records.
+    """
+    pairs, names = set(), set()
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError:
+        return pairs, names
+    if isinstance(data, dict):
+        data = data.get("crashes")
+    if not isinstance(data, list):
+        return pairs, names
+    for crash in data:
+        if not isinstance(crash, dict) or "proc" not in crash:
+            continue
+        names.add(crash["proc"])
+        if isinstance(crash.get("pid"), int):
+            pairs.add((crash["proc"], crash["pid"]))
+    return pairs, names
+
+
+def count_crashing_callers(callers: set, crash_pairs: set, crash_names: set) -> int:
+    """
+    Distinct callers of a path that later crashed. Prefer the exact
+    (proc, pid) match; fall back to the proc name alone so a crash whose pid
+    was recycled between the access and the fault still joins.
+    """
+    return sum(
+        1 for name, pid in callers
+        if (name, pid) in crash_pairs or name in crash_names
+    )
 
 
 def impact_score(impact: dict) -> int:
@@ -334,11 +375,11 @@ class PseudofileTracker(Plugin):
         return set()
 
     def _get_caller(self):
-        """Identify the current process as 'name:pid' (one portal round-trip)."""
+        """Identify the current process as (name, pid) (one portal round-trip)."""
         try:
             proc = yield from osi.get_proc()
             if proc is not None:
-                return f"{proc.name}:{proc.pid}"
+                return (proc.name, proc.pid)
         except Exception as e:
             self.logger.debug(f"Failed to resolve calling process: {e}")
         return None
@@ -409,19 +450,25 @@ class PseudofileTracker(Plugin):
 
     def _render_failures(self):
         """Shape internal state into the impact-ranked on-disk format."""
+        # Re-read on every flush so crashes that happen after an access are
+        # reflected in later dumps (and in the final one at uninit).
+        crash_pairs, crash_names = load_crashes(pjoin(self.outdir, crashes_file))
+
         rendered = {}
         for path, record in self.file_failures.items():
             events = sort_file_failures(record["events"])
             impact = {
                 "hits": get_total_counts(events),
                 "distinct_callers": len(record["callers"]),
-                # Joined against crashes.yaml once crash tracking lands;
-                # always emitted so consumers (summary.json) can rely on it.
-                "crashing_callers": 0,
+                "crashing_callers": count_crashing_callers(
+                    record["callers"], crash_pairs, crash_names
+                ),
             }
             entry = {"impact": impact}
             if record["callers"]:
-                entry["callers"] = sorted(record["callers"])
+                entry["callers"] = [
+                    f"{name}:{pid}" for name, pid in sorted(record["callers"])
+                ]
             entry["events"] = events
             suggest = suggest_models(record["events"], record["intents"])
             if suggest:

--- a/tests/integration/test_target/patches/tests/pseudofile_ioctl.yaml
+++ b/tests/integration/test_target/patches/tests/pseudofile_ioctl.yaml
@@ -8,16 +8,24 @@ plugins:
       pseudofile_ioctl+failures:
         type: yaml_contains 
         file: pseudofiles_failures.yaml
-        subkeys: 
+        subkeys:
           /dev/foo/present:
-            ioctl:
-              799: {}
+            events:
+              ioctl:
+                799: {}
           /dev/fs/present:
-            ioctl:
-              799: {}
+            events:
+              ioctl:
+                799: {}
           /dev/present:
-            ioctl:
-              799: {}
+            impact: {}
+            events:
+              ioctl:
+                799: {}
+            suggest:
+              ioctl:
+                '*':
+                  model: return_const
 
 pseudofiles:
   /dev/present: {}

--- a/tests/integration/test_target/patches/tests/pseudofile_missing.yaml
+++ b/tests/integration/test_target/patches/tests/pseudofile_missing.yaml
@@ -14,10 +14,13 @@ plugins:
           -  /dev/foo/missing
           -  /proc/missing
           -  /proc/fs/missing
-          # -  /proc/foo/missing
+          -  /proc/foo/missing
           -  /sys/missing
           -  /sys/fs/missing
           -  /sys/foo/missing
+          # New impact/suggest schema keys (rank-by-impact + model suggestion)
+          -  "distinct_callers:"
+          -  "suggest:"
 
 static_files:
   /tests/pseudofile_missing.sh:

--- a/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
+++ b/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
@@ -144,6 +144,19 @@ Ordered most-valuable first. Percentages are current host coverage.
 8. **Sibling Phase-0 plugins** as they land on this branch: `crashes.yaml`
    (draft 01) and `summary.json` (draft 02) aggregation — the harness is their
    natural host-side test.
+   - ✅ **`hyperfile/pseudofile_tracker.py`** (draft 03, PR #879) — done
+     (`test_pseudofile_tracker.py`, behind the FFI-enum boundary via
+     `real_isf=`): the -ENOENT open/stat and -ENOTTY ioctl **generator**
+     handlers via the syscall pump with `mem`/`osi` doubles (caller
+     attribution, O_ACCMODE intent, relative-dfd resolution, `/proc/PID`
+     collapse, TTY/proc ioctl filters), the pure ranking/suggest helpers
+     (`impact_score` tiers, `suggest_models`, `load_crashes` tolerance,
+     `count_crashing_callers` exact-vs-by-name), `record_default_hit`
+     provenance (the Pseudofiles `default_hit_cb` contract), the eager flush
+     (#175 durability), and end-to-end `pseudofiles_failures.yaml` ranking
+     with the crashes.yaml join. Guest round-trip (real ENOENT delivery,
+     crash → crashes.yaml production) stays in `tests/integration/` fixtures
+     (`pseudofile_missing`/`pseudofile_ioctl`/`pseudofile_ext_ops`).
 9. **`analysis/interfaces.py` + the `apis.syscalls`-importing class** ✅ done
    (`test_interfaces.py`, `analysis/interfaces.py` 4→93%) — the FFI-enum boundary,
    crossed with the **`real_isf=`** load mode. `from apis.syscalls import

--- a/tests/unit/test_pseudofile_tracker.py
+++ b/tests/unit/test_pseudofile_tracker.py
@@ -1,294 +1,271 @@
-"""
-Unit tests for the pure helpers in pyplugins/hyperfile/pseudofile_tracker.py:
-impact ranking, model suggestion, crashes.yaml parsing/joining, and the
-rendered output format.
+"""In-place harness coverage for the pseudofile tracker
+(pyplugins/hyperfile/pseudofile_tracker.py), driven host-side with no
+PANDA/guest.
 
-The plugin module expects the in-container plugin runtime (penguin.plugins,
-apis.syscalls) at import time, so it is imported here with those stubbed out;
-the helpers under test are pure Python.
-"""
+The tracker sits behind the FFI-enum boundary (``from apis.syscalls import
+ValueFilter``), so it loads with ``real_isf=``. Its host-side logic is what the
+guest-boot matrix ultimately asserts on: the ``pseudofiles_failures.yaml``
+impact ranking (crashing_callers >> crashing_callers_by_name >>
+distinct_callers > hits), caller attribution, the crashes.yaml join, the
+suggested starting models, and the default-model provenance events
+(record_default_hit) that the Pseudofiles plugin forwards.
 
-import importlib.util
-import logging
-import sys
-import types
+The -ENOENT/-ENOTTY syscall handlers are portal generators; they are driven
+through ``dispatch_syscall`` with ``mem``/``osi`` generator doubles.
+"""
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
-import yaml as real_yaml
+import yaml
 
-PLUGIN_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "pyplugins" / "hyperfile" / "pseudofile_tracker.py"
-)
+from penguin.testing import load_module, load_pyplugin
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRACKER = str(REPO_ROOT / "pyplugins" / "hyperfile" / "pseudofile_tracker.py")
 
-class _Anything:
-    """Attribute/call sink for plugin-runtime objects touched at import time."""
-
-    def __getattr__(self, name):
-        return _Anything()
-
-    def __call__(self, *args, **kwargs):
-        return _Anything()
+FAILURES = "pseudofiles_failures.yaml"
 
 
-def _import_tracker():
-    stub_names = ["penguin", "apis", "apis.syscalls"]
-    try:
-        import pydantic  # noqa: F401
-    except ImportError:
-        stub_names.append("pydantic")
-    saved = {name: sys.modules.get(name) for name in stub_names}
+class _Mem:
+    """plugins.mem double: read_str returns the path string under test."""
 
-    penguin_stub = types.ModuleType("penguin")
-    penguin_stub.Plugin = type("Plugin", (), {})
-    penguin_stub.PluginArgs = type("PluginArgs", (), {})
-    penguin_stub.yaml = real_yaml
-    penguin_stub.plugins = _Anything()
+    def __init__(self, s=""):
+        self.s = s
 
-    apis_stub = types.ModuleType("apis")
-    syscalls_stub = types.ModuleType("apis.syscalls")
-    syscalls_stub.ValueFilter = _Anything()
+    def read_str(self, addr):
+        yield from ()
+        return self.s
 
-    sys.modules["penguin"] = penguin_stub
-    sys.modules["apis"] = apis_stub
-    sys.modules["apis.syscalls"] = syscalls_stub
-    if "pydantic" in stub_names:
-        pydantic_stub = types.ModuleType("pydantic")
-        pydantic_stub.Field = lambda *args, **kwargs: None
-        sys.modules["pydantic"] = pydantic_stub
-    try:
-        spec = importlib.util.spec_from_file_location(
-            "pseudofile_tracker_under_test", PLUGIN_PATH
-        )
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-    finally:
-        for name, mod in saved.items():
-            if mod is None:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = mod
+
+class _Osi:
+    """plugins.osi double: caller identity and fd-name resolution."""
+
+    def __init__(self, name="cat", pid=77, fd_name=None):
+        self.name, self.pid, self.fd_name = name, pid, fd_name
+
+    def get_proc(self, pid=None):
+        yield from ()
+        return SimpleNamespace(name=self.name, pid=self.pid)
+
+    def get_fd_name(self, fd):
+        yield from ()
+        return self.fd_name
+
+
+def _load(tmp_path, isf, mem=None, osi=None, args=None):
+    lp = load_pyplugin(
+        TRACKER, outdir=tmp_path, real_isf=isf, args=dict(args or {}),
+        doubles={"mem": mem or _Mem(), "osi": osi or _Osi()},
+    )
+    # The handlers normalize raw retvals via panda; tests pass signed values.
+    lp.panda.from_unsigned_guest = lambda v: v
+    return lp
+
+
+def _syscall(retval=-2):
+    return SimpleNamespace(retval=retval)
+
+
+def _proto(name):
+    return SimpleNamespace(name=name)
+
+
+def _open_enoent(lp, flags=0, proto="sys_open", retval=-2):
+    """Drive an arg0-style -ENOENT hook (open/stat family) through the pump."""
+    lp.dispatch_syscall(proto, None, _proto(proto), _syscall(retval), 0xBEEF,
+                        flags, on_return=True)
+
+
+def _failures(lp):
+    text = (Path(lp.plugin.outdir) / FAILURES).read_text()
+    return text, yaml.safe_load(text)
+
+
+@pytest.fixture
+def tracker_mod(igloo_ko_isf):
+    """The tracker *module* (for its pure helpers), loaded via the harness."""
+    module, _manager = load_module(TRACKER, real_isf=igloo_ko_isf)
     return module
 
 
-pt = _import_tracker()
+# --- load + hook registration ----------------------------------------------- #
+
+def test_plugin_loads_behind_enum_boundary_and_registers_hooks(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf)
+    assert type(lp.plugin).__name__ == "PseudofileTracker"
+    hooks = {h["name"] for h in lp.manager.syscall_hooks}
+    # open/stat families at arg0 and arg1, plus the -ENOTTY ioctl hook
+    assert {"open", "openat", "stat", "newfstatat", "ioctl"} <= hooks
+    # init wrote an (empty) failures file so consumers can rely on it
+    assert (Path(tmp_path) / FAILURES).exists()
 
 
-# ---------------------------------------------------------------------------
-# open_access_intents
-# ---------------------------------------------------------------------------
+# --- pure helpers ------------------------------------------------------------ #
 
-def test_open_access_intents_rdonly():
+def test_open_access_intents(tracker_mod):
+    pt = tracker_mod
     assert pt.open_access_intents(0o0) == {"read"}
-
-
-def test_open_access_intents_wronly_with_extra_flags():
-    O_CREAT_O_TRUNC = 0o1000 | 0o100
-    assert pt.open_access_intents(0o1 | O_CREAT_O_TRUNC) == {"write"}
-
-
-def test_open_access_intents_rdwr():
+    assert pt.open_access_intents(0o1 | 0o1100) == {"write"}  # |O_CREAT|O_TRUNC
     assert pt.open_access_intents(0o2) == {"read", "write"}
 
 
-# ---------------------------------------------------------------------------
-# suggest_models
-# ---------------------------------------------------------------------------
-
-def test_suggest_read_for_open_with_unknown_intent():
+def test_suggest_models(tracker_mod):
+    pt = tracker_mod
     assert pt.suggest_models({"open": {"count": 1}}, set()) == {
-        "read": {"model": "zero"}
-    }
-
-
-def test_suggest_write_discard_for_write_only_intent():
+        "read": {"model": "zero"}}
     assert pt.suggest_models({"open": {"count": 1}}, {"write"}) == {
-        "write": {"model": "discard"}
-    }
-
-
-def test_suggest_read_and_write_for_rdwr():
-    suggest = pt.suggest_models({"open": {"count": 1}}, {"read", "write"})
-    assert suggest == {
-        "read": {"model": "zero"},
-        "write": {"model": "discard"},
-    }
-
-
-def test_suggest_ioctl_catchall():
-    suggest = pt.suggest_models({"ioctl": {799: {"count": 2}}}, set())
-    assert suggest == {"ioctl": {"*": {"model": "return_const", "val": 0}}}
-
-
-def test_suggest_combined_open_and_ioctl():
-    suggest = pt.suggest_models(
-        {"open": {"count": 1}, "ioctl": {799: {"count": 2}}}, {"read", "write"}
-    )
-    assert set(suggest) == {"read", "write", "ioctl"}
-
-
-def test_no_suggestion_without_failure_events():
+        "write": {"model": "discard"}}
+    assert pt.suggest_models({"open": {"count": 1}}, {"read", "write"}) == {
+        "read": {"model": "zero"}, "write": {"model": "discard"}}
+    assert pt.suggest_models({"ioctl": {799: {"count": 2}}}, set()) == {
+        "ioctl": {"*": {"model": "return_const", "val": 0}}}
     assert pt.suggest_models({}, set()) == {}
-    # default_* events mean a model already serves the path; nothing to paste.
+    # default_* events mean a model already serves the path; nothing to paste
     assert pt.suggest_models({"default_read": {"count": 3}}, set()) == {}
 
 
-# ---------------------------------------------------------------------------
-# load_crashes
-# ---------------------------------------------------------------------------
-
-def test_load_crashes_missing_file(tmp_path):
-    assert pt.load_crashes(str(tmp_path / "crashes.yaml")) == (set(), set())
-
-
-def test_load_crashes_empty_and_malformed(tmp_path):
-    f = tmp_path / "crashes.yaml"
+def test_load_crashes_tolerates_all_forms(tracker_mod, tmp_path):
+    pt = tracker_mod
+    f = tmp_path / "c.yaml"
+    assert pt.load_crashes(str(tmp_path / "absent.yaml")) == (set(), set())
     for content in ("", "crashes: []\n", "just a string\n", "crashes: 7\n"):
         f.write_text(content)
         assert pt.load_crashes(str(f)) == (set(), set())
-
-
-def test_load_crashes_dict_form(tmp_path):
-    f = tmp_path / "crashes.yaml"
+    # dict form; one record lacks a pid
     f.write_text(
         "crashes:\n"
         "- {proc: cat, pid: 77, signal: 11, signame: SIGSEGV,"
         " pc: '0x0040abcd', time: 3.2, count: 2}\n"
-        "- {proc: httpd, signal: 6, signame: SIGABRT,"
-        " pc: '0x00400000', time: 9.9, count: 1}\n"  # record without pid
+        "- {proc: httpd, signal: 6}\n"
     )
-    pairs, names = pt.load_crashes(str(f))
-    assert pairs == {("cat", 77)}
-    assert names == {"cat", "httpd"}
+    assert pt.load_crashes(str(f)) == ({("cat", 77)}, {"cat", "httpd"})
+    # bare list form, with junk entries
+    f.write_text("- {proc: cat, pid: 77}\n- {pid: 99}\n- notadict\n")
+    assert pt.load_crashes(str(f)) == ({("cat", 77)}, {"cat"})
 
 
-def test_load_crashes_bare_list_form(tmp_path):
-    f = tmp_path / "crashes.yaml"
-    f.write_text("- {proc: cat, pid: 77, signal: 11}\n- {pid: 99}\n- notadict\n")
-    pairs, names = pt.load_crashes(str(f))
-    assert pairs == {("cat", 77)}
-    assert names == {"cat"}
+def test_count_crashing_callers_exact_vs_by_name(tracker_mod):
+    pt = tracker_mod
+    pairs, names = {("cat", 77)}, {"cat"}
+    assert pt.count_crashing_callers({("cat", 77)}, pairs, names) == (1, 0)
+    assert pt.count_crashing_callers({("cat", 999)}, pairs, names) == (0, 1)
+    assert pt.count_crashing_callers({("init", 1)}, pairs, names) == (0, 0)
+    # exact match is not double-counted as a name match
+    assert pt.count_crashing_callers(
+        {("cat", 77), ("cat", 999), ("init", 1)}, pairs, names) == (1, 1)
 
 
-# ---------------------------------------------------------------------------
-# count_crashing_callers
-# ---------------------------------------------------------------------------
+def test_impact_score_tier_ordering(tracker_mod):
+    pt = tracker_mod
 
-def test_count_crashing_exact_match():
-    assert pt.count_crashing_callers({("cat", 77)}, {("cat", 77)}, {"cat"}) == (1, 0)
+    def impact(hits=0, distinct=0, crashing=0, by_name=0):
+        return {"hits": hits, "distinct_callers": distinct,
+                "crashing_callers": crashing, "crashing_callers_by_name": by_name}
 
-
-def test_count_crashing_name_only_fallback():
-    # pid recycled: name matches a crash, pid does not
-    assert pt.count_crashing_callers({("cat", 999)}, {("cat", 77)}, {"cat"}) == (0, 1)
-
-
-def test_count_crashing_no_match():
-    assert pt.count_crashing_callers({("init", 1)}, {("cat", 77)}, {"cat"}) == (0, 0)
+    assert pt.impact_score(impact(hits=5)) == 5
+    assert pt.impact_score(impact(distinct=1)) > pt.impact_score(impact(hits=999))
+    assert pt.impact_score(impact(by_name=1)) > pt.impact_score(impact(distinct=9))
+    assert pt.impact_score(impact(crashing=1)) > pt.impact_score(impact(by_name=99))
 
 
-def test_count_crashing_mixed_not_double_counted():
-    callers = {("cat", 77), ("cat", 999), ("init", 1)}
-    assert pt.count_crashing_callers(callers, {("cat", 77)}, {"cat"}) == (1, 1)
+# --- the -ENOENT open/stat generator handlers (syscall pump) ----------------- #
+
+def test_open_enoent_records_caller_and_intent(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf, mem=_Mem("/dev/missing"),
+               osi=_Osi("httpd", 42))
+    _open_enoent(lp, flags=0o2)  # O_RDWR
+    lp.finalize()
+    _, data = _failures(lp)
+    entry = data["/dev/missing"]
+    assert entry["callers"] == ["httpd:42"]
+    assert entry["impact"]["distinct_callers"] == 1
+    assert entry["suggest"] == {"read": {"model": "zero"},
+                                "write": {"model": "discard"}}
 
 
-# ---------------------------------------------------------------------------
-# impact_score
-# ---------------------------------------------------------------------------
-
-def _impact(hits=0, distinct=0, crashing=0, by_name=0):
-    return {
-        "hits": hits,
-        "distinct_callers": distinct,
-        "crashing_callers": crashing,
-        "crashing_callers_by_name": by_name,
-    }
+def test_stat_enoent_has_unknown_intent_suggests_read(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf, mem=_Mem("/sys/foo/missing"))
+    lp.dispatch_syscall("sys_stat", None, _proto("sys_stat"), _syscall(-2),
+                        0xBEEF, on_return=True)
+    lp.finalize()
+    _, data = _failures(lp)
+    assert data["/sys/foo/missing"]["suggest"] == {"read": {"model": "zero"}}
 
 
-def test_impact_score_arithmetic():
-    assert pt.impact_score(_impact(hits=5)) == 5
-    assert pt.impact_score(_impact(hits=2, distinct=3, crashing=1, by_name=1)) == (
-        pt.SCORE_CRASHING_CALLER + pt.SCORE_CRASHING_BY_NAME
-        + 3 * pt.SCORE_DISTINCT_CALLER + 2
-    )
+def test_non_enoent_and_uninteresting_paths_ignored(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf, mem=_Mem("/etc/passwd"))
+    _open_enoent(lp)                     # not a pseudofile path
+    lp2 = _load(tmp_path, igloo_ko_isf, mem=_Mem("/dev/missing"))
+    _open_enoent(lp2, retval=-13)        # -EACCES, not -ENOENT
+    for plugin in (lp, lp2):
+        plugin.finalize()
+        _, data = _failures(plugin)
+        assert data == {}
 
 
-def test_impact_score_tier_ordering():
-    # one distinct caller beats any realistic hit count
-    assert pt.impact_score(_impact(distinct=1)) > pt.impact_score(_impact(hits=999))
-    # one name-only crash beats several distinct callers
-    assert pt.impact_score(_impact(by_name=1)) > pt.impact_score(_impact(distinct=9))
-    # one exact crash beats dozens of name-only crashes
-    assert pt.impact_score(_impact(crashing=1)) > pt.impact_score(_impact(by_name=99))
+def test_relative_path_resolved_against_dfd(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf, mem=_Mem("watchdog"),
+               osi=_Osi("wd", 9, fd_name="/dev"))
+    lp.dispatch_syscall("sys_openat", None, _proto("sys_openat"), _syscall(-2),
+                        3, 0xBEEF, 0o0, on_return=True)
+    lp.finalize()
+    _, data = _failures(lp)
+    assert "/dev/watchdog" in data
 
 
-# ---------------------------------------------------------------------------
-# end-to-end rendering through dump_results (no plugin runtime needed)
-# ---------------------------------------------------------------------------
-
-@pytest.fixture
-def tracker(tmp_path):
-    t = pt.PseudofileTracker.__new__(pt.PseudofileTracker)
-    t.outdir = str(tmp_path)
-    t.log_missing = True
-    t.logger = logging.getLogger("test_pseudofile_tracker")
-    t.file_failures = {}
-    return t
+def test_proc_pid_paths_collapse(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf, mem=_Mem("/proc/1234/missing"))
+    _open_enoent(lp)
+    lp.finalize()
+    _, data = _failures(lp)
+    assert "/proc/PID/missing" in data
 
 
-def _dumped(tracker):
-    tracker.dump_results()
-    text = (Path(tracker.outdir) / pt.outfile_missing).read_text()
-    return text, real_yaml.safe_load(text)
+def test_flush_is_eager_not_only_at_uninit(tmp_path, igloo_ko_isf):
+    # Results must survive a run that never reaches uninit (SIGKILL, emulator
+    # crash) -- see rehosting/penguin#175.
+    lp = _load(tmp_path, igloo_ko_isf, mem=_Mem("/dev/missing"))
+    _open_enoent(lp)
+    _, data = _failures(lp)  # no finalize()
+    assert "/dev/missing" in data
 
 
-def test_dump_ranks_by_impact_and_emits_valid_yaml(tracker, tmp_path):
-    (tmp_path / pt.crashes_file).write_text(
-        "crashes:\n- {proc: watchdogd, pid: 412, signal: 11, signame: SIGSEGV,"
-        " pc: '0x0040abcd', time: 3.2, count: 1}\n"
-    )
-    for _ in range(100):
-        tracker.centralized_log("/proc/foo/missing", "open",
-                                caller=("cat", 77), intents={"read"})
-    tracker.centralized_log("/dev/watchdog", "open",
-                            caller=("watchdogd", 412), intents={"read", "write"})
-    tracker.centralized_log("/dev/watchdog", "open",
-                            caller=("init", 1), intents={"read", "write"})
-    for _ in range(5):
-        tracker.log_ioctl_failure("/dev/watchdog", 0x80045700,
-                                  caller=("watchdogd", 412))
-    tracker.centralized_log("/sys/foo/missing", "open")
+# --- the -ENOTTY ioctl generator handler ------------------------------------- #
 
-    text, data = _dumped(tracker)  # safe_load also proves comments don't break parsing
-    assert list(data) == ["/dev/watchdog", "/proc/foo/missing", "/sys/foo/missing"]
-
-    watchdog = data["/dev/watchdog"]
-    assert watchdog["impact"] == {
-        "hits": 7,
-        "distinct_callers": 2,
-        "crashing_callers": 1,
-        "crashing_callers_by_name": 0,
-    }
-    assert watchdog["callers"] == ["init:1", "watchdogd:412"]
-    assert watchdog["events"]["ioctl"][0x80045700]["count"] == 5
-    assert watchdog["suggest"] == {
-        "read": {"model": "zero"},
-        "write": {"model": "discard"},
-        "ioctl": {"*": {"model": "return_const", "val": 0}},
-    }
-    assert "# TODO" in text
-
-    anonymous = data["/sys/foo/missing"]
-    assert "callers" not in anonymous
-    assert anonymous["impact"]["distinct_callers"] == 0
+def test_ioctl_enotty_recorded_with_suggestion(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf,
+               osi=_Osi("wdog", 5, fd_name="/dev/watchdog"))
+    lp.dispatch_syscall("sys_ioctl", None, _proto("sys_ioctl"), _syscall(-25),
+                        4, 0x6700, 0, on_return=True)
+    lp.finalize()
+    _, data = _failures(lp)
+    entry = data["/dev/watchdog"]
+    assert entry["events"]["ioctl"][0x6700]["count"] == 1
+    assert entry["callers"] == ["wdog:5"]
+    assert entry["suggest"]["ioctl"] == {"*": {"model": "return_const", "val": 0}}
 
 
-def test_record_default_hit_lands_in_events(tracker):
-    tracker.record_default_hit("/dev/stub", "read")
-    tracker.record_default_hit("/dev/stub", "ioctl", details="cmd 0x31f")
-    _, data = _dumped(tracker)
+def test_ioctl_tty_cmds_and_proc_paths_ignored(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf, osi=_Osi(fd_name="/dev/ttyS0"))
+    lp.dispatch_syscall("sys_ioctl", None, _proto("sys_ioctl"), _syscall(-25),
+                        4, 0x5401, 0, on_return=True)  # TCGETS: TTY range
+    lp2 = _load(tmp_path, igloo_ko_isf, osi=_Osi(fd_name="/proc/sys/foo"))
+    lp2.dispatch_syscall("sys_ioctl", None, _proto("sys_ioctl"), _syscall(-25),
+                         4, 0x6700, 0, on_return=True)
+    for plugin in (lp, lp2):
+        plugin.finalize()
+        _, data = _failures(plugin)
+        assert data == {}
+
+
+# --- default-model provenance (record_default_hit) ---------------------------- #
+
+def test_record_default_hit_lands_in_events(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf)
+    lp.plugin.record_default_hit("/dev/stub", "read")
+    lp.plugin.record_default_hit("/dev/stub", "ioctl", details="cmd 0x31f")
+    _, data = _failures(lp)  # record_default_hit flushes itself
     entry = data["/dev/stub"]
     assert entry["events"]["default_read"]["count"] == 1
     assert entry["events"]["default_ioctl"]["details"] == ["cmd 0x31f"]
@@ -297,14 +274,49 @@ def test_record_default_hit_lands_in_events(tracker):
     assert entry["impact"]["hits"] == 2
 
 
-def test_record_default_hit_filters_uninteresting_paths(tracker):
-    tracker.record_default_hit("/etc/passwd", "read")
-    _, data = _dumped(tracker)
+def test_record_default_hit_filters_uninteresting_paths(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf)
+    lp.plugin.record_default_hit("/etc/passwd", "read")
+    lp.finalize()
+    _, data = _failures(lp)
     assert data == {}
 
 
-def test_normalize_path_collapses_pids(tracker):
-    assert tracker._normalize_path("/proc/1234/status") == "/proc/PID/status"
-    assert tracker._normalize_path("/proc/tc3162/adsl_fwver") == "/proc/tc3162/adsl_fwver"
-    assert tracker._normalize_path("/etc/passwd") is None
-    assert tracker._normalize_path("/dev/pipe:[123]") is None
+# --- ranking + crashes.yaml join, end to end ---------------------------------- #
+
+def test_ranking_by_impact_with_crash_join(tmp_path, igloo_ko_isf):
+    (tmp_path / "crashes.yaml").write_text(
+        "crashes:\n- {proc: watchdogd, pid: 412, signal: 11, signame: SIGSEGV,"
+        " pc: '0x0040abcd', time: 3.2, count: 1}\n"
+    )
+    lp = _load(tmp_path, igloo_ko_isf)
+    t = lp.plugin
+    # many hits, one caller
+    for _ in range(100):
+        t.centralized_log("/proc/foo/missing", "open",
+                          caller=("cat", 77), intents={"read"})
+    # fewer hits, two callers, one of which crashed (exact proc+pid match)
+    t.centralized_log("/dev/watchdog", "open",
+                      caller=("watchdogd", 412), intents={"read", "write"})
+    t.centralized_log("/dev/watchdog", "open", caller=("init", 1),
+                      intents={"read", "write"})
+    for _ in range(5):
+        t.log_ioctl_failure("/dev/watchdog", 0x80045700,
+                            caller=("watchdogd", 412))
+    # name-only crash match (pid recycled)
+    t.centralized_log("/dev/mtd", "open", caller=("watchdogd", 999))
+    t.centralized_log("/sys/foo/missing", "open")  # no caller resolved
+    lp.finalize()
+
+    text, data = _failures(lp)  # safe_load also proves comments parse cleanly
+    assert list(data) == ["/dev/watchdog", "/dev/mtd",
+                          "/proc/foo/missing", "/sys/foo/missing"]
+    assert data["/dev/watchdog"]["impact"] == {
+        "hits": 7, "distinct_callers": 2,
+        "crashing_callers": 1, "crashing_callers_by_name": 0}
+    assert data["/dev/watchdog"]["callers"] == ["init:1", "watchdogd:412"]
+    assert data["/dev/watchdog"]["events"]["ioctl"][0x80045700]["count"] == 5
+    assert data["/dev/mtd"]["impact"]["crashing_callers_by_name"] == 1
+    assert data["/dev/mtd"]["impact"]["crashing_callers"] == 0
+    assert "callers" not in data["/sys/foo/missing"]
+    assert "# TODO" in text

--- a/tests/unit/test_pseudofile_tracker.py
+++ b/tests/unit/test_pseudofile_tracker.py
@@ -1,0 +1,310 @@
+"""
+Unit tests for the pure helpers in pyplugins/hyperfile/pseudofile_tracker.py:
+impact ranking, model suggestion, crashes.yaml parsing/joining, and the
+rendered output format.
+
+The plugin module expects the in-container plugin runtime (penguin.plugins,
+apis.syscalls) at import time, so it is imported here with those stubbed out;
+the helpers under test are pure Python.
+"""
+
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import yaml as real_yaml
+
+PLUGIN_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "pyplugins" / "hyperfile" / "pseudofile_tracker.py"
+)
+
+
+class _Anything:
+    """Attribute/call sink for plugin-runtime objects touched at import time."""
+
+    def __getattr__(self, name):
+        return _Anything()
+
+    def __call__(self, *args, **kwargs):
+        return _Anything()
+
+
+def _import_tracker():
+    stub_names = ["penguin", "apis", "apis.syscalls"]
+    try:
+        import pydantic  # noqa: F401
+    except ImportError:
+        stub_names.append("pydantic")
+    saved = {name: sys.modules.get(name) for name in stub_names}
+
+    penguin_stub = types.ModuleType("penguin")
+    penguin_stub.Plugin = type("Plugin", (), {})
+    penguin_stub.PluginArgs = type("PluginArgs", (), {})
+    penguin_stub.yaml = real_yaml
+    penguin_stub.plugins = _Anything()
+
+    apis_stub = types.ModuleType("apis")
+    syscalls_stub = types.ModuleType("apis.syscalls")
+    syscalls_stub.ValueFilter = _Anything()
+
+    sys.modules["penguin"] = penguin_stub
+    sys.modules["apis"] = apis_stub
+    sys.modules["apis.syscalls"] = syscalls_stub
+    if "pydantic" in stub_names:
+        pydantic_stub = types.ModuleType("pydantic")
+        pydantic_stub.Field = lambda *args, **kwargs: None
+        sys.modules["pydantic"] = pydantic_stub
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "pseudofile_tracker_under_test", PLUGIN_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        for name, mod in saved.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+    return module
+
+
+pt = _import_tracker()
+
+
+# ---------------------------------------------------------------------------
+# open_access_intents
+# ---------------------------------------------------------------------------
+
+def test_open_access_intents_rdonly():
+    assert pt.open_access_intents(0o0) == {"read"}
+
+
+def test_open_access_intents_wronly_with_extra_flags():
+    O_CREAT_O_TRUNC = 0o1000 | 0o100
+    assert pt.open_access_intents(0o1 | O_CREAT_O_TRUNC) == {"write"}
+
+
+def test_open_access_intents_rdwr():
+    assert pt.open_access_intents(0o2) == {"read", "write"}
+
+
+# ---------------------------------------------------------------------------
+# suggest_models
+# ---------------------------------------------------------------------------
+
+def test_suggest_read_for_open_with_unknown_intent():
+    assert pt.suggest_models({"open": {"count": 1}}, set()) == {
+        "read": {"model": "zero"}
+    }
+
+
+def test_suggest_write_discard_for_write_only_intent():
+    assert pt.suggest_models({"open": {"count": 1}}, {"write"}) == {
+        "write": {"model": "discard"}
+    }
+
+
+def test_suggest_read_and_write_for_rdwr():
+    suggest = pt.suggest_models({"open": {"count": 1}}, {"read", "write"})
+    assert suggest == {
+        "read": {"model": "zero"},
+        "write": {"model": "discard"},
+    }
+
+
+def test_suggest_ioctl_catchall():
+    suggest = pt.suggest_models({"ioctl": {799: {"count": 2}}}, set())
+    assert suggest == {"ioctl": {"*": {"model": "return_const", "val": 0}}}
+
+
+def test_suggest_combined_open_and_ioctl():
+    suggest = pt.suggest_models(
+        {"open": {"count": 1}, "ioctl": {799: {"count": 2}}}, {"read", "write"}
+    )
+    assert set(suggest) == {"read", "write", "ioctl"}
+
+
+def test_no_suggestion_without_failure_events():
+    assert pt.suggest_models({}, set()) == {}
+    # default_* events mean a model already serves the path; nothing to paste.
+    assert pt.suggest_models({"default_read": {"count": 3}}, set()) == {}
+
+
+# ---------------------------------------------------------------------------
+# load_crashes
+# ---------------------------------------------------------------------------
+
+def test_load_crashes_missing_file(tmp_path):
+    assert pt.load_crashes(str(tmp_path / "crashes.yaml")) == (set(), set())
+
+
+def test_load_crashes_empty_and_malformed(tmp_path):
+    f = tmp_path / "crashes.yaml"
+    for content in ("", "crashes: []\n", "just a string\n", "crashes: 7\n"):
+        f.write_text(content)
+        assert pt.load_crashes(str(f)) == (set(), set())
+
+
+def test_load_crashes_dict_form(tmp_path):
+    f = tmp_path / "crashes.yaml"
+    f.write_text(
+        "crashes:\n"
+        "- {proc: cat, pid: 77, signal: 11, signame: SIGSEGV,"
+        " pc: '0x0040abcd', time: 3.2, count: 2}\n"
+        "- {proc: httpd, signal: 6, signame: SIGABRT,"
+        " pc: '0x00400000', time: 9.9, count: 1}\n"  # record without pid
+    )
+    pairs, names = pt.load_crashes(str(f))
+    assert pairs == {("cat", 77)}
+    assert names == {"cat", "httpd"}
+
+
+def test_load_crashes_bare_list_form(tmp_path):
+    f = tmp_path / "crashes.yaml"
+    f.write_text("- {proc: cat, pid: 77, signal: 11}\n- {pid: 99}\n- notadict\n")
+    pairs, names = pt.load_crashes(str(f))
+    assert pairs == {("cat", 77)}
+    assert names == {"cat"}
+
+
+# ---------------------------------------------------------------------------
+# count_crashing_callers
+# ---------------------------------------------------------------------------
+
+def test_count_crashing_exact_match():
+    assert pt.count_crashing_callers({("cat", 77)}, {("cat", 77)}, {"cat"}) == (1, 0)
+
+
+def test_count_crashing_name_only_fallback():
+    # pid recycled: name matches a crash, pid does not
+    assert pt.count_crashing_callers({("cat", 999)}, {("cat", 77)}, {"cat"}) == (0, 1)
+
+
+def test_count_crashing_no_match():
+    assert pt.count_crashing_callers({("init", 1)}, {("cat", 77)}, {"cat"}) == (0, 0)
+
+
+def test_count_crashing_mixed_not_double_counted():
+    callers = {("cat", 77), ("cat", 999), ("init", 1)}
+    assert pt.count_crashing_callers(callers, {("cat", 77)}, {"cat"}) == (1, 1)
+
+
+# ---------------------------------------------------------------------------
+# impact_score
+# ---------------------------------------------------------------------------
+
+def _impact(hits=0, distinct=0, crashing=0, by_name=0):
+    return {
+        "hits": hits,
+        "distinct_callers": distinct,
+        "crashing_callers": crashing,
+        "crashing_callers_by_name": by_name,
+    }
+
+
+def test_impact_score_arithmetic():
+    assert pt.impact_score(_impact(hits=5)) == 5
+    assert pt.impact_score(_impact(hits=2, distinct=3, crashing=1, by_name=1)) == (
+        pt.SCORE_CRASHING_CALLER + pt.SCORE_CRASHING_BY_NAME
+        + 3 * pt.SCORE_DISTINCT_CALLER + 2
+    )
+
+
+def test_impact_score_tier_ordering():
+    # one distinct caller beats any realistic hit count
+    assert pt.impact_score(_impact(distinct=1)) > pt.impact_score(_impact(hits=999))
+    # one name-only crash beats several distinct callers
+    assert pt.impact_score(_impact(by_name=1)) > pt.impact_score(_impact(distinct=9))
+    # one exact crash beats dozens of name-only crashes
+    assert pt.impact_score(_impact(crashing=1)) > pt.impact_score(_impact(by_name=99))
+
+
+# ---------------------------------------------------------------------------
+# end-to-end rendering through dump_results (no plugin runtime needed)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tracker(tmp_path):
+    t = pt.PseudofileTracker.__new__(pt.PseudofileTracker)
+    t.outdir = str(tmp_path)
+    t.log_missing = True
+    t.logger = logging.getLogger("test_pseudofile_tracker")
+    t.file_failures = {}
+    return t
+
+
+def _dumped(tracker):
+    tracker.dump_results()
+    text = (Path(tracker.outdir) / pt.outfile_missing).read_text()
+    return text, real_yaml.safe_load(text)
+
+
+def test_dump_ranks_by_impact_and_emits_valid_yaml(tracker, tmp_path):
+    (tmp_path / pt.crashes_file).write_text(
+        "crashes:\n- {proc: watchdogd, pid: 412, signal: 11, signame: SIGSEGV,"
+        " pc: '0x0040abcd', time: 3.2, count: 1}\n"
+    )
+    for _ in range(100):
+        tracker.centralized_log("/proc/foo/missing", "open",
+                                caller=("cat", 77), intents={"read"})
+    tracker.centralized_log("/dev/watchdog", "open",
+                            caller=("watchdogd", 412), intents={"read", "write"})
+    tracker.centralized_log("/dev/watchdog", "open",
+                            caller=("init", 1), intents={"read", "write"})
+    for _ in range(5):
+        tracker.log_ioctl_failure("/dev/watchdog", 0x80045700,
+                                  caller=("watchdogd", 412))
+    tracker.centralized_log("/sys/foo/missing", "open")
+
+    text, data = _dumped(tracker)  # safe_load also proves comments don't break parsing
+    assert list(data) == ["/dev/watchdog", "/proc/foo/missing", "/sys/foo/missing"]
+
+    watchdog = data["/dev/watchdog"]
+    assert watchdog["impact"] == {
+        "hits": 7,
+        "distinct_callers": 2,
+        "crashing_callers": 1,
+        "crashing_callers_by_name": 0,
+    }
+    assert watchdog["callers"] == ["init:1", "watchdogd:412"]
+    assert watchdog["events"]["ioctl"][0x80045700]["count"] == 5
+    assert watchdog["suggest"] == {
+        "read": {"model": "zero"},
+        "write": {"model": "discard"},
+        "ioctl": {"*": {"model": "return_const", "val": 0}},
+    }
+    assert "# TODO" in text
+
+    anonymous = data["/sys/foo/missing"]
+    assert "callers" not in anonymous
+    assert anonymous["impact"]["distinct_callers"] == 0
+
+
+def test_record_default_hit_lands_in_events(tracker):
+    tracker.record_default_hit("/dev/stub", "read")
+    tracker.record_default_hit("/dev/stub", "ioctl", details="cmd 0x31f")
+    _, data = _dumped(tracker)
+    entry = data["/dev/stub"]
+    assert entry["events"]["default_read"]["count"] == 1
+    assert entry["events"]["default_ioctl"]["details"] == ["cmd 0x31f"]
+    # default hits carry no caller identity and must not pollute callers
+    assert "callers" not in entry
+    assert entry["impact"]["hits"] == 2
+
+
+def test_record_default_hit_filters_uninteresting_paths(tracker):
+    tracker.record_default_hit("/etc/passwd", "read")
+    _, data = _dumped(tracker)
+    assert data == {}
+
+
+def test_normalize_path_collapses_pids(tracker):
+    assert tracker._normalize_path("/proc/1234/status") == "/proc/PID/status"
+    assert tracker._normalize_path("/proc/tc3162/adsl_fwver") == "/proc/tc3162/adsl_fwver"
+    assert tracker._normalize_path("/etc/passwd") is None
+    assert tracker._normalize_path("/dev/pipe:[123]") is None


### PR DESCRIPTION
Implements planning draft 03 (pseudofile failure ranking) and fixes #175.

## What changed

`pseudofiles_failures.yaml` entries are now `path -> {impact, callers, events, suggest}`, sorted by an impact score instead of raw event count:

```yaml
/dev/watchdog:
  impact: {hits: 243, distinct_callers: 2, crashing_callers: 1, crashing_callers_by_name: 0}
  callers: [init:1, watchdogd:412]
  events:
    ioctl:
      2147768064: {count: 240}
    open: {count: 3}
  suggest:  # TODO: heuristic starting point -- verify before relying on it
    read: {model: zero}
    ioctl: {'*': {model: return_const, val: 0}}
```

### Impact ranking
- `hits`: total failure events for the path.
- `distinct_callers`: distinct `(comm, pid)` callers, resolved via one `osi.get_proc()` round-trip per failure event (only paid after path filtering). Rendered as `name:pid` strings.
- `crashing_callers`: callers whose exact `(proc, pid)` appears in the crashes plugin's `crashes.yaml` (read on every flush, tolerant of the file being absent -- merge order with the crashes PR doesn't matter).
- `crashing_callers_by_name`: name-only crash matches (pid recycled between access and fault), reported separately and weighted far lower so one crash of a common name (`sh`, `init`) can't reorder the file.
- Sort weights: exact crash 1e6 >> by-name crash 1e4 >> distinct caller 1e3 > hit.

### Model suggestions
Each entry gets a `suggest` block that is a **schema-valid `pseudofiles:` value** (validated against the `Pseudofile` pydantic model) -- paste it under the path in your config:
- ioctl ENOTTY -> `ioctl: {'*': {model: return_const, val: 0}}`
- open/stat ENOENT with read intent (or unknown) -> `read: {model: zero}`
- open ENOENT with write intent (from O_ACCMODE flags / `creat`) -> `write: {model: discard}`

Read sizes aren't observable at ENOENT-open time, so there's no small/large `const_buf` split yet; the file header directs users to `const_buf` when real contents matter.

### #175 fix
The nested-nonexistent-`/proc`-dir case (`/proc/tc3162/adsl_fwver`) was a limitation of the old kernel-patch-based tracking; the current syscall-return tracker captures it. Re-enabled the previously disabled `/proc/foo/missing` assertion in `pseudofile_missing.yaml` as the regression guard, and added an eager flush on every new path/event so results survive runs that never reach `uninit()` (SIGKILL, emulator crash) -- previously open failures only hit disk at teardown.

### Rebase note
`record_default_hit` (added on main in b8ad241f) is preserved and adapted to the new record shape: `default_read`/`default_write`/`default_ioctl` events flow into the same impact/events records, so default-model provenance and the `pseudofile_ext_ops` CI target keep working.

## Verification
- `tests/unit_tests/test_pseudofile_tracker.py`: 23 host-side unit tests for the pure helpers and rendered output.
- Guest fixtures on armel + mipsel (4.10): `pseudofile_missing`, `pseudofile_ioctl`, `pseudofile_ext_ops` all pass.
- Crash-join verified end-to-end against the draft-01 crashes plugin: a child `sh` that opens unmodeled `/dev/crashjoin` then SIGSEGVs itself yields `crashing_callers: 1` and ranks that path first.