### PR TITLE
boot_env: keep kernel-parsed knobs (igloo_task_size) on the cmdline

### DIFF
--- a/src/penguin/boot_env.py
+++ b/src/penguin/boot_env.py
@@ -4,15 +4,22 @@ penguin.boot_env
 
 Partitioning and delivery of penguin's boot-time guest environment.
 
-Penguin's internal env knobs (``ROOT_SHELL``, ``igloo_init``, the ``IGLOO_*``
-family, ...) are consumed only by guest *userspace* -- the ``source.d`` boot
-scripts, ``/igloo/init``, and ``LD_PRELOAD`` constructors -- and only after
-``igloo.ko`` has been inserted. None of them is read by the kernel or the
-module at boot. So rather than smuggling them on the kernel command line (which
-is capped at ``COMMAND_LINE_SIZE`` -- as low as 256B on MIPS, where it silently
-truncates), we deliver them in an early-boot env blob that ``preinit.sh``
-sources into PID1's environment, whence they propagate to the whole guest
-process tree exactly as cmdline env did.
+Most of Penguin's internal env knobs (``ROOT_SHELL``, ``igloo_init``, the
+``IGLOO_*`` family, ...) are consumed only by guest *userspace* -- the
+``source.d`` boot scripts, ``/igloo/init``, and ``LD_PRELOAD`` constructors --
+and only after ``igloo.ko`` has been inserted. So rather than smuggling them on
+the kernel command line (which is capped at ``COMMAND_LINE_SIZE`` -- as low as
+256B on MIPS, where it silently truncates), we deliver them in an early-boot env
+blob that ``preinit.sh`` sources into PID1's environment, whence they propagate
+to the whole guest process tree exactly as cmdline env did.
+
+A few knobs are the exception: they are read by the *kernel* itself at boot,
+before any userspace runs, so they MUST reach ``/proc/cmdline`` and cannot be
+diverted to the blob (which is fetched over the portal and sourced only after
+``insmod``). These are listed in :data:`KERNEL_CMDLINE_KNOBS` and always stay on
+the cmdline. ``igloo_task_size`` (the user/kernel VM-split boundary the igloo
+kernel parses to size the guest address space) is one such knob -- diverting it
+silently gave targets that rely on it the wrong VM split.
 
 The kernel command line then carries only what must be there: ``root=``,
 ``init=``, ``panic=``, ``console=``, ``rw``, plus any *firmware-expected*
@@ -45,13 +52,30 @@ PENGUIN_INTERNAL_ENV: frozenset = frozenset({
 })
 
 
+# Knobs the KERNEL parses from the command line at boot (before userspace, and
+# before the env blob is fetched/sourced in preinit.sh). These carry the
+# ``igloo_`` prefix but are NOT userspace env, so they must never be diverted to
+# the blob -- they have to reach /proc/cmdline like any real kernel parameter.
+#   * igloo_task_size -- user/kernel VM-split boundary (0xBF/0x7F/0x3F000000);
+#     the igloo kernel reads it to size the guest address space. Firmware built
+#     for an older VM split (e.g. RouterOS 6 on a 3.x kernel) boots wrong -- or
+#     crashes marginally, layout-dependent -- if this doesn't reach the kernel.
+KERNEL_CMDLINE_KNOBS: frozenset = frozenset({
+    "igloo_task_size",
+})
+
+
 def is_penguin_internal_env(key: str) -> bool:
     """Return True if ``key`` is a penguin-internal knob delivered via the
     boot env blob (off the kernel cmdline).
 
     Matches the ``igloo_``/``IGLOO_`` namespace plus the small set of
-    historically un-prefixed knobs in :data:`PENGUIN_INTERNAL_ENV`.
+    historically un-prefixed knobs in :data:`PENGUIN_INTERNAL_ENV` -- EXCEPT the
+    kernel-parsed knobs in :data:`KERNEL_CMDLINE_KNOBS`, which are read by the
+    kernel at boot and must stay on the cmdline.
     """
+    if key in KERNEL_CMDLINE_KNOBS:
+        return False
     return key in PENGUIN_INTERNAL_ENV or key.lower().startswith("igloo_")
 
 

