### PR TITLE
binary_patch: idempotent expect + why/tag provenance

### DIFF
--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -2602,6 +2602,128 @@ Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseud
 |__Type__|string|
 
 
+##### `static_files.<string>.<type=inline_file>.patches` Binary patches to apply after this file is placed
+
+|||
+|-|-|
+|__Type__|list of Binary patch entry|
+|__Default__|`null`|
+
+A list of binary edits applied to this file after it is staged into the guest, in a single host-side pass (same semantics as the standalone 'binary_patch' action). Each edit may verify the bytes currently at its offset (expect/on_mismatch) and record rationale (why/tag); every outcome is written to binary_patches.yaml in the run output. Overlapping write ranges are rejected. Cannot be combined with a glob source or destination (the patch target would be ambiguous).
+
+###### `static_files.<string>.<type=inline_file>.patches.<item>` Binary patch entry
+
+A single edit within a ``binary_patch`` action: bytes to write at one
+    file offset, optionally guarded by an ``expect`` check. Multiple entries can
+    target one file via the action's ``patches`` list; they are applied
+    host-side to one buffer in a single pass, and overlapping write ranges are
+    rejected.
+
+###### `static_files.<string>.<type=inline_file>.patches.<item>.file_offset` File offset (integer)
+
+|||
+|-|-|
+|__Type__|integer|
+
+
+###### `static_files.<string>.<type=inline_file>.patches.<item>.hex_bytes` Bytes to write at offset (hex string)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+DEADBEEF
+```
+
+```yaml
+90 90
+```
+
+###### `static_files.<string>.<type=inline_file>.patches.<item>.asm` Assembly code to write at offset (runs through keystone)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+nop
+```
+
+```yaml
+'mov r0, #0xdeadbeef'
+```
+
+###### `static_files.<string>.<type=inline_file>.patches.<item>.mode` Assembly mode
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+arm
+```
+
+```yaml
+thumb
+```
+
+###### `static_files.<string>.<type=inline_file>.patches.<item>.expect` Expected bytes at offset before patching (hex string)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+If set, the current bytes at file_offset are compared against this hex string (over its own length, which may differ from the patch length) before the patch is written. If the bytes at the offset already equal the patch bytes, the patch is skipped (idempotent re-run); otherwise the on_mismatch policy applies.
+
+```yaml
+0102 0304
+```
+
+```yaml
+DEADBEEF
+```
+
+###### `static_files.<string>.<type=inline_file>.patches.<item>.on_mismatch` Policy when 'expect' does not match
+
+|||
+|-|-|
+|__Type__|`"fail"` or `"skip"` or `"warn"`|
+|__Default__|`fail`|
+
+fail: abort the run (default, safest). skip: leave the file unpatched and continue. warn: log a warning and write the patch anyway. Only meaningful when 'expect' is set.
+
+###### `static_files.<string>.<type=inline_file>.patches.<item>.why` Rationale for this patch, recorded in the run's binary_patches.yaml
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+NOP out the secure-boot check
+```
+
+###### `static_files.<string>.<type=inline_file>.patches.<item>.tag` Label grouping related patches, recorded in the run's binary_patches.yaml
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+secureboot
+```
+
 #### `static_files.<string>.<type=host_file>` Copy host file
 
 Copy a file from the host into the guest
@@ -2636,6 +2758,128 @@ Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseud
 |-|-|
 |__Type__|string|
 
+
+##### `static_files.<string>.<type=host_file>.patches` Binary patches to apply after this file is placed
+
+|||
+|-|-|
+|__Type__|list of Binary patch entry|
+|__Default__|`null`|
+
+A list of binary edits applied to this file after it is staged into the guest, in a single host-side pass (same semantics as the standalone 'binary_patch' action). Each edit may verify the bytes currently at its offset (expect/on_mismatch) and record rationale (why/tag); every outcome is written to binary_patches.yaml in the run output. Overlapping write ranges are rejected. Cannot be combined with a glob source or destination (the patch target would be ambiguous).
+
+###### `static_files.<string>.<type=host_file>.patches.<item>` Binary patch entry
+
+A single edit within a ``binary_patch`` action: bytes to write at one
+    file offset, optionally guarded by an ``expect`` check. Multiple entries can
+    target one file via the action's ``patches`` list; they are applied
+    host-side to one buffer in a single pass, and overlapping write ranges are
+    rejected.
+
+###### `static_files.<string>.<type=host_file>.patches.<item>.file_offset` File offset (integer)
+
+|||
+|-|-|
+|__Type__|integer|
+
+
+###### `static_files.<string>.<type=host_file>.patches.<item>.hex_bytes` Bytes to write at offset (hex string)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+DEADBEEF
+```
+
+```yaml
+90 90
+```
+
+###### `static_files.<string>.<type=host_file>.patches.<item>.asm` Assembly code to write at offset (runs through keystone)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+nop
+```
+
+```yaml
+'mov r0, #0xdeadbeef'
+```
+
+###### `static_files.<string>.<type=host_file>.patches.<item>.mode` Assembly mode
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+arm
+```
+
+```yaml
+thumb
+```
+
+###### `static_files.<string>.<type=host_file>.patches.<item>.expect` Expected bytes at offset before patching (hex string)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+If set, the current bytes at file_offset are compared against this hex string (over its own length, which may differ from the patch length) before the patch is written. If the bytes at the offset already equal the patch bytes, the patch is skipped (idempotent re-run); otherwise the on_mismatch policy applies.
+
+```yaml
+0102 0304
+```
+
+```yaml
+DEADBEEF
+```
+
+###### `static_files.<string>.<type=host_file>.patches.<item>.on_mismatch` Policy when 'expect' does not match
+
+|||
+|-|-|
+|__Type__|`"fail"` or `"skip"` or `"warn"`|
+|__Default__|`fail`|
+
+fail: abort the run (default, safest). skip: leave the file unpatched and continue. warn: log a warning and write the patch anyway. Only meaningful when 'expect' is set.
+
+###### `static_files.<string>.<type=host_file>.patches.<item>.why` Rationale for this patch, recorded in the run's binary_patches.yaml
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+NOP out the secure-boot check
+```
+
+###### `static_files.<string>.<type=host_file>.patches.<item>.tag` Label grouping related patches, recorded in the run's binary_patches.yaml
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+secureboot
+```
 
 #### `static_files.<string>.<type=dir>` Add directory
 

--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -2819,7 +2819,7 @@ Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseud
 
 #### `static_files.<string>.<type=binary_patch>` Patch binary file
 
-Make a patch to a binary file at the specified offset. This can either be arbitrary bytes specified as a hex string, or assembly code that will be automatically assembled in the specified mode.
+Patch a binary file at one or more offsets. A single edit is given inline (file_offset + one of hex_bytes/asm); multiple edits to the same file go in the 'patches' list (applied together in one host-side pass, with overlapping write ranges rejected). Each edit may verify the bytes currently at its offset first (expect/on_mismatch) so the patch is idempotent and safe across firmware variants, and record rationale (why/tag); every edit's outcome is written to binary_patches.yaml in the run output.
 
 ##### `static_files.<string>.<type=binary_patch>.type` Type of file action (patch binary file)
 
@@ -2837,11 +2837,12 @@ Make a patch to a binary file at the specified offset. This can either be arbitr
 
 Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
 
-##### `static_files.<string>.<type=binary_patch>.file_offset` File offset (integer)
+##### `static_files.<string>.<type=binary_patch>.file_offset` File offset (integer) — for a single inline edit; omit when using 'patches'
 
 |||
 |-|-|
-|__Type__|integer|
+|__Type__|integer or null|
+|__Default__|`null`|
 
 
 ##### `static_files.<string>.<type=binary_patch>.hex_bytes` Bytes to write at offset (hex string)
@@ -2890,6 +2891,178 @@ arm
 
 ```yaml
 thumb
+```
+
+##### `static_files.<string>.<type=binary_patch>.expect` Expected bytes at offset before patching (hex string)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+If set, the current bytes at file_offset are compared against this hex string (over its own length, which may differ from the patch length) before the patch is written. If the bytes at the offset already equal the patch bytes, the patch is skipped (idempotent re-run); otherwise the on_mismatch policy applies.
+
+```yaml
+0102 0304
+```
+
+```yaml
+DEADBEEF
+```
+
+##### `static_files.<string>.<type=binary_patch>.on_mismatch` Policy when 'expect' does not match
+
+|||
+|-|-|
+|__Type__|`"fail"` or `"skip"` or `"warn"`|
+|__Default__|`fail`|
+
+fail: abort the run (default, safest). skip: leave the file unpatched and continue. warn: log a warning and write the patch anyway. Only meaningful when 'expect' is set.
+
+##### `static_files.<string>.<type=binary_patch>.why` Rationale for this patch, recorded in the run's binary_patches.yaml
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+NOP out the secure-boot check
+```
+
+##### `static_files.<string>.<type=binary_patch>.tag` Label grouping related patches, recorded in the run's binary_patches.yaml
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+secureboot
+```
+
+##### `static_files.<string>.<type=binary_patch>.patches` Multiple edits to this file
+
+|||
+|-|-|
+|__Type__|list of Binary patch entry|
+|__Default__|`null`|
+
+A list of edits applied to this one file in a single host-side pass. Use this instead of the inline file_offset/hex_bytes/asm fields when patching a binary at more than one offset. Overlapping write ranges are rejected.
+
+###### `static_files.<string>.<type=binary_patch>.patches.<item>` Binary patch entry
+
+A single edit within a ``binary_patch`` action: bytes to write at one
+    file offset, optionally guarded by an ``expect`` check. Multiple entries can
+    target one file via the action's ``patches`` list; they are applied
+    host-side to one buffer in a single pass, and overlapping write ranges are
+    rejected.
+
+###### `static_files.<string>.<type=binary_patch>.patches.<item>.file_offset` File offset (integer)
+
+|||
+|-|-|
+|__Type__|integer|
+
+
+###### `static_files.<string>.<type=binary_patch>.patches.<item>.hex_bytes` Bytes to write at offset (hex string)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+DEADBEEF
+```
+
+```yaml
+90 90
+```
+
+###### `static_files.<string>.<type=binary_patch>.patches.<item>.asm` Assembly code to write at offset (runs through keystone)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+nop
+```
+
+```yaml
+'mov r0, #0xdeadbeef'
+```
+
+###### `static_files.<string>.<type=binary_patch>.patches.<item>.mode` Assembly mode
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+arm
+```
+
+```yaml
+thumb
+```
+
+###### `static_files.<string>.<type=binary_patch>.patches.<item>.expect` Expected bytes at offset before patching (hex string)
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+If set, the current bytes at file_offset are compared against this hex string (over its own length, which may differ from the patch length) before the patch is written. If the bytes at the offset already equal the patch bytes, the patch is skipped (idempotent re-run); otherwise the on_mismatch policy applies.
+
+```yaml
+0102 0304
+```
+
+```yaml
+DEADBEEF
+```
+
+###### `static_files.<string>.<type=binary_patch>.patches.<item>.on_mismatch` Policy when 'expect' does not match
+
+|||
+|-|-|
+|__Type__|`"fail"` or `"skip"` or `"warn"`|
+|__Default__|`fail`|
+
+fail: abort the run (default, safest). skip: leave the file unpatched and continue. warn: log a warning and write the patch anyway. Only meaningful when 'expect' is set.
+
+###### `static_files.<string>.<type=binary_patch>.patches.<item>.why` Rationale for this patch, recorded in the run's binary_patches.yaml
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+NOP out the secure-boot check
+```
+
+###### `static_files.<string>.<type=binary_patch>.patches.<item>.tag` Label grouping related patches, recorded in the run's binary_patches.yaml
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+
+```yaml
+secureboot
 ```
 
 ## `plugins` Plugins

--- a/guest-utils/native/hyp_file_op.c
+++ b/guest-utils/native/hyp_file_op.c
@@ -52,7 +52,61 @@ int main(int argc, char **argv) {
     char *path = malloc(path_len);
     require(path, "malloc failed for path");
     strcpy(path, path_arg);
+
+    // Optional trailing "--range <off> [len]": transfer only a byte window of
+    // the *local* (guest) file rather than the whole file. put reads
+    // [off, off+len) and uploads it; get downloads the staged window and writes
+    // it at off in the target without truncating. Used by binary_patch so a
+    // few patched bytes don't stream the whole target file both ways.
+    int has_range = 0;
+    uint64_t range_off = 0, range_len = 0;
+    for (int i = arg_offset; i < argc; i++) {
+        if (strcmp(argv[i], "--range") == 0) {
+            require(i + 1 < argc, "--range needs an offset");
+            range_off = strtoull(argv[i + 1], NULL, 0);
+            if (i + 2 < argc && strncmp(argv[i + 2], "--", 2) != 0)
+                range_len = strtoull(argv[i + 2], NULL, 0);
+            has_range = 1;
+            break;
+        }
+    }
+
     if (strcmp(op, "get") == 0) {
+        if (has_range) {
+            // Download the staged window (path = staged file) and write it into
+            // the local target at range_off, r+b so the file is NOT truncated.
+            const char *local_path = (argc - arg_offset > 2) ? argv[arg_offset + 2] : NULL;
+            require(local_path && strcmp(local_path, "-") != 0,
+                    "--range get requires a target file");
+            long staged_size = portal_callN(MAGIC_GETSIZE, 1, (uint64_t)path);
+            if (staged_size < 0) {
+                fprintf(stderr, "hyp_file_op: error: staged file '%s' missing\n", path);
+                free(path);
+                return 2;
+            }
+            uint8_t *buffer = malloc(staged_size > 0 ? (size_t)staged_size : 1);
+            require(buffer, "malloc failed");
+            size_t total = 0;
+            while (total < (size_t)staged_size) {
+                size_t chunk = (size_t)staged_size - total;
+                if (chunk > MAX_MALLOC_SIZE) chunk = MAX_MALLOC_SIZE;
+                int ret = portal_call4(MAGIC_GET, (uint64_t)path, total, chunk, (uint64_t)(buffer + total));
+                if (ret < 0) { free(buffer); free(path); return 2; }
+                if (ret == 0) break;
+                total += ret;
+            }
+            FILE *f = fopen(local_path, "r+b");
+            require(f, "failed to open target file for --range get (must exist)");
+            require(fseek(f, (long)range_off, SEEK_SET) == 0, "fseek failed on target file");
+            size_t wrote = fwrite(buffer, 1, total, f);
+            fclose(f);
+            free(buffer);
+            require(wrote == total, "short write applying patch window");
+            log_fmt("Applied %zu-byte window at offset %llu of '%s'", total,
+                    (unsigned long long)range_off, local_path);
+            free(path);
+            return 0;
+        }
         log_fmt("Requesting file size for '%s'", path);
         long file_size = portal_callN(MAGIC_GETSIZE, 1, (uint64_t)path);
         if (file_size == -1) {
@@ -126,6 +180,33 @@ int main(int argc, char **argv) {
         require(argc - arg_offset >= 3, "put requires source and dest arguments");
         const char *local_path = argv[arg_offset + 1];
         const char *remote_path = argv[arg_offset + 2];
+        if (has_range) {
+            // Upload only [range_off, range_off+range_len) of the local guest
+            // file to the staged file. A zero-length window still issues one
+            // MAGIC_PUT so the staged file is created (host reads it back).
+            FILE *rin = fopen(local_path, "rb");
+            require(rin, "failed to open input file for --range put");
+            require(fseek(rin, (long)range_off, SEEK_SET) == 0, "fseek failed on input file");
+            uint8_t *rbuf = malloc(range_len > 0 ? range_len : 1);
+            require(rbuf, "malloc failed");
+            size_t nread = range_len > 0 ? fread(rbuf, 1, range_len, rin) : 0;
+            fclose(rin);
+            size_t sent = 0;
+            while (1) {
+                size_t chunk = nread - sent;
+                if (chunk > MAX_MALLOC_SIZE) chunk = MAX_MALLOC_SIZE;
+                int ret = portal_call4(MAGIC_PUT, (uint64_t)remote_path, sent, chunk, (uint64_t)(rbuf + sent));
+                if (ret < 0) { free(rbuf); free(path); return 2; }
+                sent += (size_t)ret;
+                if (sent >= nread) break;   // also exits immediately when nread==0
+                if (ret == 0) break;        // safety: no forward progress
+            }
+            log_fmt("Uploaded %zu-byte window from offset %llu of '%s'", nread,
+                    (unsigned long long)range_off, local_path);
+            free(rbuf);
+            free(path);
+            return 0;
+        }
         log_fmt("Starting file upload: '%s' to remote '%s'", local_path, remote_path);
         FILE *in = strcmp(local_path, "-") == 0 ? stdin : fopen(local_path, "rb");
         char errbuf[256];

--- a/pyplugins/apis/static_fs.py
+++ b/pyplugins/apis/static_fs.py
@@ -30,10 +30,17 @@ class StaticFS(Plugin):
             norm_path = "/" + norm_path
         return norm_path
 
-    def _resolve_path(self, path: str, max_depth: int = 40) -> Tuple[Optional[str], Optional[FileInfo]]:
+    def _resolve_path(self, path: str, max_depth: int = 40,
+                      transparent: frozenset = frozenset()) -> Tuple[Optional[str], Optional[FileInfo]]:
         """
         Resolves symlinks in both static_files and ratarmountcore up to a max_depth limit.
         Returns a tuple of the resolved path and its FileInfo (if applicable).
+
+        ``transparent`` names static_files action *types* that modify an
+        existing file in place (e.g. ``binary_patch``) rather than defining a
+        new one. For those, resolution falls through to the underlying file
+        instead of treating the action as a concrete/opaque entry, so callers
+        can query the real file (its size, bytes, ...).
         """
         norm_path = self._normalize_path(path)
 
@@ -41,7 +48,8 @@ class StaticFS(Plugin):
             # Check static files first (they take precedence)
             static_action = self._config.get("static_files", {}).get(norm_path)
             if static_action:
-                if static_action.get("type") == "symlink":
+                atype = static_action.get("type")
+                if atype == "symlink":
                     link_target = static_action.get("target")
                     if not link_target:
                         return None, None  # Invalid symlink
@@ -50,8 +58,9 @@ class StaticFS(Plugin):
                     else:
                         norm_path = self._normalize_path(os.path.join(os.path.dirname(norm_path), link_target))
                     continue   # Follow the symlink defined in config
-                else:
+                elif atype not in transparent:
                     return norm_path, None  # Found a concrete static file
+                # else: in-place action -> fall through to the underlying file
 
             # Lookup with cache for ratarmountcore
             if norm_path not in self._fileinfo_cache:
@@ -88,17 +97,22 @@ class StaticFS(Plugin):
         self._exists_cache[norm_path] = exists
         return exists
 
-    def get_size(self, path: str) -> Optional[int]:
+    def get_size(self, path: str, transparent: frozenset = frozenset()) -> Optional[int]:
         """
         Returns the size of the file in bytes without opening it.
+
+        ``transparent`` (see :meth:`_resolve_path`) lets in-place action types
+        such as ``binary_patch`` resolve to the underlying file's size instead
+        of the action's (0-byte) placeholder.
         """
-        resolved_path, fileInfo = self._resolve_path(path)
+        resolved_path, fileInfo = self._resolve_path(path, transparent=transparent)
         if not resolved_path:
             return None
 
-        # Check static_files first
-        if resolved_path in self._config.get("static_files", {}):
-            action = self._config["static_files"][resolved_path]
+        # Check static_files first, unless this path is only an in-place
+        # (transparent) action, in which case use the underlying file below.
+        action = self._config.get("static_files", {}).get(resolved_path)
+        if action is not None and action.get("type") not in transparent:
             if action.get("type") == "inline_file":
                 contents = action.get("contents", b"")
                 if isinstance(contents, str):

--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -314,6 +314,14 @@ class LiveImage(Plugin):
                         if 'mode' in action:
                             record_mode(file_path, action['mode'])
 
+                # A placed host_file/inline_file may carry 'patches' to apply
+                # after it lands in the guest. Expand them into the same Phase 4
+                # binary_patch pipeline by queueing a synthetic binary_patch
+                # against this path (which now resolves to the staged file).
+                synth = self._synth_file_patch_action(file_path, action)
+                if synth is not None:
+                    self.patch_queue.append((file_path, synth))
+
             # Queue or generate commands for post-tar execution
             elif action_type == "binary_patch":
                 self.patch_queue.append((file_path, action))
@@ -583,6 +591,31 @@ class LiveImage(Plugin):
         validator and this build-time parser accept exactly the same inputs.
         Raises ValueError on invalid/odd-length hex."""
         return bytes.fromhex(normalize_hex_string(s))
+
+    @staticmethod
+    def _synth_file_patch_action(file_path: str, action: Dict) -> Optional[Dict]:
+        """Turn a placed ``host_file``/``inline_file`` that carries a
+        ``patches`` list into the equivalent standalone ``binary_patch`` action
+        to queue against its staged path, so both go through one pipeline.
+
+        Returns ``None`` when the action has no patches. Raises ValueError if
+        the file uses a glob source or destination, since the patch target
+        would then be ambiguous (which of the matched files?). Glob detection
+        matches the staging code, which only treats a wildcard in the final
+        path component (``dest_path.name`` / source ``name``) as a glob.
+        """
+        patches = action.get("patches")
+        if not patches:
+            return None
+        dest_name = os.path.basename(file_path)
+        src_name = os.path.basename(action.get("host_path") or "")
+        if any(c in dest_name or c in src_name for c in ("*", "?")):
+            raise ValueError(
+                f"static_files {action.get('type')} {file_path}: 'patches' "
+                "cannot be combined with a glob source or destination — the "
+                "patch target would be ambiguous. Give each file its own "
+                "host_file/inline_file entry with its own patches.")
+        return {"type": "binary_patch", "patches": list(patches)}
 
     def _normalize_patch_entries(self, action: Dict) -> Tuple[Optional[list], Optional[str]]:
         """Expand a binary_patch action into a flat list of per-offset edit

--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -483,6 +483,7 @@ class LiveImage(Plugin):
                 shared_file_name = f"patch_{i}"
                 base_off, win_len = self._patch_window(action)
                 self._patch_base_offset[i] = base_off
+                self._check_patch_within_file(file_path, base_off, win_len)
                 add_require_exists(file_path, "binary_patch")
                 patch_staging_cmds.append(
                     f"/igloo/boot/hyp_file_op put {shlex.quote(file_path)} "
@@ -781,6 +782,38 @@ class LiveImage(Plugin):
             lo = off if lo is None else min(lo, off)
             hi = off + span if hi is None else max(hi, off + span)
         return lo, hi - lo
+
+    @staticmethod
+    def _window_exceeds_size(base_off: int, win_len: int,
+                             size: Optional[int]) -> bool:
+        """True only when the size is known (not None) and the patch window
+        runs past the end of the file. Unknown size -> never flagged (skip)."""
+        return size is not None and base_off + win_len > size
+
+    def _check_patch_within_file(self, file_path: str, base_off: int,
+                                 win_len: int) -> None:
+        """Fail before boot if a patch window falls past the end of its target
+        file, when the size can be determined from the static filesystem.
+
+        Uses the ``static_fs`` view, which composes the base rootfs with
+        config operations (``host_file``/``inline_file``) and resolves symlinks;
+        ``binary_patch`` is passed through as an in-place edit so we read the
+        underlying file's size. If the size can't be determined (target not in
+        the rootfs, static_fs unavailable), the check is skipped rather than
+        failing — this catches out-of-bounds offsets without false positives,
+        and is complementary to per-edit ``expect`` verification.
+        """
+        try:
+            size = plugins.static_fs.get_size(file_path, transparent={"binary_patch"})
+        except Exception as e:
+            self.logger.debug(
+                f"binary_patch: size check skipped for {file_path}: {e}")
+            return
+        if self._window_exceeds_size(base_off, win_len, size):
+            raise ValueError(
+                f"binary_patch {file_path}: patch window "
+                f"{base_off:#x}..{base_off + win_len:#x} exceeds file size "
+                f"{size} bytes — wrong offset or wrong target file?")
 
     def _gen_asm_patch_bytes(self, asm_code: str, user_mode: Optional[str]) -> Optional[bytes]:
         """Assembles assembly code into bytes using Keystone."""

--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -12,6 +12,9 @@ Overview
 - Supports various file actions: delete, move, shim, dir, host_file, inline_file, binary_patch, dev, symlink.
 - Efficient setup script generation using hyp_file_op for file transfer.
 - Batch processing of binary patches via a single hypercall.
+- Optional pre-patch verification of expected bytes (``expect`` /
+  ``on_mismatch``) and per-patch provenance (``why`` / ``tag``), recorded in
+  ``binary_patches.yaml`` in the run output directory.
 - Handles permissions, symlinks, device nodes, and error reporting.
 
 Usage
@@ -32,7 +35,8 @@ Classes
 
 """
 
-from penguin import Plugin, plugins
+from penguin import Plugin, plugins, yaml
+from penguin.penguin_config.structure import normalize_hex_string
 from penguin.plugin_manager import resolve_bound_method_from_class
 from penguin.defaults import static_dir as STATIC_DIR
 from penguin.utils import get_arch_subdir
@@ -558,27 +562,168 @@ class LiveImage(Plugin):
         add_run_or_report(f"/igloo/boot/send_portalcall {GEN_LIVE_IMAGE_ACTION_FINISHED:#x}")
         return "\n".join(script_lines) + "\n"
 
-    def _apply_patch_to_file_content(self, original_content: bytes, action: Dict) -> Optional[bytes]:
-        """Applies a patch to a byte string and returns the new bytes."""
-        if bool(action.get('hex_bytes')) == bool(action.get('asm')):
-            self.logger.error(
-                "Binary patch must have exactly one of 'hex_bytes' or 'asm'.")
-            return None
+    @staticmethod
+    def _parse_hex(s: str) -> bytes:
+        """Parse a hex byte string, allowing an optional 0x prefix and spaces.
+        Delegates to the schema's normalize_hex_string so the config-load
+        validator and this build-time parser accept exactly the same inputs.
+        Raises ValueError on invalid/odd-length hex."""
+        return bytes.fromhex(normalize_hex_string(s))
 
-        if action.get('asm'):
-            patch_bytes = self._gen_asm_patch_bytes(
-                action['asm'], action.get('mode'))
-            if patch_bytes is None:
-                return None
-        else:
-            patch_bytes = bytes.fromhex(action['hex_bytes'].replace(" ", ""))
+    def _normalize_patch_entries(self, action: Dict) -> Tuple[Optional[list], Optional[str]]:
+        """Expand a binary_patch action into a flat list of per-offset edit
+        dicts. An action uses *either* the inline single-edit form
+        (file_offset + hex_bytes/asm) *or* the ``patches`` list, not both.
+        Returns ``(entries, error)``."""
+        patches = action.get("patches")
+        # Per-edit fields carried at the action level are meaningless once
+        # 'patches' is used (each entry carries its own), so reject that mix
+        # loudly. on_mismatch is omitted here: it defaults to "fail" in the
+        # schema, so an action-level value can't be told apart from the default.
+        action_level = [k for k in ("file_offset", "hex_bytes", "asm", "mode",
+                                    "expect", "why", "tag")
+                        if action.get(k) is not None]
+        if patches:
+            if action_level:
+                return None, ("binary_patch: per-edit fields must go inside each "
+                              f"'patches' entry, not at the action level "
+                              f"(saw action-level {action_level})")
+            return list(patches), None
+        if action.get("file_offset") is None:
+            return None, ("binary_patch: needs 'file_offset' (inline single edit) "
+                          "or a non-empty 'patches' list")
+        # Inline single edit: reuse every patch-relevant field from the action
+        # (all but the wrapper keys) so new fields flow through automatically.
+        entry = {k: v for k, v in action.items() if k not in ("type", "patches")}
+        return [entry], None
 
-        file_offset = action['file_offset']
-        return (
-            original_content[:file_offset] +
-            patch_bytes +
-            original_content[file_offset + len(patch_bytes):]
-        )
+    def _entry_patch_bytes(self, entry: Dict) -> Tuple[Optional[bytes], Optional[str]]:
+        """Compute the bytes one edit writes (assemble asm or parse hex).
+        Returns ``(patch_bytes, error)``."""
+        has_hex = bool(entry.get("hex_bytes"))
+        has_asm = bool(entry.get("asm"))
+        if has_hex == has_asm:
+            return None, "must have exactly one of 'hex_bytes' or 'asm'"
+        if has_asm:
+            pb = self._gen_asm_patch_bytes(entry["asm"], entry.get("mode"))
+            if pb is None:
+                return None, "failed to assemble asm"
+            return pb, None
+        try:
+            return self._parse_hex(entry["hex_bytes"]), None
+        except ValueError as e:
+            return None, f"invalid hex_bytes {entry['hex_bytes']!r}: {e}"
+
+    def _verify_entry(self, original_content: bytes, entry: Dict,
+                      patch_bytes: bytes) -> Tuple[str, str]:
+        """Apply one edit's ``expect``/``on_mismatch`` policy against the
+        pristine file bytes. Returns ``(status, detail)`` where status is
+        'applied', 'skipped', or 'failed'.
+
+        ``expect`` is checked over its own length (which may differ from the
+        patch length). If the bytes at the offset already equal the patch
+        bytes, the edit is an idempotent skip under *every* policy.
+        """
+        off = entry["file_offset"]
+        if not entry.get("expect"):
+            return "applied", ""
+        try:
+            expect_bytes = self._parse_hex(entry["expect"])
+        except ValueError as e:
+            return "failed", f"invalid expect {entry['expect']!r}: {e}"
+        current = original_content[off:off + len(expect_bytes)]
+        if current == expect_bytes:
+            return "applied", ""
+        if original_content[off:off + len(patch_bytes)] == patch_bytes:
+            return "skipped", "already patched (bytes at offset equal the patch bytes)"
+        mismatch = (
+            f"expected {expect_bytes.hex()} at offset {off:#x} "
+            f"but found {current.hex() or '<EOF>'} "
+            f"(file is {len(original_content)} bytes)")
+        policy = entry.get("on_mismatch") or "fail"
+        if policy == "skip":
+            return "skipped", mismatch
+        if policy == "warn":
+            return "applied", f"patched despite mismatch: {mismatch}"
+        return "failed", mismatch
+
+    @staticmethod
+    def _patch_record(entry: Dict, result: str, detail: str) -> Dict:
+        """Build one provenance record (ordered: offset, result, tag, why, detail)."""
+        rec = {}
+        if entry.get("file_offset") is not None:
+            rec["file_offset"] = hex(entry["file_offset"])
+        rec["result"] = result
+        for k in ("tag", "why"):
+            if entry.get(k):
+                rec[k] = entry[k]
+        if detail:
+            rec["detail"] = detail
+        return rec
+
+    def _apply_binary_patch(self, original_content: bytes,
+                            action: Dict) -> Tuple[Optional[bytes], list, bool]:
+        """Apply every edit of one binary_patch action to a single buffer.
+
+        Returns ``(new_content, records, failed)``:
+          - ``records``: one provenance dict per edit.
+          - ``new_content``: the patched bytes, or None if any edit failed.
+          - ``failed``: True if any edit failed (fail-policy mismatch, bad
+            bytes, or an overlapping write range). The caller must then abort
+            and leave the file untouched.
+
+        All edits are applied to one buffer in a single pass; overlapping write
+        ranges are detected up front and rejected so no edit can silently
+        clobber another.
+        """
+        entries, err = self._normalize_patch_entries(action)
+        if err:
+            return None, [{"result": "failed", "detail": err}], True
+
+        # Compute the bytes each edit writes first — needed both to apply and to
+        # compute write ranges for overlap detection.
+        computed = [(entry, *self._entry_patch_bytes(entry)) for entry in entries]
+
+        # Reject overlapping write ranges [off, off+len). Verifying against the
+        # pristine buffer below is only equivalent to "verify against original"
+        # because disjoint ranges cannot perturb one another. Compared pairwise
+        # (not just adjacent) so a range fully contained in another is caught
+        # too; patch lists are short, so O(n^2) is fine.
+        ranges = [(entry["file_offset"], entry["file_offset"] + len(pb), id(entry))
+                  for entry, pb, perr in computed if pb is not None]
+        overlapping = set()
+        for i, a in enumerate(ranges):
+            for b in ranges[i + 1:]:
+                if a[0] < b[1] and b[0] < a[1]:
+                    overlapping.add(a[2])
+                    overlapping.add(b[2])
+
+        buf = bytearray(original_content)
+        records = []
+        failed = False
+        for entry, patch_bytes, perr in computed:
+            if perr is not None:
+                records.append(self._patch_record(entry, "failed", perr))
+                failed = True
+                continue
+            if id(entry) in overlapping:
+                off = entry["file_offset"]
+                records.append(self._patch_record(
+                    entry, "failed",
+                    f"write range {off:#x}..{off + len(patch_bytes):#x} "
+                    "overlaps another patch to this file"))
+                failed = True
+                continue
+            status, detail = self._verify_entry(original_content, entry, patch_bytes)
+            if status == "applied":
+                off = entry["file_offset"]
+                buf[off:off + len(patch_bytes)] = patch_bytes
+            elif status == "failed":
+                failed = True
+            records.append(self._patch_record(entry, status, detail))
+
+        new_content = None if failed else bytes(buf)
+        return new_content, records, failed
 
     def _gen_asm_patch_bytes(self, asm_code: str, user_mode: Optional[str]) -> Optional[bytes]:
         """Assembles assembly code into bytes using Keystone."""
@@ -625,6 +770,7 @@ class LiveImage(Plugin):
         if staged_dir is None:
             staged_dir = tempfile.gettempdir()
 
+        records = []
         for i, (guest_path, action) in enumerate(self.patch_queue):
             shared_file_name = f"patch_{i}"
             host_side_path = Path(staged_dir) / shared_file_name
@@ -634,23 +780,56 @@ class LiveImage(Plugin):
 
             try:
                 original_content = host_side_path.read_bytes()
-                patched_content = self._apply_patch_to_file_content(
+                new_content, recs, failed = self._apply_binary_patch(
                     original_content, action)
-
-                if patched_content is None:
-                    self.logger.error(
-                        f"Failed to generate patch for {guest_path}")
-                    return -1
-
-                host_side_path.write_bytes(patched_content)
-
             except Exception as e:
                 self.logger.error(
                     f"Error during file patch of {host_side_path}: {e}", exc_info=True)
-                return -1
+                new_content, recs, failed = None, [{"result": "failed",
+                                                    "detail": str(e)}], True
 
+            for r in recs:
+                r = {"file": guest_path, **r}
+                records.append(r)
+                offset = r.get("file_offset", "?")
+                provenance = "".join(f" [{k}={r[k]}]"
+                                     for k in ("tag", "why") if k in r)
+                detail = r.get("detail")
+                line = (f"binary_patch {guest_path} @ {offset}{provenance}: "
+                        f"{r['result']}" + (f" ({detail})" if detail else ""))
+                if r["result"] == "failed":
+                    self.logger.error(line)
+                elif detail:
+                    self.logger.warning(line)
+                else:
+                    self.logger.info(line)
+
+            # Only persist the patched file when every edit succeeded; on
+            # failure we abort so the guest never copies back a half-patched
+            # file. Returning -1 propagates through send_portalcall's exit code
+            # to run_or_report, which halts the image build.
+            if failed:
+                self._write_patch_report(records)
+                self.logger.error(
+                    f"Aborting: binary patch of '{guest_path}' failed.")
+                return -1
+            if new_content is not None:
+                host_side_path.write_bytes(new_content)
+
+        self._write_patch_report(records)
         self.logger.info("Batch patching completed successfully.")
         return 0
+
+    def _write_patch_report(self, records):
+        """Record patch provenance (offset, tag, why, result) in the run output."""
+        outdir = self.get_arg("outdir")
+        if not outdir or not records:
+            return
+        try:
+            with open(Path(outdir) / "binary_patches.yaml", "w") as f:
+                yaml.dump(records, f, sort_keys=False)
+        except Exception as e:
+            self.logger.error(f"Could not write binary_patches.yaml: {e}")
 
     @plugins.portalcall.portalcall(GEN_LIVE_IMAGE_ACTION_FINISHED)
     def _on_live_image_finished(self):

--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -47,7 +47,14 @@ import os
 from typing import Iterator, Dict, Tuple, Optional, Callable
 from pathlib import Path
 import tempfile
-import keystone
+try:
+    import keystone
+except ImportError:
+    # keystone (asm assembly) is optional: only the 'asm' patch form needs it,
+    # and that path is exercised by the integration fixture, not host unit
+    # tests. _gen_asm_patch_bytes already guards on `keystone is None`. Making
+    # the import soft lets the plugin load in a host [test]-only venv.
+    keystone = None
 import tarfile
 import shlex
 

--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -773,10 +773,27 @@ class LiveImage(Plugin):
                     "overlaps another patch to this file"))
                 failed = True
                 continue
+            # Bounds-check the write against the actual buffer before touching
+            # it. bytearray slice-assignment silently misplaces bytes when the
+            # start is past the end (appends) or negative (writes from the far
+            # end), so an offset beyond the real window — e.g. a short read
+            # because the guest file was smaller than declared, or a negative
+            # offset — would corrupt the file instead of failing. In the normal
+            # windowed case pos is in [0, len) by construction, so this never
+            # false-trips; it only fires on those degenerate reads.
+            pos = entry["file_offset"] - base_offset
+            if pos < 0 or pos + len(patch_bytes) > len(original_content):
+                off = entry["file_offset"]
+                records.append(self._patch_record(
+                    entry, "failed",
+                    f"offset {off:#x} (window position {pos}) is outside the "
+                    f"{len(original_content)}-byte target window — bad offset "
+                    "or the file is shorter than the patch expects"))
+                failed = True
+                continue
             status, detail = self._verify_entry(
                 original_content, entry, patch_bytes, base_offset)
             if status == "applied":
-                pos = entry["file_offset"] - base_offset
                 buf[pos:pos + len(patch_bytes)] = patch_bytes
             elif status == "failed":
                 failed = True

--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -79,6 +79,7 @@ class LiveImage(Plugin):
         self.script_generated = False
         self.fs_generated = False
         self.patch_queue = []
+        self._patch_base_offset = {}
         self.config = self.get_arg("conf")
         core_config = self.config.get("core", {})
         self.arch = core_config.get("arch", "x86_64")
@@ -179,6 +180,7 @@ class LiveImage(Plugin):
         post_tar_commands = []
         paths_to_delete = []
         self.patch_queue = []  # Reset for this run
+        self._patch_base_offset = {}  # index -> window base offset (set in Phase 4)
         move_sources_to_remove = []
         staging_dir = Path(self.staged_dir)
         from collections import defaultdict
@@ -468,16 +470,25 @@ class LiveImage(Plugin):
         add_run_or_report("tar x -om -f /igloo/boot/filesystem.tar -C / --no-same-permissions")
 
         # --- Phase 4: Batch-process binary patches ---
+        # Only the byte window each patch touches is shipped host<->guest (via
+        # hyp_file_op --range), not the whole target file, so patching a few
+        # bytes of a large binary no longer streams the entire file twice. The
+        # host records each window's base offset so the batch hypercall can
+        # apply edits (whose offsets are absolute) against the window.
         if self.patch_queue:
             patch_staging_cmds = []
             patch_return_cmds = []
 
-            for i, (file_path, _) in enumerate(self.patch_queue):
+            for i, (file_path, action) in enumerate(self.patch_queue):
                 shared_file_name = f"patch_{i}"
+                base_off, win_len = self._patch_window(action)
+                self._patch_base_offset[i] = base_off
                 add_require_exists(file_path, "binary_patch")
                 patch_staging_cmds.append(
-                    f"/igloo/boot/hyp_file_op put {shlex.quote(file_path)} {shlex.quote(os.path.basename(shared_file_name))}")
-            script_lines.append("\n# Staging all files for patching")
+                    f"/igloo/boot/hyp_file_op put {shlex.quote(file_path)} "
+                    f"{shlex.quote(os.path.basename(shared_file_name))} "
+                    f"--range {base_off:#x} {win_len:#x}")
+            script_lines.append("\n# Staging patch windows")
             for cmd in patch_staging_cmds:
                 add_run_or_report(cmd)
 
@@ -486,9 +497,11 @@ class LiveImage(Plugin):
 
             for i, (file_path, _) in enumerate(self.patch_queue):
                 shared_file_name = f"patch_{i}"
+                base_off = self._patch_base_offset[i]
                 patch_return_cmds.append(
-                    f"/igloo/boot/hyp_file_op get {shlex.quote(shared_file_name)} {shlex.quote(file_path)}")
-            script_lines.append("\n# Moving all patched files back")
+                    f"/igloo/boot/hyp_file_op get {shlex.quote(shared_file_name)} "
+                    f"{shlex.quote(file_path)} --range {base_off:#x}")
+            script_lines.append("\n# Writing patched windows back")
             for cmd in patch_return_cmds:
                 add_run_or_report(cmd)
 
@@ -615,7 +628,7 @@ class LiveImage(Plugin):
             return None, f"invalid hex_bytes {entry['hex_bytes']!r}: {e}"
 
     def _verify_entry(self, original_content: bytes, entry: Dict,
-                      patch_bytes: bytes) -> Tuple[str, str]:
+                      patch_bytes: bytes, base_offset: int = 0) -> Tuple[str, str]:
         """Apply one edit's ``expect``/``on_mismatch`` policy against the
         pristine file bytes. Returns ``(status, detail)`` where status is
         'applied', 'skipped', or 'failed'.
@@ -623,18 +636,24 @@ class LiveImage(Plugin):
         ``expect`` is checked over its own length (which may differ from the
         patch length). If the bytes at the offset already equal the patch
         bytes, the edit is an idempotent skip under *every* policy.
+
+        ``base_offset`` is subtracted from the edit's ``file_offset`` before
+        indexing ``original_content``, so the caller can pass just a window of
+        the file (starting at ``base_offset``) instead of the whole thing;
+        recorded/reported offsets stay absolute. Defaults to 0 (whole file).
         """
         off = entry["file_offset"]
+        pos = off - base_offset
         if not entry.get("expect"):
             return "applied", ""
         try:
             expect_bytes = self._parse_hex(entry["expect"])
         except ValueError as e:
             return "failed", f"invalid expect {entry['expect']!r}: {e}"
-        current = original_content[off:off + len(expect_bytes)]
+        current = original_content[pos:pos + len(expect_bytes)]
         if current == expect_bytes:
             return "applied", ""
-        if original_content[off:off + len(patch_bytes)] == patch_bytes:
+        if original_content[pos:pos + len(patch_bytes)] == patch_bytes:
             return "skipped", "already patched (bytes at offset equal the patch bytes)"
         mismatch = (
             f"expected {expect_bytes.hex()} at offset {off:#x} "
@@ -661,8 +680,8 @@ class LiveImage(Plugin):
             rec["detail"] = detail
         return rec
 
-    def _apply_binary_patch(self, original_content: bytes,
-                            action: Dict) -> Tuple[Optional[bytes], list, bool]:
+    def _apply_binary_patch(self, original_content: bytes, action: Dict,
+                            base_offset: int = 0) -> Tuple[Optional[bytes], list, bool]:
         """Apply every edit of one binary_patch action to a single buffer.
 
         Returns ``(new_content, records, failed)``:
@@ -675,6 +694,12 @@ class LiveImage(Plugin):
         All edits are applied to one buffer in a single pass; overlapping write
         ranges are detected up front and rejected so no edit can silently
         clobber another.
+
+        ``base_offset`` is subtracted from each edit's ``file_offset`` before
+        indexing ``original_content``, so the caller may pass just a window of
+        the file (starting at ``base_offset``). ``new_content`` is then that
+        window with the edits applied; recorded offsets stay absolute. Defaults
+        to 0 (``original_content`` is the whole file).
         """
         entries, err = self._normalize_patch_entries(action)
         if err:
@@ -714,16 +739,48 @@ class LiveImage(Plugin):
                     "overlaps another patch to this file"))
                 failed = True
                 continue
-            status, detail = self._verify_entry(original_content, entry, patch_bytes)
+            status, detail = self._verify_entry(
+                original_content, entry, patch_bytes, base_offset)
             if status == "applied":
-                off = entry["file_offset"]
-                buf[off:off + len(patch_bytes)] = patch_bytes
+                pos = entry["file_offset"] - base_offset
+                buf[pos:pos + len(patch_bytes)] = patch_bytes
             elif status == "failed":
                 failed = True
             records.append(self._patch_record(entry, status, detail))
 
         new_content = None if failed else bytes(buf)
         return new_content, records, failed
+
+    def _patch_window(self, action: Dict) -> Tuple[int, int]:
+        """Compute the ``(base_offset, length)`` byte window that covers every
+        edit of one binary_patch action, so only that range is transferred
+        to/from the guest instead of the whole file. The window spans from the
+        lowest edit offset to the furthest byte any edit reads (``expect``) or
+        writes (patch). Raises ValueError on a malformed edit (bad bytes,
+        missing offset, both/neither hex_bytes+asm) so the run fails before
+        boot rather than aborting mid-build.
+        """
+        entries, err = self._normalize_patch_entries(action)
+        if err:
+            raise ValueError(err)
+        lo = hi = None
+        for entry in entries:
+            patch_bytes, perr = self._entry_patch_bytes(entry)
+            if perr is not None:
+                raise ValueError(
+                    f"binary_patch at offset {entry.get('file_offset')}: {perr}")
+            off = entry["file_offset"]
+            span = len(patch_bytes)
+            if entry.get("expect"):
+                try:
+                    span = max(span, len(self._parse_hex(entry["expect"])))
+                except ValueError as e:
+                    raise ValueError(
+                        f"binary_patch at offset {off:#x}: invalid expect "
+                        f"{entry['expect']!r}: {e}")
+            lo = off if lo is None else min(lo, off)
+            hi = off + span if hi is None else max(hi, off + span)
+        return lo, hi - lo
 
     def _gen_asm_patch_bytes(self, asm_code: str, user_mode: Optional[str]) -> Optional[bytes]:
         """Assembles assembly code into bytes using Keystone."""
@@ -779,9 +836,13 @@ class LiveImage(Plugin):
                 f"Patching guest file '{guest_path}' via staged file '{host_side_path}'")
 
             try:
-                original_content = host_side_path.read_bytes()
+                # original_content is only the window that was staged
+                # (hyp_file_op --range); base_offset rebases absolute edit
+                # offsets onto it.
+                window = host_side_path.read_bytes()
+                base_offset = self._patch_base_offset.get(i, 0)
                 new_content, recs, failed = self._apply_binary_patch(
-                    original_content, action)
+                    window, action, base_offset)
             except Exception as e:
                 self.logger.error(
                     f"Error during file patch of {host_side_path}: {e}", exc_info=True)

--- a/src/penguin/penguin_config/gen_docs.py
+++ b/src/penguin/penguin_config/gen_docs.py
@@ -48,6 +48,11 @@ def gen_docs_literal_arg(a):
 def gen_docs_type_name(t):
     """Convert the Python type `t` to a string for use in generated docs."""
 
+    # Strip Annotated[...] metadata (e.g. AfterValidator-carrying type aliases)
+    # down to the underlying type for naming purposes.
+    if hasattr(t, "__metadata__"):
+        return gen_docs_type_name(typing.get_args(t)[0])
+
     og = typing.get_origin(t)
     args = typing.get_args(t)
 
@@ -58,7 +63,17 @@ def gen_docs_type_name(t):
     elif og is Literal:
         return " or ".join([gen_docs_literal_arg(a) for a in args])
     elif og in (list, tuple) or t in (list, tuple):
-        return "list of " + gen_docs_type_name(args[0]) if args else "list"
+        if not args:
+            return "list"
+        inner = args[0]
+        if hasattr(inner, "model_fields"):
+            # Name a model element by its title so `list of <Model>` renders;
+            # the element's own fields are documented by the list branch in
+            # gen_docs. (Models are otherwise left to raise in this function so
+            # type_has_simple_name can detect them.)
+            title = getattr(inner, "model_config", {}).get("title")
+            return "list of " + (title or inner.__name__)
+        return "list of " + gen_docs_type_name(inner)
     elif og is dict or t is dict:
         if len(args) >= 2:
             return f"mapping from {gen_docs_type_name(args[0])} to {gen_docs_type_name(args[1])}"
@@ -290,11 +305,35 @@ def gen_docs(path=[], docs_field=DocsField.from_type(structure.Main)):
             path=path + [f"<{key_type_str}>"],
             docs_field=DocsField.from_type(val_type),
         )
-    elif type_origin is Union and first_model_arg is not None:
-        # The type is `Optional[T]`. Try again with just `T`.
+    elif type_origin is Union:
+        # The type is `Optional[T]` (or a wider Union). Re-dispatch on the inner
+        # type so nested structure is documented — including `Optional[list[T]]`,
+        # whose inner `list[T]` is handled by the list branch below.
+        non_none = [a for a in type_args if a is not NoneType]
+        inner = non_none[0] if len(non_none) == 1 else None
+        inner_is_recursable = inner is not None and (
+            hasattr(inner, "model_fields")
+            or (typing.get_origin(inner) in (list, tuple)
+                and any(hasattr(x, "model_fields") for x in typing.get_args(inner)))
+        )
+        if inner_is_recursable:
+            out += gen_docs(
+                path=path,
+                docs_field=DocsField.from_type(inner).merge(docs_field),
+            )
+        elif first_model_arg is not None:
+            out += gen_docs(
+                path=path,
+                docs_field=DocsField.from_type(first_model_arg).merge(docs_field),
+            )
+        else:
+            out += gen_docs_field(path, docs_field)
+    elif type_origin in (list, tuple) and first_model_arg is not None:
+        # The type is `list[Model]`. Name the list here, then document one item.
+        out += gen_docs_field(path=path, docs_field=docs_field)
         out += gen_docs(
-            path=path,
-            docs_field=DocsField.from_type(first_model_arg).merge(docs_field),
+            path=path + ["<item>"],
+            docs_field=DocsField.from_type(first_model_arg),
         )
     else:
         # The type does not inherit from `BaseModel` and it doesn't have an argument that does.

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -1272,6 +1272,29 @@ class BinaryPatchEntry(PartialModelMixin, BaseModel):
     ] = None
 
 
+# Shared 'patches' field for the file-producing actions (inline_file /
+# host_file). Placing a file and patching it are orthogonal — the file's
+# 'type' says what it is, 'patches' modifies what was placed — so patching is
+# expressed as an operation on those actions rather than a mutually-exclusive
+# type. The edits funnel into the same host-side pipeline as the standalone
+# 'binary_patch' action, applied after the file is staged into the guest.
+_PLACED_FILE_PATCHES = (
+    "patches",
+    Optional[List[BinaryPatchEntry]],
+    Field(
+        default=None,
+        title="Binary patches to apply after this file is placed",
+        description="A list of binary edits applied to this file after it is "
+        "staged into the guest, in a single host-side pass (same semantics as "
+        "the standalone 'binary_patch' action). Each edit may verify the bytes "
+        "currently at its offset (expect/on_mismatch) and record rationale "
+        "(why/tag); every outcome is written to binary_patches.yaml in the run "
+        "output. Overlapping write ranges are rejected. Cannot be combined with "
+        "a glob source or destination (the patch target would be ambiguous).",
+    ),
+)
+
+
 StaticFileAction = _union(
     class_name="StaticFileAction",
     title="Static filesystem action",
@@ -1286,6 +1309,7 @@ StaticFileAction = _union(
             fields=(
                 ("mode", int, Field(0o644, title="Permissions of file")),
                 ("contents", str, Field(title="Contents of file")),
+                _PLACED_FILE_PATCHES,
             ),
         ),
         dict(
@@ -1295,6 +1319,7 @@ StaticFileAction = _union(
             fields=(
                 ("mode", int, Field(0o755, title="Permissions of file")),
                 ("host_path", str, Field(title="Host path")),
+                _PLACED_FILE_PATCHES,
             ),
         ),
         dict(

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -1230,7 +1230,7 @@ class BinaryPatchEntry(PartialModelMixin, BaseModel):
 
     model_config = ConfigDict(title="Binary patch entry", extra="forbid")
 
-    file_offset: Annotated[int, Field(title="File offset (integer)")]
+    file_offset: Annotated[int, Field(title="File offset (integer)", ge=0)]
     hex_bytes: Annotated[
         Optional[HexStr],
         Field(default=None, title="Bytes to write at offset (hex string)",
@@ -1394,6 +1394,7 @@ StaticFileAction = _union(
                     Optional[int],
                     Field(
                         default=None,
+                        ge=0,
                         title="File offset (integer) — for a single inline edit; omit when using 'patches'",
                     ),
                 ),

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -1,6 +1,7 @@
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union, ClassVar
 from pydantic import BaseModel, Field, RootModel, field_validator, model_validator
 from pydantic.config import ConfigDict
+from pydantic.functional_validators import AfterValidator
 from pydantic_partial import PartialModelMixin, create_partial_model
 
 '''
@@ -10,6 +11,40 @@ functions that use them.
 '''
 
 ENV_MAGIC_VAL = "DYNVALDYNVALDYNVAL"
+
+
+def normalize_hex_string(value: str) -> str:
+    """Normalize a user-supplied hex byte string: strip whitespace, allow an
+    optional ``0x``/``0X`` prefix, and drop internal spaces. Returns lowercase
+    hex with no separators. Raises ``ValueError`` if it is not valid hex or has
+    an odd digit count. Shared by the schema validator and the patch applier so
+    both accept exactly the same inputs."""
+    s = value.strip()
+    if s[:2].lower() == "0x":
+        s = s[2:]
+    s = s.replace(" ", "")
+    # bytes.fromhex validates both the alphabet and the even-length requirement.
+    bytes.fromhex(s)
+    return s.lower()
+
+
+def _validate_hex_string(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return value
+    try:
+        normalize_hex_string(value)
+    except ValueError as e:
+        raise ValueError(
+            f"expected an even-length hex byte string (optionally 0x-prefixed, "
+            f"spaces allowed), got {value!r}: {e}"
+        )
+    return value
+
+
+# A hex byte string that is validated at config-load time (so a typo fails with
+# a clear message instead of a raw fromhex error during image build). The
+# original text is preserved; callers normalize with normalize_hex_string.
+HexStr = Annotated[str, AfterValidator(_validate_hex_string)]
 
 
 class StrSep(RootModel):
@@ -1186,6 +1221,57 @@ class LibInject(PartialModelMixin, BaseModel):
     ]
 
 
+class BinaryPatchEntry(PartialModelMixin, BaseModel):
+    """A single edit within a ``binary_patch`` action: bytes to write at one
+    file offset, optionally guarded by an ``expect`` check. Multiple entries can
+    target one file via the action's ``patches`` list; they are applied
+    host-side to one buffer in a single pass, and overlapping write ranges are
+    rejected."""
+
+    model_config = ConfigDict(title="Binary patch entry", extra="forbid")
+
+    file_offset: Annotated[int, Field(title="File offset (integer)")]
+    hex_bytes: Annotated[
+        Optional[HexStr],
+        Field(default=None, title="Bytes to write at offset (hex string)",
+              examples=["DEADBEEF", "90 90"]),
+    ] = None
+    asm: Annotated[
+        Optional[str],
+        Field(default=None,
+              title="Assembly code to write at offset (runs through keystone)",
+              examples=["nop", "mov r0, #0xdeadbeef"]),
+    ] = None
+    mode: Annotated[
+        Optional[str],
+        Field(default=None, title="Assembly mode", examples=["arm", "thumb"]),
+    ] = None
+    expect: Annotated[
+        Optional[HexStr],
+        Field(default=None,
+              title="Expected bytes at offset before patching (hex string)",
+              description="If set, the current bytes at file_offset are compared against this hex string (over its own length, which may differ from the patch length) before the patch is written. If the bytes at the offset already equal the patch bytes, the patch is skipped (idempotent re-run); otherwise the on_mismatch policy applies.",
+              examples=["0102 0304", "DEADBEEF"]),
+    ] = None
+    on_mismatch: Annotated[
+        Literal["fail", "skip", "warn"],
+        Field(default="fail", title="Policy when 'expect' does not match",
+              description="fail: abort the run (default, safest). skip: leave the file unpatched and continue. warn: log a warning and write the patch anyway. Only meaningful when 'expect' is set."),
+    ] = "fail"
+    why: Annotated[
+        Optional[str],
+        Field(default=None,
+              title="Rationale for this patch, recorded in the run's binary_patches.yaml",
+              examples=["NOP out the secure-boot check"]),
+    ] = None
+    tag: Annotated[
+        Optional[str],
+        Field(default=None,
+              title="Label grouping related patches, recorded in the run's binary_patches.yaml",
+              examples=["secureboot"]),
+    ] = None
+
+
 StaticFileAction = _union(
     class_name="StaticFileAction",
     title="Static filesystem action",
@@ -1276,16 +1362,19 @@ StaticFileAction = _union(
         dict(
             discrim_val="binary_patch",
             title="Patch binary file",
-            description="Make a patch to a binary file at the specified offset. This can either be arbitrary bytes specified as a hex string, or assembly code that will be automatically assembled in the specified mode.",
+            description="Patch a binary file at one or more offsets. A single edit is given inline (file_offset + one of hex_bytes/asm); multiple edits to the same file go in the 'patches' list (applied together in one host-side pass, with overlapping write ranges rejected). Each edit may verify the bytes currently at its offset first (expect/on_mismatch) so the patch is idempotent and safe across firmware variants, and record rationale (why/tag); every edit's outcome is written to binary_patches.yaml in the run output.",
             fields=(
                 (
                     "file_offset",
-                    int,
-                    Field(title="File offset (integer)"),
+                    Optional[int],
+                    Field(
+                        default=None,
+                        title="File offset (integer) — for a single inline edit; omit when using 'patches'",
+                    ),
                 ),
                 (
                     "hex_bytes",
-                    Optional[str],
+                    Optional[HexStr],
                     Field(
                         default=None,
                         title="Bytes to write at offset (hex string)",
@@ -1308,6 +1397,52 @@ StaticFileAction = _union(
                         default=None,
                         title="Assembly mode",
                         examples=["arm", "thumb"],
+                    ),
+                ),
+                (
+                    "expect",
+                    Optional[HexStr],
+                    Field(
+                        default=None,
+                        title="Expected bytes at offset before patching (hex string)",
+                        description="If set, the current bytes at file_offset are compared against this hex string (over its own length, which may differ from the patch length) before the patch is written. If the bytes at the offset already equal the patch bytes, the patch is skipped (idempotent re-run); otherwise the on_mismatch policy applies.",
+                        examples=["0102 0304", "DEADBEEF"],
+                    ),
+                ),
+                (
+                    "on_mismatch",
+                    Literal["fail", "skip", "warn"],
+                    Field(
+                        default="fail",
+                        title="Policy when 'expect' does not match",
+                        description="fail: abort the run (default, safest). skip: leave the file unpatched and continue. warn: log a warning and write the patch anyway. Only meaningful when 'expect' is set.",
+                    ),
+                ),
+                (
+                    "why",
+                    Optional[str],
+                    Field(
+                        default=None,
+                        title="Rationale for this patch, recorded in the run's binary_patches.yaml",
+                        examples=["NOP out the secure-boot check"],
+                    ),
+                ),
+                (
+                    "tag",
+                    Optional[str],
+                    Field(
+                        default=None,
+                        title="Label grouping related patches, recorded in the run's binary_patches.yaml",
+                        examples=["secureboot"],
+                    ),
+                ),
+                (
+                    "patches",
+                    Optional[List[BinaryPatchEntry]],
+                    Field(
+                        default=None,
+                        title="Multiple edits to this file",
+                        description="A list of edits applied to this one file in a single host-side pass. Use this instead of the inline file_offset/hex_bytes/asm fields when patching a binary at more than one offset. Overlapping write ranges are rejected.",
                     ),
                 ),
             )

--- a/src/penguin/testing/harness.py
+++ b/src/penguin/testing/harness.py
@@ -436,11 +436,12 @@ class NullManager:
         self.published.append((plugin, event, args, kwargs))
         return iter(())
 
-    def portalcall(self, *a, **k):
-        """Identity decorator factory: ``@plugins.portalcall(magic)``."""
-        def decorator(func):
-            return func
-        return decorator
+    # NB: no ``portalcall`` method — ``portalcall`` is itself a sibling *plugin*
+    # (apis/portalcall.py), and the real decorator form is
+    # ``@plugins.portalcall.portalcall(magic)``. Letting the name fall through to
+    # ``__getattr__`` resolves it to a RecorderStub, which supports both that
+    # double form and the shorthand ``@plugins.portalcall(magic)`` as an identity
+    # decorator (a RecorderStub returns the decorated function unchanged).
 
     def get_plugin_by_name(self, name: str) -> Optional[Any]:
         return self._doubles.get(name) or self._doubles.get(name.lower())

--- a/tests/integration/test_binary_patch.py
+++ b/tests/integration/test_binary_patch.py
@@ -91,7 +91,8 @@ def _load_live_image():
                 sys.modules[k] = v
 
 
-LI = _load_live_image().LiveImage
+_MOD = _load_live_image()
+LI = _MOD.LiveImage
 
 
 @pytest.fixture
@@ -339,6 +340,45 @@ def test_patch_window_multi_disjoint(li):
 def test_patch_window_raises_on_bad_edit(li):
     with pytest.raises(ValueError):
         li._patch_window({"file_offset": 0, "hex_bytes": "aa", "asm": "nop"})
+
+
+# --- bounds check against the static filesystem ---------------------------
+@pytest.mark.parametrize("base,win,size,expected", [
+    (0, 4, None, False),   # unknown size -> never flagged
+    (0, 4, 4, False),      # exactly fits
+    (0, 4, 3, True),       # 1 byte past EOF
+    (0x10, 4, 0x13, True),  # window 0x10..0x14 exceeds size 0x13
+    (0x10, 4, 0x14, False),  # window 0x10..0x14 exactly fits size 0x14
+])
+def test_window_exceeds_size(base, win, size, expected):
+    assert LI._window_exceeds_size(base, win, size) is expected
+
+
+def test_check_within_file_raises_when_out_of_bounds(li, monkeypatch):
+    monkeypatch.setattr(_MOD.plugins, "static_fs",
+                        types.SimpleNamespace(get_size=lambda p, transparent=None: 3),
+                        raising=False)
+    with pytest.raises(ValueError, match="exceeds file size"):
+        li._check_patch_within_file("/bin/foo", 0, 4)
+
+
+def test_check_within_file_ok_when_fits(li, monkeypatch):
+    monkeypatch.setattr(_MOD.plugins, "static_fs",
+                        types.SimpleNamespace(get_size=lambda p, transparent=None: 64),
+                        raising=False)
+    li._check_patch_within_file("/bin/foo", 0x10, 4)  # no raise
+
+
+def test_check_within_file_skips_when_size_unknown(li, monkeypatch):
+    monkeypatch.setattr(_MOD.plugins, "static_fs",
+                        types.SimpleNamespace(get_size=lambda p, transparent=None: None),
+                        raising=False)
+    li._check_patch_within_file("/bin/foo", 0, 999999)  # None -> skipped, no raise
+
+
+def test_check_within_file_skips_when_static_fs_unavailable(li):
+    # default stub _Plugins has no static_fs -> AttributeError caught -> skip
+    li._check_patch_within_file("/bin/foo", 0, 999999)  # no raise
 
 
 def test_apply_with_base_offset(li):

--- a/tests/integration/test_binary_patch.py
+++ b/tests/integration/test_binary_patch.py
@@ -302,9 +302,10 @@ def test_apply_skip_leaves_region_untouched_but_applies_others(li):
 
 
 # --- abort contract at the hypercall handler (#2) -------------------------
-def _prep_handler(li, tmp_path, queue):
+def _prep_handler(li, tmp_path, queue, base_offsets=None):
     li.staged_dir = str(tmp_path)
     li.patch_queue = queue
+    li._patch_base_offset = base_offsets or {}
     li.get_arg = lambda k: str(tmp_path) if k == "outdir" else None
     for i, (path, action, content) in enumerate(queue_files(queue)):
         (tmp_path / f"patch_{i}").write_bytes(content)
@@ -314,6 +315,61 @@ def queue_files(queue):
     # helper: yield (path, action, staged-content) using the action's own seed
     for path, action in queue:
         yield path, action, action.pop("_content")
+
+
+# --- windowed transfer (ranged hyp_file_op) -------------------------------
+def test_patch_window_inline_single(li):
+    assert li._patch_window({"file_offset": 0x10, "hex_bytes": "aabbccdd"}) == (0x10, 4)
+
+
+def test_patch_window_expect_extends_span(li):
+    # window must cover the longer of the patch (1 byte) and expect (4 bytes)
+    assert li._patch_window(
+        {"file_offset": 0x10, "hex_bytes": "aa", "expect": "01020304"}) == (0x10, 4)
+
+
+def test_patch_window_multi_disjoint(li):
+    base, length = li._patch_window({"patches": [
+        {"file_offset": 0, "hex_bytes": "aabb"},   # 0..2
+        {"file_offset": 8, "hex_bytes": "cc"},     # 8..9
+    ]})
+    assert (base, length) == (0, 9)
+
+
+def test_patch_window_raises_on_bad_edit(li):
+    with pytest.raises(ValueError):
+        li._patch_window({"file_offset": 0, "hex_bytes": "aa", "asm": "nop"})
+
+
+def test_apply_with_base_offset(li):
+    # original_content is only the window starting at base_offset=0x100
+    window = b"\xde\xad"
+    new, recs, failed = li._apply_binary_patch(
+        window, {"file_offset": 0x100, "hex_bytes": "aabb", "expect": "dead",
+                 "tag": "t", "why": "w"}, base_offset=0x100)
+    assert not failed and new == b"\xaa\xbb"
+    assert recs[0]["file_offset"] == "0x100"   # provenance offset stays absolute
+
+
+def test_verify_with_base_offset(li):
+    window = b"\x01\x02\x03\x04"
+    st, _ = li._verify_entry(window, {"file_offset": 0x1000, "expect": "0304"},
+                             b"\xff\xff", base_offset=0x1000 - 2)
+    assert st == "applied"  # expect '0304' checked at window pos 2
+
+
+def test_handler_windowed_roundtrip(li, tmp_path):
+    # staged file is the 2-byte window at offset 0x100; handler applies with the
+    # recorded base offset and writes the patched window back.
+    queue = [("/bin/foo", {"file_offset": 0x100, "hex_bytes": "aabb",
+                           "expect": "0102", "tag": "t", "why": "w",
+                           "_content": b"\x01\x02"})]
+    _prep_handler(li, tmp_path, queue, base_offsets={0: 0x100})
+    rc = li._on_batch_patch_hypercall()
+    assert rc == 0
+    assert (tmp_path / "patch_0").read_bytes() == b"\xaa\xbb"
+    report = yaml.safe_load((tmp_path / "binary_patches.yaml").read_text())
+    assert report[0]["result"] == "applied" and report[0]["file_offset"] == "0x100"
 
 
 def test_handler_success_writes_file_and_report(li, tmp_path):

--- a/tests/integration/test_binary_patch.py
+++ b/tests/integration/test_binary_patch.py
@@ -1,0 +1,347 @@
+"""Host-side unit tests for the binary_patch applier in the LiveImage plugin.
+
+These exercise the byte-level patch logic directly, without booting a guest:
+expect/on_mismatch policy, idempotent re-runs, length-mismatch and past-EOF
+verification, multi-patch-per-file application with overlap detection, hex
+parsing (0x prefix / spaces), and the fail-policy *abort contract* — that a
+mismatched ``expect`` under the default ``fail`` policy makes the batch
+hypercall return -1 (which, via send_portalcall's exit code and run_or_report,
+halts the image build) and records the offending patch's tag/why.
+
+Importing the pyplugin standalone requires stubbing the plugin framework and
+keystone, which is done below before the module is loaded.
+"""
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+import yaml
+
+_HERE = os.path.dirname(__file__)
+_LIVE_IMAGE = os.path.abspath(
+    os.path.join(_HERE, "../../pyplugins/core/live_image.py"))
+
+
+def _load_live_image():
+    """Load pyplugins/core/live_image.py with the plugin framework stubbed.
+
+    The module decorates methods with ``@plugins.portalcall.portalcall(...)``
+    and imports keystone at top level; neither is available (or wanted) for a
+    pure host-side unit test, so we stub them before executing the module.
+    """
+    class _Portalcall:
+        def portalcall(self, magic):
+            return lambda f: f  # identity: leave the method directly callable
+
+    class _Plugins:
+        portalcall = _Portalcall()
+
+    class _Plugin:
+        def __init_subclass__(cls, **kw):
+            pass
+
+    penguin_stub = types.ModuleType("penguin")
+    penguin_stub.Plugin = _Plugin
+    penguin_stub.plugins = _Plugins()
+    penguin_stub.yaml = yaml
+
+    pm = types.ModuleType("penguin.plugin_manager")
+    pm.resolve_bound_method_from_class = lambda x: x
+    defaults = types.ModuleType("penguin.defaults")
+    defaults.static_dir = "/nonexistent"
+    utils = types.ModuleType("penguin.utils")
+    utils.get_arch_subdir = lambda c: "x86_64"
+    boot_env = types.ModuleType("penguin.boot_env")
+    boot_env.partition_boot_env = lambda *a, **k: ({}, {})
+    boot_env.render_env_blob = lambda *a, **k: b""
+
+    # live_image imports normalize_hex_string from the schema module; load the
+    # real one (it only needs pydantic, not the full penguin package).
+    pc_pkg = types.ModuleType("penguin.penguin_config")
+    sspec = importlib.util.spec_from_file_location(
+        "penguin.penguin_config.structure",
+        os.path.abspath(os.path.join(_HERE, "../../src/penguin/penguin_config/structure.py")))
+    structure = importlib.util.module_from_spec(sspec)
+
+    saved = {k: sys.modules.get(k) for k in
+             ("penguin", "penguin.plugin_manager", "penguin.defaults",
+              "penguin.utils", "penguin.boot_env", "penguin.penguin_config",
+              "penguin.penguin_config.structure", "keystone")}
+    sys.modules["penguin"] = penguin_stub
+    sys.modules["penguin.plugin_manager"] = pm
+    sys.modules["penguin.defaults"] = defaults
+    sys.modules["penguin.utils"] = utils
+    sys.modules["penguin.boot_env"] = boot_env
+    sys.modules["penguin.penguin_config"] = pc_pkg
+    sys.modules["penguin.penguin_config.structure"] = structure
+    sspec.loader.exec_module(structure)
+    sys.modules.setdefault("keystone", types.ModuleType("keystone"))
+    try:
+        spec = importlib.util.spec_from_file_location("live_image_mod", _LIVE_IMAGE)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+LI = _load_live_image().LiveImage
+
+
+@pytest.fixture
+def li():
+    """A bare LiveImage instance with a stub logger, bypassing __init__."""
+    inst = object.__new__(LI)
+    inst.logger = types.SimpleNamespace(
+        info=lambda *a, **k: None, warning=lambda *a, **k: None,
+        error=lambda *a, **k: None, debug=lambda *a, **k: None)
+    return inst
+
+
+ORIG = b"\x01\x02\x03\x04rest"
+
+
+# --- _parse_hex -----------------------------------------------------------
+@pytest.mark.parametrize("text,expected", [
+    ("aabb", b"\xaa\xbb"),
+    ("AA BB", b"\xaa\xbb"),
+    ("0xaabb", b"\xaa\xbb"),
+    ("0X AA BB", b"\xaa\xbb"),
+    ("  deadbeef  ", b"\xde\xad\xbe\xef"),
+])
+def test_parse_hex_accepts_prefix_and_spaces(li, text, expected):
+    assert li._parse_hex(text) == expected
+
+
+@pytest.mark.parametrize("bad", ["zz", "abc", "0xzz"])
+def test_parse_hex_rejects_bad(li, bad):
+    with pytest.raises(ValueError):
+        li._parse_hex(bad)
+
+
+# --- _verify_entry (expect / on_mismatch) ---------------------------------
+def test_verify_no_expect_applies(li):
+    assert li._verify_entry(ORIG, {"file_offset": 0}, b"\xaa") == ("applied", "")
+
+
+def test_verify_match_applies(li):
+    st, _ = li._verify_entry(ORIG, {"file_offset": 0, "expect": "01020304"}, b"\xaa")
+    assert st == "applied"
+
+
+def test_verify_expect_shorter_than_patch(li):
+    # verify 2 bytes, patch writes 4 — allowed, they need not match in length
+    st, _ = li._verify_entry(ORIG, {"file_offset": 0, "expect": "0102"},
+                             b"\xaa\xbb\xcc\xdd")
+    assert st == "applied"
+
+
+def test_verify_mismatch_default_fails(li):
+    st, detail = li._verify_entry(ORIG, {"file_offset": 0, "expect": "ffff"}, b"\xaa")
+    assert st == "failed"
+    assert "expected ffff" in detail and "found 0102" in detail
+
+
+def test_verify_mismatch_skip(li):
+    st, _ = li._verify_entry(ORIG, {"file_offset": 0, "expect": "ffff",
+                                    "on_mismatch": "skip"}, b"\xaa")
+    assert st == "skipped"
+
+
+def test_verify_mismatch_warn_applies(li):
+    st, detail = li._verify_entry(ORIG, {"file_offset": 0, "expect": "ffff",
+                                         "on_mismatch": "warn"}, b"\xaa")
+    assert st == "applied"
+    assert "patched despite mismatch" in detail
+
+
+def test_verify_already_patched_idempotent_skip_under_fail(li):
+    already = b"\xaa\xbb\xcc\xddrest"
+    st, detail = li._verify_entry(already, {"file_offset": 0, "expect": "01020304"},
+                                  b"\xaa\xbb\xcc\xdd")  # default fail
+    assert st == "skipped"
+    assert "already patched" in detail
+
+
+def test_verify_expect_past_eof_reports(li):
+    st, detail = li._verify_entry(b"\x01", {"file_offset": 100, "expect": "bb"}, b"\xaa")
+    assert st == "failed"
+    assert "<EOF>" in detail and "file is 1 bytes" in detail
+
+
+# --- _normalize_patch_entries ---------------------------------------------
+def test_normalize_inline_single(li):
+    entries, err = li._normalize_patch_entries(
+        {"file_offset": 4, "hex_bytes": "aa"})
+    assert err is None and len(entries) == 1 and entries[0]["file_offset"] == 4
+
+
+def test_normalize_patches_list(li):
+    entries, err = li._normalize_patch_entries(
+        {"patches": [{"file_offset": 0, "hex_bytes": "aa"},
+                     {"file_offset": 8, "asm": "nop"}]})
+    assert err is None and len(entries) == 2
+
+
+def test_normalize_both_forms_errors(li):
+    entries, err = li._normalize_patch_entries(
+        {"file_offset": 0, "hex_bytes": "aa", "patches": [{"file_offset": 8}]})
+    assert entries is None and "action level" in err
+
+
+def test_normalize_empty_needs_offset_or_list(li):
+    entries, err = li._normalize_patch_entries({"hex_bytes": "aa"})
+    assert entries is None and "file_offset" in err
+
+
+def test_normalize_action_level_fields_with_patches_rejected(li):
+    # per-edit fields at the action level are silently meaningless with patches;
+    # the applier must reject the mix rather than drop them
+    entries, err = li._normalize_patch_entries(
+        {"expect": "0102", "why": "oops", "patches": [{"file_offset": 0, "hex_bytes": "aa"}]})
+    assert entries is None and "action level" in err
+
+
+def test_normalize_inline_keeps_all_fields(li):
+    # a new/late field on the action flows through to the inline entry
+    entries, err = li._normalize_patch_entries(
+        {"type": "binary_patch", "file_offset": 4, "hex_bytes": "aa",
+         "expect": "01", "why": "w", "tag": "t", "on_mismatch": "warn"})
+    assert err is None
+    e = entries[0]
+    assert "type" not in e and e["on_mismatch"] == "warn" and e["why"] == "w"
+
+
+# --- _entry_patch_bytes ---------------------------------------------------
+def test_entry_bytes_hex(li):
+    pb, err = li._entry_patch_bytes({"file_offset": 0, "hex_bytes": "0x aa bb"})
+    assert err is None and pb == b"\xaa\xbb"
+
+
+def test_entry_bytes_both_hex_and_asm_errors(li):
+    pb, err = li._entry_patch_bytes({"file_offset": 0, "hex_bytes": "aa", "asm": "nop"})
+    assert pb is None and "exactly one" in err
+
+
+def test_entry_bytes_neither_errors(li):
+    pb, err = li._entry_patch_bytes({"file_offset": 0})
+    assert pb is None and "exactly one" in err
+
+
+# --- _apply_binary_patch (whole action) -----------------------------------
+def test_apply_single_inline(li):
+    new, recs, failed = li._apply_binary_patch(
+        ORIG, {"file_offset": 0, "hex_bytes": "aabbccdd"})
+    assert not failed and new == b"\xaa\xbb\xcc\xddrest"
+    assert recs[0]["result"] == "applied"
+
+
+def test_apply_multiple_disjoint_offsets(li):
+    orig = b"\x00" * 16
+    new, recs, failed = li._apply_binary_patch(orig, {"patches": [
+        {"file_offset": 0, "hex_bytes": "aabb", "tag": "t", "why": "first"},
+        {"file_offset": 8, "hex_bytes": "ccdd", "tag": "t", "why": "second"},
+    ]})
+    assert not failed
+    assert new == b"\xaa\xbb" + b"\x00" * 6 + b"\xcc\xdd" + b"\x00" * 6
+    assert [r["result"] for r in recs] == ["applied", "applied"]
+    assert recs[0]["why"] == "first" and recs[1]["file_offset"] == "0x8"
+
+
+def test_apply_overlapping_offsets_rejected(li):
+    orig = b"\x00" * 16
+    new, recs, failed = li._apply_binary_patch(orig, {"patches": [
+        {"file_offset": 0, "hex_bytes": "aabbccdd"},   # covers 0..4
+        {"file_offset": 2, "hex_bytes": "eeff"},        # covers 2..4 -> overlaps
+    ]})
+    assert failed and new is None
+    assert all(r["result"] == "failed" for r in recs)
+    assert any("overlaps" in r.get("detail", "") for r in recs)
+
+
+def test_apply_contained_overlap_rejected(li):
+    # a small edit fully inside a larger edit's range must be flagged even
+    # though it is not adjacent to it once ranges are sorted by start
+    orig = b"\x00" * 32
+    new, recs, failed = li._apply_binary_patch(orig, {"patches": [
+        {"file_offset": 0, "hex_bytes": "aabbccddeeff00112233"},  # 0..10
+        {"file_offset": 20, "hex_bytes": "0102"},                 # 20..22 (disjoint)
+        {"file_offset": 4, "hex_bytes": "99"},                    # 4..5, inside 0..10
+    ]})
+    assert failed and new is None
+    by_off = {r["file_offset"]: r["result"] for r in recs}
+    assert by_off["0x0"] == "failed" and by_off["0x4"] == "failed"
+    assert by_off["0x14"] == "applied"  # the disjoint one is not falsely flagged
+
+
+def test_apply_one_failed_policy_aborts_whole_file(li):
+    orig = b"\x00" * 16
+    new, recs, failed = li._apply_binary_patch(orig, {"patches": [
+        {"file_offset": 0, "hex_bytes": "aabb"},                       # ok
+        {"file_offset": 8, "hex_bytes": "ccdd", "expect": "ffff"},     # mismatch, fail
+    ]})
+    assert failed and new is None  # nothing written back when any edit fails
+
+
+def test_apply_skip_leaves_region_untouched_but_applies_others(li):
+    orig = b"\xde\xad" + b"\x00" * 14
+    new, recs, failed = li._apply_binary_patch(orig, {"patches": [
+        {"file_offset": 0, "hex_bytes": "aabb", "expect": "ffff", "on_mismatch": "skip"},
+        {"file_offset": 8, "hex_bytes": "ccdd"},
+    ]})
+    assert not failed
+    assert new[:2] == b"\xde\xad"        # skipped edit left original bytes
+    assert new[8:10] == b"\xcc\xdd"      # other edit applied
+    assert recs[0]["result"] == "skipped"
+
+
+# --- abort contract at the hypercall handler (#2) -------------------------
+def _prep_handler(li, tmp_path, queue):
+    li.staged_dir = str(tmp_path)
+    li.patch_queue = queue
+    li.get_arg = lambda k: str(tmp_path) if k == "outdir" else None
+    for i, (path, action, content) in enumerate(queue_files(queue)):
+        (tmp_path / f"patch_{i}").write_bytes(content)
+
+
+def queue_files(queue):
+    # helper: yield (path, action, staged-content) using the action's own seed
+    for path, action in queue:
+        yield path, action, action.pop("_content")
+
+
+def test_handler_success_writes_file_and_report(li, tmp_path):
+    queue = [("/bin/foo", {"file_offset": 0, "hex_bytes": "aabb",
+                           "tag": "grp", "why": "flip", "_content": b"\x01\x02\x03"})]
+    _prep_handler(li, tmp_path, queue)
+    rc = li._on_batch_patch_hypercall()
+    assert rc == 0
+    assert (tmp_path / "patch_0").read_bytes() == b"\xaa\xbb\x03"
+    report = yaml.safe_load((tmp_path / "binary_patches.yaml").read_text())
+    assert report[0]["result"] == "applied"
+    assert report[0]["tag"] == "grp" and report[0]["file"] == "/bin/foo"
+
+
+def test_handler_fail_policy_aborts_and_names_patch(li, tmp_path):
+    # default on_mismatch: fail with a mismatched expect -> handler returns -1
+    queue = [("/bin/foo", {"file_offset": 0, "hex_bytes": "aabb", "expect": "ffff",
+                           "tag": "secureboot", "why": "nop the check",
+                           "_content": b"\x01\x02\x03"})]
+    _prep_handler(li, tmp_path, queue)
+    rc = li._on_batch_patch_hypercall()
+    assert rc == -1  # this exit code halts the image build via run_or_report
+    # the staged file must NOT have been patched (no half-applied write-back)
+    assert (tmp_path / "patch_0").read_bytes() == b"\x01\x02\x03"
+    report = yaml.safe_load((tmp_path / "binary_patches.yaml").read_text())
+    assert report[0]["result"] == "failed"
+    assert report[0]["tag"] == "secureboot" and report[0]["why"] == "nop the check"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/integration/test_binary_patch.py
+++ b/tests/integration/test_binary_patch.py
@@ -325,6 +325,34 @@ def test_apply_contained_overlap_rejected(li):
     assert by_off["0x14"] == "applied"  # the disjoint one is not falsely flagged
 
 
+def test_apply_offset_past_end_fails_not_corrupts(li):
+    # an offset past the end of the buffer must fail cleanly rather than let
+    # bytearray slice-assignment silently append the patch at the wrong place
+    orig = b"\x00\x01"
+    new, recs, failed = li._apply_binary_patch(
+        orig, {"file_offset": 5, "hex_bytes": "aabb"})
+    assert failed and new is None
+    assert "outside" in recs[0]["detail"]
+
+
+def test_apply_short_window_fails_not_corrupts(li):
+    # the guest may return a shorter window than declared (file smaller than
+    # the patch expected + no expect guard); the edit at the far end must fail,
+    # not land appended at the end of the short read
+    window = b"AB"                       # declared window was longer
+    new, recs, failed = li._apply_binary_patch(
+        window, {"patches": [{"file_offset": 8, "hex_bytes": "cc"}]},
+        base_offset=8)                   # pos 0 within a 1-byte-short read? no: len 2, pos 0 ok
+    # offset 8, base 8 -> pos 0, patch len 1, needs len>=1; buffer len 2 -> ok, applies
+    assert not failed
+    # now a far offset within the same declared window but past the short read
+    new2, recs2, failed2 = li._apply_binary_patch(
+        window, {"patches": [{"file_offset": 16, "hex_bytes": "cc"}]},
+        base_offset=8)                   # pos 8 into a 2-byte buffer -> out of range
+    assert failed2 and new2 is None
+    assert "outside" in recs2[0]["detail"]
+
+
 def test_apply_one_failed_policy_aborts_whole_file(li):
     orig = b"\x00" * 16
     new, recs, failed = li._apply_binary_patch(orig, {"patches": [

--- a/tests/integration/test_binary_patch.py
+++ b/tests/integration/test_binary_patch.py
@@ -219,6 +219,50 @@ def test_normalize_inline_keeps_all_fields(li):
     assert "type" not in e and e["on_mismatch"] == "warn" and e["why"] == "w"
 
 
+# --- _synth_file_patch_action (Option B: patch a placed file) -------------
+def test_synth_none_without_patches(li):
+    # a plain host_file/inline_file with no patches produces nothing to queue
+    assert li._synth_file_patch_action("/foo", {"type": "host_file",
+                                                 "host_path": "x"}) is None
+    assert li._synth_file_patch_action("/foo", {"type": "inline_file",
+                                                 "contents": "x"}) is None
+
+
+def test_synth_builds_binary_patch_action(li):
+    patches = [{"file_offset": 0, "hex_bytes": "50", "expect": "4f"}]
+    synth = li._synth_file_patch_action(
+        "/testfile7.bin", {"type": "inline_file", "contents": "ORIGINAL",
+                           "patches": patches})
+    assert synth["type"] == "binary_patch"
+    assert synth["patches"] == patches
+    # it must feed the existing pipeline cleanly (no action-level-mix error)
+    entries, err = li._normalize_patch_entries(synth)
+    assert err is None and len(entries) == 1 and entries[0]["file_offset"] == 0
+
+
+def test_synth_copies_patches_list(li):
+    # the synthetic action must not alias the config's list
+    patches = [{"file_offset": 0, "hex_bytes": "aa"}]
+    synth = li._synth_file_patch_action(
+        "/f", {"type": "host_file", "host_path": "x", "patches": patches})
+    assert synth["patches"] is not patches and synth["patches"] == patches
+
+
+@pytest.mark.parametrize("file_path,action", [
+    ("/dir/*", {"type": "host_file", "host_path": "src/bin",
+                "patches": [{"file_offset": 0, "hex_bytes": "aa"}]}),
+    ("/dir/f?", {"type": "host_file", "host_path": "src/bin",
+                 "patches": [{"file_offset": 0, "hex_bytes": "aa"}]}),
+    ("/f", {"type": "host_file", "host_path": "src/*.bin",
+            "patches": [{"file_offset": 0, "hex_bytes": "aa"}]}),
+    ("/f", {"type": "host_file", "host_path": "src/b?n",
+            "patches": [{"file_offset": 0, "hex_bytes": "aa"}]}),
+])
+def test_synth_rejects_glob_targets(li, file_path, action):
+    with pytest.raises(ValueError, match="ambiguous"):
+        li._synth_file_patch_action(file_path, action)
+
+
 # --- _entry_patch_bytes ---------------------------------------------------
 def test_entry_bytes_hex(li):
     pb, err = li._entry_patch_bytes({"file_offset": 0, "hex_bytes": "0x aa bb"})

--- a/tests/integration/test_target/patches/tests/live_image.yaml
+++ b/tests/integration/test_target/patches/tests/live_image.yaml
@@ -130,6 +130,16 @@ static_files:
         expect: "0809"
         why: "second edit at offset 8"
         tag: livetest
+  /testfile7.bin:                # inline_file placed AND patched in one entry
+    type: inline_file
+    contents: "ORIGINAL"
+    mode: 0o644
+    patches:
+      - file_offset: 0
+        hex_bytes: "50"          # 'P' -> "PRIGINAL"
+        expect: "4f"             # 'O', the byte inline_file placed
+        why: "patch a freshly placed inline_file"
+        tag: livetest
   /shim.txt:
     type: shim
     target: /shimtarget.txt
@@ -242,6 +252,10 @@ static_files:
       # Check /testfile6.bin got BOTH edits from the patches list (offsets 0 and 8)
       if ! /igloo/utils/busybox head -c 10 /testfile6.bin | /igloo/utils/busybox hexdump -v -e '10/1 "%02X"' | /igloo/utils/busybox grep -q "AABB020304050607CCDD"; then
         echo "/testfile6.bin multi-patch failed"; exit 1
+      fi
+      # Check /testfile7.bin (inline_file placed, then binary-patched at offset 0)
+      if [ "$(/igloo/utils/busybox head -c 8 /testfile7.bin)" != "PRIGINAL" ]; then
+        echo "/testfile7.bin inline_file+patch failed"; exit 1
       fi
       # Check shim
       if ! /igloo/utils/busybox grep target /shim.txt ; then

--- a/tests/integration/test_target/patches/tests/live_image.yaml
+++ b/tests/integration/test_target/patches/tests/live_image.yaml
@@ -5,6 +5,15 @@ plugins:
         type: file_contains
         file: console.log
         string: "/tests/live_image.sh PASS"
+      live_image+patch_provenance:
+        type: file_contains
+        file: binary_patches.yaml
+        strings:
+          - "tag: livetest"
+          - "why: expect-match applies the patch"
+          - "result: applied"
+          - "result: skipped"
+          - "already patched (bytes at offset equal the patch bytes)"
 
 static_files:
   /testdir:
@@ -78,10 +87,49 @@ static_files:
     type: binary_patch
     file_offset: 0
     hex_bytes: "aabbccdd"
+    expect: "01020304"           # matches the original bytes -> patch applies
+    why: "expect-match applies the patch"
+    tag: livetest
   /testfile2.bin:
     type: binary_patch
     file_offset: 0
     hex_bytes: "11223344"
+  /testfile3.bin:
+    type: binary_patch
+    file_offset: 0
+    hex_bytes: "cafef00d"
+    expect: "00000000"           # mismatch (file is deadbeef) + skip -> untouched
+    on_mismatch: skip
+    why: "expect-mismatch with skip leaves the file alone"
+    tag: livetest
+  /testfile4.bin:
+    type: binary_patch
+    file_offset: 0
+    hex_bytes: "aabbccdd"
+    expect: "01020304"           # mismatch, but bytes already equal the patch -> idempotent skip under default fail policy
+    why: "already-patched file skips idempotently"
+    tag: livetest
+  /testfile5.bin:
+    type: binary_patch
+    file_offset: 0
+    hex_bytes: "55667788"
+    expect: "ffffffff"           # mismatch + warn -> patch applies anyway
+    on_mismatch: warn
+    why: "expect-mismatch with warn still patches"
+    tag: livetest
+  /testfile6.bin:
+    type: binary_patch          # multiple offsets in one file via patches list
+    patches:
+      - file_offset: 0
+        hex_bytes: "0xaabb"     # 0x-prefixed hex; overwrites bytes 00 01
+        expect: "0001"
+        why: "first edit at offset 0"
+        tag: livetest
+      - file_offset: 8
+        hex_bytes: "cc dd"      # spaced hex; overwrites bytes 08 09
+        expect: "0809"
+        why: "second edit at offset 8"
+        tag: livetest
   /shim.txt:
     type: shim
     target: /shimtarget.txt
@@ -178,6 +226,22 @@ static_files:
       # Check binary patch for /testfile2.bin
       if ! /igloo/utils/busybox head -c 4 /testfile2.bin | /igloo/utils/busybox hexdump -v -e '4/1 "%02X"' | /igloo/utils/busybox grep -q "11223344"; then
         echo "/testfile2.bin binary patch failed"; exit 1
+      fi
+      # Check /testfile3.bin was NOT patched (expect mismatch + on_mismatch: skip)
+      if ! /igloo/utils/busybox head -c 4 /testfile3.bin | /igloo/utils/busybox hexdump -v -e '4/1 "%02X"' | /igloo/utils/busybox grep -q "DEADBEEF"; then
+        echo "/testfile3.bin should be untouched after skipped patch"; exit 1
+      fi
+      # Check /testfile4.bin kept its already-patched bytes (idempotent skip)
+      if ! /igloo/utils/busybox head -c 4 /testfile4.bin | /igloo/utils/busybox hexdump -v -e '4/1 "%02X"' | /igloo/utils/busybox grep -q "AABBCCDD"; then
+        echo "/testfile4.bin idempotent skip failed"; exit 1
+      fi
+      # Check /testfile5.bin WAS patched despite expect mismatch (on_mismatch: warn)
+      if ! /igloo/utils/busybox head -c 4 /testfile5.bin | /igloo/utils/busybox hexdump -v -e '4/1 "%02X"' | /igloo/utils/busybox grep -q "55667788"; then
+        echo "/testfile5.bin warn-policy patch failed"; exit 1
+      fi
+      # Check /testfile6.bin got BOTH edits from the patches list (offsets 0 and 8)
+      if ! /igloo/utils/busybox head -c 10 /testfile6.bin | /igloo/utils/busybox hexdump -v -e '10/1 "%02X"' | /igloo/utils/busybox grep -q "AABB020304050607CCDD"; then
+        echo "/testfile6.bin multi-patch failed"; exit 1
       fi
       # Check shim
       if ! /igloo/utils/busybox grep target /shim.txt ; then

--- a/tests/integration/test_target/test.py
+++ b/tests/integration/test_target/test.py
@@ -123,6 +123,10 @@ def run_test(kernel, arch, image, test_file=None, docs_only=False, execution_mod
         "helloworld": b"helloworld\0",
         "testfile1.bin": b"\x01\x02\x03\x04",
         "testfile2.bin": b"\x10\x20\x30\x40",
+        "testfile3.bin": b"\xde\xad\xbe\xef",
+        "testfile4.bin": b"\xaa\xbb\xcc\xdd",
+        "testfile5.bin": b"\x01\x02\x03\x04",
+        "testfile6.bin": bytes(range(16)),  # 00 01 02 ... 0f; multi-patch target
         "shim.txt": b"original data\0",
         "shimtarget.txt": b"target data\0",
     }

--- a/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
+++ b/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
@@ -163,6 +163,30 @@ Ordered most-valuable first. Percentages are current host coverage.
    plugins work too. The one enum with no host-reachable ISF home
    (`igloo_base_hypercalls`, defined in igloo_base) is supplied by `RealKffi` as a
    single ABI-fixed constant.
+10. ✅ **`core/live_image.py` — `binary_patch` logic** — done
+    (`test_binary_patch.py`). The host-side half of the `static_files`
+    `binary_patch` action (Phase-0 draft 04: `expect`/`on_mismatch` verify,
+    idempotent re-runs, `why`/`tag` provenance, multi-edit `patches`, and
+    composing patches onto a placed `host_file`/`inline_file`). Loaded in place
+    with `load_pyplugin` (`proj_dir`/`conf` args + `outdir`), controlling the
+    one sibling it calls, `static_fs`, with a `doubles={"static_fs": …}` entry
+    for the out-of-bounds size check. Covers hex parsing (0x/space forms),
+    `_verify_entry` policy matrix incl. length-mismatch/past-EOF/`base_offset`,
+    `_normalize_patch_entries`, `_synth_file_patch_action` (compose + glob
+    rejection), `_apply_binary_patch` (disjoint/overlap/contained-overlap +
+    out-of-window & negative-offset rejection), the `_patch_window` windowed
+    offset math, `_check_patch_within_file` bounds check (fits/exceeds/unknown/
+    errors→skip), and the `_on_batch_patch_hypercall` handler's success,
+    windowed round-trip, and **fail→return-`-1` abort contract** (asserts the
+    staged window is left untouched and the tag/why land in
+    `binary_patches.yaml`). This replaces the file's original hand-rolled
+    `sys.modules`-stub loader — the case that motivated the harness.
+
+    **Out of scope — stays a `tests/integration/` fixture (`live_image.yaml`):**
+    the real guest round-trip (the batch hypercall's `hyp_file_op --range`
+    transport, whose reply drives the write-back) and keystone `asm`
+    assembly (a native-toolchain concern; `import keystone` is soft so the
+    plugin still loads host-side, and `_gen_asm_patch_bytes` guards on it).
 
 ### Harness capabilities (as landed)
 

--- a/tests/unit/test_binary_patch.py
+++ b/tests/unit/test_binary_patch.py
@@ -1,111 +1,63 @@
-"""Host-side unit tests for the binary_patch applier in the LiveImage plugin.
+"""Host-side unit tests for the ``binary_patch`` logic in the LiveImage plugin,
+driven through the ``penguin.testing`` harness — no PANDA, no guest, no per-arch
+boot.
 
-These exercise the byte-level patch logic directly, without booting a guest:
-expect/on_mismatch policy, idempotent re-runs, length-mismatch and past-EOF
-verification, multi-patch-per-file application with overlap detection, hex
-parsing (0x prefix / spaces), and the fail-policy *abort contract* — that a
-mismatched ``expect`` under the default ``fail`` policy makes the batch
-hypercall return -1 (which, via send_portalcall's exit code and run_or_report,
-halts the image build) and records the offending patch's tag/why.
+This file was the original hand-rolled ``sys.modules``-stub hack that motivated
+the harness; it now loads the real plugin in place via ``load_pyplugin`` and
+controls the one sibling it touches (``static_fs``) with a ``doubles=`` entry.
 
-Importing the pyplugin standalone requires stubbing the plugin framework and
-keystone, which is done below before the module is loaded.
+Scope (per ``docs/testing.md``): the host-side patch *logic* is what runs on the
+host — hex parsing, ``expect``/``on_mismatch`` verification, idempotent re-runs,
+multi-edit application with overlap + bounds rejection, the windowed-transfer
+offset math, provenance records, and the batch-hypercall handler's abort
+contract against a pre-staged window. The guest round-trip itself (the real
+``hyp_file_op --range`` transport) and keystone ``asm`` assembly stay
+``tests/integration`` fixtures (``live_image.yaml``): they need the guest / a
+native toolchain, which the harness cannot fake faithfully.
 """
-import importlib.util
-import os
-import sys
-import types
+from pathlib import Path
 
 import pytest
 import yaml
 
-_HERE = os.path.dirname(__file__)
-_LIVE_IMAGE = os.path.abspath(
-    os.path.join(_HERE, "../../pyplugins/core/live_image.py"))
+from penguin.testing import load_pyplugin
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIVE_IMAGE = REPO_ROOT / "pyplugins" / "core" / "live_image.py"
+
+ORIG = b"\x01\x02\x03\x04rest"
 
 
-def _load_live_image():
-    """Load pyplugins/core/live_image.py with the plugin framework stubbed.
-
-    The module decorates methods with ``@plugins.portalcall.portalcall(...)``
-    and imports keystone at top level; neither is available (or wanted) for a
-    pure host-side unit test, so we stub them before executing the module.
-    """
-    class _Portalcall:
-        def portalcall(self, magic):
-            return lambda f: f  # identity: leave the method directly callable
-
-    class _Plugins:
-        portalcall = _Portalcall()
-
-    class _Plugin:
-        def __init_subclass__(cls, **kw):
-            pass
-
-    penguin_stub = types.ModuleType("penguin")
-    penguin_stub.Plugin = _Plugin
-    penguin_stub.plugins = _Plugins()
-    penguin_stub.yaml = yaml
-
-    pm = types.ModuleType("penguin.plugin_manager")
-    pm.resolve_bound_method_from_class = lambda x: x
-    defaults = types.ModuleType("penguin.defaults")
-    defaults.static_dir = "/nonexistent"
-    utils = types.ModuleType("penguin.utils")
-    utils.get_arch_subdir = lambda c: "x86_64"
-    boot_env = types.ModuleType("penguin.boot_env")
-    boot_env.partition_boot_env = lambda *a, **k: ({}, {})
-    boot_env.render_env_blob = lambda *a, **k: b""
-
-    # live_image imports normalize_hex_string from the schema module; load the
-    # real one (it only needs pydantic, not the full penguin package).
-    pc_pkg = types.ModuleType("penguin.penguin_config")
-    sspec = importlib.util.spec_from_file_location(
-        "penguin.penguin_config.structure",
-        os.path.abspath(os.path.join(_HERE, "../../src/penguin/penguin_config/structure.py")))
-    structure = importlib.util.module_from_spec(sspec)
-
-    saved = {k: sys.modules.get(k) for k in
-             ("penguin", "penguin.plugin_manager", "penguin.defaults",
-              "penguin.utils", "penguin.boot_env", "penguin.penguin_config",
-              "penguin.penguin_config.structure", "keystone")}
-    sys.modules["penguin"] = penguin_stub
-    sys.modules["penguin.plugin_manager"] = pm
-    sys.modules["penguin.defaults"] = defaults
-    sys.modules["penguin.utils"] = utils
-    sys.modules["penguin.boot_env"] = boot_env
-    sys.modules["penguin.penguin_config"] = pc_pkg
-    sys.modules["penguin.penguin_config.structure"] = structure
-    sspec.loader.exec_module(structure)
-    sys.modules.setdefault("keystone", types.ModuleType("keystone"))
-    try:
-        spec = importlib.util.spec_from_file_location("live_image_mod", _LIVE_IMAGE)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod
-    finally:
-        for k, v in saved.items():
-            if v is None:
-                sys.modules.pop(k, None)
-            else:
-                sys.modules[k] = v
-
-
-_MOD = _load_live_image()
-LI = _MOD.LiveImage
+def _load(tmp_path, conf=None, doubles=None):
+    """Construct a real LiveImage via the harness. ``proj_dir``/``conf`` satisfy
+    ``__init__``; ``outdir`` (wired into ``get_arg('outdir')``) is where the
+    provenance report lands."""
+    return load_pyplugin(
+        str(LIVE_IMAGE),
+        outdir=tmp_path,
+        args={"proj_dir": str(tmp_path), "conf": conf or {}},
+        doubles=doubles or {},
+    )
 
 
 @pytest.fixture
-def li():
-    """A bare LiveImage instance with a stub logger, bypassing __init__."""
-    inst = object.__new__(LI)
-    inst.logger = types.SimpleNamespace(
-        info=lambda *a, **k: None, warning=lambda *a, **k: None,
-        error=lambda *a, **k: None, debug=lambda *a, **k: None)
-    return inst
+def li(tmp_path):
+    """A real, harness-constructed LiveImage instance (no framework stubbing)."""
+    return _load(tmp_path).plugin
 
 
-ORIG = b"\x01\x02\x03\x04rest"
+class _FakeStaticFs:
+    """Double for the one sibling ``_check_patch_within_file`` calls. ``size``
+    is what ``get_size`` returns; if it is an Exception instance, raising it
+    models the defensive 'size can't be determined' path."""
+
+    def __init__(self, size):
+        self._size = size
+
+    def get_size(self, path, transparent=frozenset()):
+        if isinstance(self._size, Exception):
+            raise self._size
+        return self._size
 
 
 # --- _parse_hex -----------------------------------------------------------
@@ -219,13 +171,13 @@ def test_normalize_inline_keeps_all_fields(li):
     assert "type" not in e and e["on_mismatch"] == "warn" and e["why"] == "w"
 
 
-# --- _synth_file_patch_action (Option B: patch a placed file) -------------
+# --- _synth_file_patch_action (compose: patch a placed file) --------------
 def test_synth_none_without_patches(li):
     # a plain host_file/inline_file with no patches produces nothing to queue
-    assert li._synth_file_patch_action("/foo", {"type": "host_file",
-                                                 "host_path": "x"}) is None
-    assert li._synth_file_patch_action("/foo", {"type": "inline_file",
-                                                 "contents": "x"}) is None
+    assert li._synth_file_patch_action(
+        "/foo", {"type": "host_file", "host_path": "x"}) is None
+    assert li._synth_file_patch_action(
+        "/foo", {"type": "inline_file", "contents": "x"}) is None
 
 
 def test_synth_builds_binary_patch_action(li):
@@ -342,8 +294,7 @@ def test_apply_short_window_fails_not_corrupts(li):
     window = b"AB"                       # declared window was longer
     new, recs, failed = li._apply_binary_patch(
         window, {"patches": [{"file_offset": 8, "hex_bytes": "cc"}]},
-        base_offset=8)                   # pos 0 within a 1-byte-short read? no: len 2, pos 0 ok
-    # offset 8, base 8 -> pos 0, patch len 1, needs len>=1; buffer len 2 -> ok, applies
+        base_offset=8)                   # offset 8, base 8 -> pos 0, fits len-2 buffer
     assert not failed
     # now a far offset within the same declared window but past the short read
     new2, recs2, failed2 = li._apply_binary_patch(
@@ -374,20 +325,21 @@ def test_apply_skip_leaves_region_untouched_but_applies_others(li):
     assert recs[0]["result"] == "skipped"
 
 
-# --- abort contract at the hypercall handler (#2) -------------------------
-def _prep_handler(li, tmp_path, queue, base_offsets=None):
-    li.staged_dir = str(tmp_path)
-    li.patch_queue = queue
-    li._patch_base_offset = base_offsets or {}
-    li.get_arg = lambda k: str(tmp_path) if k == "outdir" else None
-    for i, (path, action, content) in enumerate(queue_files(queue)):
-        (tmp_path / f"patch_{i}").write_bytes(content)
+def test_apply_with_base_offset(li):
+    # original_content is only the window starting at base_offset=0x100
+    window = b"\xde\xad"
+    new, recs, failed = li._apply_binary_patch(
+        window, {"file_offset": 0x100, "hex_bytes": "aabb", "expect": "dead",
+                 "tag": "t", "why": "w"}, base_offset=0x100)
+    assert not failed and new == b"\xaa\xbb"
+    assert recs[0]["file_offset"] == "0x100"   # provenance offset stays absolute
 
 
-def queue_files(queue):
-    # helper: yield (path, action, staged-content) using the action's own seed
-    for path, action in queue:
-        yield path, action, action.pop("_content")
+def test_verify_with_base_offset(li):
+    window = b"\x01\x02\x03\x04"
+    st, _ = li._verify_entry(window, {"file_offset": 0x1000, "expect": "0304"},
+                             b"\xff\xff", base_offset=0x1000 - 2)
+    assert st == "applied"  # expect '0304' checked at window pos 2
 
 
 # --- windowed transfer (ranged hyp_file_op) -------------------------------
@@ -414,7 +366,7 @@ def test_patch_window_raises_on_bad_edit(li):
         li._patch_window({"file_offset": 0, "hex_bytes": "aa", "asm": "nop"})
 
 
-# --- bounds check against the static filesystem ---------------------------
+# --- bounds check against the static filesystem (static_fs double) --------
 @pytest.mark.parametrize("base,win,size,expected", [
     (0, 4, None, False),   # unknown size -> never flagged
     (0, 4, 4, False),      # exactly fits
@@ -422,52 +374,51 @@ def test_patch_window_raises_on_bad_edit(li):
     (0x10, 4, 0x13, True),  # window 0x10..0x14 exceeds size 0x13
     (0x10, 4, 0x14, False),  # window 0x10..0x14 exactly fits size 0x14
 ])
-def test_window_exceeds_size(base, win, size, expected):
-    assert LI._window_exceeds_size(base, win, size) is expected
+def test_window_exceeds_size(li, base, win, size, expected):
+    assert li._window_exceeds_size(base, win, size) is expected
 
 
-def test_check_within_file_raises_when_out_of_bounds(li, monkeypatch):
-    monkeypatch.setattr(_MOD.plugins, "static_fs",
-                        types.SimpleNamespace(get_size=lambda p, transparent=None: 3),
-                        raising=False)
+def test_check_within_file_raises_when_out_of_bounds(tmp_path):
+    li = _load(tmp_path, doubles={"static_fs": _FakeStaticFs(3)}).plugin
     with pytest.raises(ValueError, match="exceeds file size"):
         li._check_patch_within_file("/bin/foo", 0, 4)
 
 
-def test_check_within_file_ok_when_fits(li, monkeypatch):
-    monkeypatch.setattr(_MOD.plugins, "static_fs",
-                        types.SimpleNamespace(get_size=lambda p, transparent=None: 64),
-                        raising=False)
+def test_check_within_file_ok_when_fits(tmp_path):
+    li = _load(tmp_path, doubles={"static_fs": _FakeStaticFs(64)}).plugin
     li._check_patch_within_file("/bin/foo", 0x10, 4)  # no raise
 
 
-def test_check_within_file_skips_when_size_unknown(li, monkeypatch):
-    monkeypatch.setattr(_MOD.plugins, "static_fs",
-                        types.SimpleNamespace(get_size=lambda p, transparent=None: None),
-                        raising=False)
+def test_check_within_file_skips_when_size_unknown(tmp_path):
+    li = _load(tmp_path, doubles={"static_fs": _FakeStaticFs(None)}).plugin
     li._check_patch_within_file("/bin/foo", 0, 999999)  # None -> skipped, no raise
 
 
-def test_check_within_file_skips_when_static_fs_unavailable(li):
-    # default stub _Plugins has no static_fs -> AttributeError caught -> skip
+def test_check_within_file_skips_when_get_size_raises(tmp_path):
+    # the defensive path: if the size can't be determined (static_fs errors),
+    # skip the check rather than fail the build
+    li = _load(tmp_path,
+               doubles={"static_fs": _FakeStaticFs(RuntimeError("no fs"))}).plugin
     li._check_patch_within_file("/bin/foo", 0, 999999)  # no raise
 
 
-def test_apply_with_base_offset(li):
-    # original_content is only the window starting at base_offset=0x100
-    window = b"\xde\xad"
-    new, recs, failed = li._apply_binary_patch(
-        window, {"file_offset": 0x100, "hex_bytes": "aabb", "expect": "dead",
-                 "tag": "t", "why": "w"}, base_offset=0x100)
-    assert not failed and new == b"\xaa\xbb"
-    assert recs[0]["file_offset"] == "0x100"   # provenance offset stays absolute
+# --- batch-hypercall handler: apply staged window + write provenance ------
+def _prep_handler(li, tmp_path, queue, base_offsets=None):
+    """Stage each queued patch's ``_content`` as ``patch_<i>`` under a staged
+    dir the handler reads, and point the plugin at it. ``outdir`` (where the
+    report lands) is already wired to ``tmp_path`` by the harness."""
+    li.staged_dir = str(tmp_path)
+    li.patch_queue = [(path, action) for path, action, _ in _queue_files(queue)]
+    li._patch_base_offset = base_offsets or {}
+    for i, (_path, _action, content) in enumerate(_queue_files(queue)):
+        (tmp_path / f"patch_{i}").write_bytes(content)
 
 
-def test_verify_with_base_offset(li):
-    window = b"\x01\x02\x03\x04"
-    st, _ = li._verify_entry(window, {"file_offset": 0x1000, "expect": "0304"},
-                             b"\xff\xff", base_offset=0x1000 - 2)
-    assert st == "applied"  # expect '0304' checked at window pos 2
+def _queue_files(queue):
+    # yield (path, action-without-_content, staged-content) from the seeded queue
+    for path, action in queue:
+        action = dict(action)
+        yield path, action, action.pop("_content")
 
 
 def test_handler_windowed_roundtrip(li, tmp_path):
@@ -509,7 +460,3 @@ def test_handler_fail_policy_aborts_and_names_patch(li, tmp_path):
     report = yaml.safe_load((tmp_path / "binary_patches.yaml").read_text())
     assert report[0]["result"] == "failed"
     assert report[0]["tag"] == "secureboot" and report[0]["why"] == "nop the check"
-
-
-if __name__ == "__main__":
-    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Extends the existing `static_files.binary_patch` action so binary patches are **idempotent and safe across firmware variants** instead of applied blindly, and so patching a few bytes of a large binary no longer streams the whole file. Implements planning draft 04.

New optional fields on the action:

| field | meaning |
|-------|---------|
| `expect` | hex bytes verified at `file_offset` before writing |
| `on_mismatch` | `fail` (default) \| `skip` \| `warn` |
| `why` / `tag` | rationale + grouping, surfaced in run output |
| `patches` | list of edits to one file (multi-offset patching) |

```yaml
static_files:
  /usr/sbin/httpd:
    type: binary_patch
    patches:
      - {file_offset: 0x1234, expect: '01 02', hex_bytes: 'aa bb', why: 'nop check A', tag: sb}
      - {file_offset: 0x2000, asm: 'nop', why: 'nop check B', tag: sb}
```

## Behavior

- If `expect` is set, the current bytes at the offset are verified (over `len(expect)`, which may differ from the patch length) before writing. On mismatch the `on_mismatch` policy applies. If the bytes already equal the *patch* bytes, the edit is skipped as an idempotent re-run (safe — re-writing identical bytes is a no-op).
- Verification/application happen **host-side** in the LiveImage plugin, before the batched patch hypercall.
- Each edit's outcome (`file`, `file_offset`, `result`, `tag`/`why`/`detail`) is recorded to **`binary_patches.yaml`** in the run output dir and logged one line per edit.
- `on_mismatch: fail` genuinely aborts the image build (hypercall returns `-1` → `send_portalcall` exit code → `run_or_report` → `REPORT_ERROR`).

## Same-file accumulation

Multiple edits to one file go in the `patches` list. They are accumulated into a **single host-side buffer and applied in one pass**, with **overlapping write ranges rejected** (checked pairwise, so a contained range is caught too) — clobber-free by construction. (`static_files` is keyed by path, so two `binary_patch` actions can't target one file; the list is how you patch multiple offsets.)

## Compose: place a file *and* patch it

Patching is an operation on a placed file, not a mutually-exclusive file *type*. Because `static_files` is keyed by path, a path could previously be a `host_file`/`inline_file` **or** a `binary_patch`, never both — so you couldn't stage a file and then patch it in one config. `host_file` and `inline_file` now take an optional `patches` list (same `BinaryPatchEntry` shape, same semantics):

```yaml
static_files:
  /usr/sbin/httpd:
    type: host_file
    host_path: ./blobs/httpd
    patches:
      - {file_offset: 0x1234, expect: '01 02', hex_bytes: 'aa bb', why: 'nop check', tag: sb}
```

The placed file is staged, then a synthetic `binary_patch` is queued against its path and runs through the **exact same Phase 4 pipeline** — one applier, one verify/idempotency/provenance/overlap path, no second implementation. `static_fs` already resolves the path to the staged file, so the out-of-bounds size check validates against the real staged size. A glob source/destination combined with `patches` is rejected (ambiguous target).

## Efficiency: windowed transfer (no whole-file round-trips)

Previously each `binary_patch` copied the entire target file host↔guest twice (`hyp_file_op put` then `get`) just to change a few bytes — expensive for large binaries. Now only the byte window an action touches is moved:

- `hyp_file_op` gains a `--range <off> [len]` mode: ranged `put` uploads only `[off, off+len)` of the guest file; ranged `get` writes the patched window back at `off` with `r+b` (no truncation). The host portal handlers are unchanged — the staged blob just becomes small.
- LiveImage computes each action's window (`_patch_window`), emits ranged put/get, and applies edits against the window via `_apply_binary_patch(..., base_offset=...)`. All verify / idempotent-skip / overlap / provenance logic stays host-side and single-sourced — nothing is reimplemented guest-side; keystone assembly is unchanged. Recorded offsets stay absolute.

## Failure handling

Failures are caught in layers, earliest first:

- **Config load (pydantic):** malformed `hex_bytes`/`expect` (non-hex or odd length, via the `HexStr` validator), a bad `on_mismatch` value, or a `patches` entry missing `file_offset`.
- **Script generation (before boot):** structurally invalid edits (inline form with no `file_offset` and no `patches`, neither/both of `hex_bytes`+`asm`, un-assemblable `asm`, action-level fields mixed with `patches`) raise via `_patch_window`. **Out-of-bounds offsets** are also caught here: when the target's size is knowable from the static filesystem, the patch window (`base_off + win_len`) is checked against it and a window past EOF raises `... exceeds file size N bytes — wrong offset or wrong target file?`. Size lookups go through the `static_fs` view, which composes the base rootfs with `host_file`/`inline_file` and resolves symlinks; `binary_patch` is resolved as an in-place edit (new opt-in `transparent` mode) so we read the underlying file. If the size can't be determined, the check is skipped (no false positives).
- **Patch application (batch hypercall, host-side):** a failing `expect` follows the `on_mismatch` policy — `fail` (default) returns `-1` and aborts the build with the file left untouched; `skip` continues unpatched; `warn` patches and logs. Overlapping writes and bad bytes also fail → abort. Every outcome is recorded in `binary_patches.yaml`.

**Atomicity:** on any hard failure the target is never modified in the guest — all window write-backs run *after* the batch hypercall, so a `-1` return aborts before any `get`, leaving every target in its original state (all-or-nothing across the whole queue).

The out-of-bounds check is complementary to `expect`: it catches wrong/too-large offsets without needing `expect`; `expect` still catches a wrong-but-in-bounds offset.

## Relations

- Sibling of #649 (`string_patch`/`diff_patch` for non-binary config files) — same `expect`/idempotency ergonomics (`on_mismatch` verb set, "already equals target → skip" rule, multi-edit list shape) so binary and text patches read the same.
- `binary_patches.yaml` provenance is a candidate feed for `run_manifest.yaml` (Tier 2).

## Tests

- `tests/unit_tests/test_binary_patch.py` — host-side (framework-stubbed, no container): expect/policy matrix, length-mismatch & past-EOF, hex `0x`/space tolerance, multi-patch, overlap rejection (incl. contained range), `on_mismatch: fail` abort contract, the windowed path (`_patch_window`, `base_offset` apply/verify, windowed handler round-trip), and the out-of-bounds bounds check (pure predicate + raise/skip paths).
- Compose: `_synth_file_patch_action` unit tests (no-patches → nothing queued, builds a clean `binary_patch` action, copies the list, glob source/dest rejection).
- Container fixture (`test_target`): expect-match/skip/idempotent/warn cases + a two-offset `patches` case + an `inline_file` placed then patched at offset 0, asserting `binary_patches.yaml` provenance — now exercised over the ranged transport.
- Schema doc regenerated.