--- a/tests/unit_tests/test_boot_env.py
+++ b/tests/unit_tests/test_boot_env.py
@@ -11,6 +11,7 @@ Everything here runs without a rootfs, kernel, or container.
 import pytest
 
 from penguin.boot_env import (
+    KERNEL_CMDLINE_KNOBS,
     PENGUIN_INTERNAL_ENV,
     is_penguin_internal_env,
     partition_boot_env,
@@ -19,7 +20,7 @@ from penguin.boot_env import (
 
 
 @pytest.mark.parametrize("key", [
-    "igloo_init", "igloo_task_size",          # lowercase igloo_ prefix
+    "igloo_init",                              # lowercase igloo_ prefix
     "IGLOO_LTRACE", "IGLOO_CGROUP_MODE",       # uppercase IGLOO_ prefix
     "IGLOO_OWN_IFACES", "IGLOO_EXT_MAC",       # newer prefixed knobs (no edit needed)
     "ROOT_SHELL", "SHARED_DIR", "WWW", "CID",  # un-prefixed knobs
@@ -34,6 +35,18 @@ def test_internal_keys_recognized(key):
 ])
 def test_external_keys_not_internal(key):
     assert not is_penguin_internal_env(key)
+
+
+@pytest.mark.parametrize("key", sorted(KERNEL_CMDLINE_KNOBS))
+def test_kernel_cmdline_knobs_stay_on_cmdline(key):
+    # Kernel-parsed knobs carry the igloo_ prefix but must NOT be diverted to the
+    # blob -- the kernel reads them from /proc/cmdline at boot, before the blob is
+    # sourced in preinit.sh. Regression guard for the ros6 VM-split break
+    # (igloo_task_size diverted off the cmdline -> wrong guest address-space split).
+    assert not is_penguin_internal_env(key)
+    cmdline_env, blob_env = partition_boot_env({key: "0x7f000000"})
+    assert key not in blob_env
+    assert cmdline_env == {key: "0x7f000000"}
 
 
 def test_explicit_set_is_a_subset_of_recognized():


### PR DESCRIPTION
## Problem

`ba064b52` ("Deliver penguin env off the kernel cmdline") partitions every `igloo_`/`IGLOO_`-prefixed `env` key into the early-boot blob that `preinit.sh` fetches over the portal and sources **after** `insmod`. That rests on the premise that none of these knobs are read by the kernel at boot — which is wrong for one: **`igloo_task_size`** is the user/kernel VM-split boundary (`0xBF/0x7F/0x3F000000`) the igloo kernel parses from the command line, before any userspace runs. Diverting it removed it from `/proc/cmdline` (and `init.sh`'s handoff scrub then unset it too), so any target that sets it boots with the wrong guest address-space split.

## Impact

Regressed rehostings **ros6** (RouterOS 6.45.8, armel, kernel 4.10) — the one target that sets `igloo_task_size: 0x7f000000` for its 3.x-on-4.x VM-split hack. Its nova loader failed the `CTRL_READY` handshake and `SIGABRT`'d (only `btest` bound). The wrong split made it layout-dependent, so it presented as **flaky/marginal** (run-to-run 1-vs-5 services) — which is why it first looked like an environment/timing problem.

## How it was found

Controlled same-environment A/B on the CI cluster:
- v3.0.22/34/40/44/48 green; v3.0.50/51 red → regression entered at **v3.0.50**
- `ba064b52^` green 3/3; `ba064b52` red 3/3; the QEMU `0.0.10→0.0.14` bump on top changed nothing → **`ba064b52`** is the cause
- keeping only `igloo_task_size` on the cmdline (this fix) → **green 3/3** on the v3.0.51 base

## Fix

Add `KERNEL_CMDLINE_KNOBS` — prefixed knobs the kernel reads at boot that must never be diverted — and exclude them in `is_penguin_internal_env`. Only `igloo_task_size` qualifies today; the set documents the constraint so a future kernel knob can't silently regress the same way. User-intended kernel params still belong in `kernel_cmdline_append`; this covers the `igloo_`-prefixed knob penguin itself manages via `env`.

Regression test in `test_boot_env.py` pins that every `KERNEL_CMDLINE_KNOBS` member stays on the cmdline and out of the blob. All 26 boot_env unit tests pass locally.