### PR TITLE
Fix GitHub Pages deploy failing on re-run (duplicate github-pages artifact)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,6 +25,7 @@ permissions:
   contents: write   # attach PDF/docs.tar.gz assets to the release
   pages: write
   id-token: write
+  actions: write    # delete stale github-pages artifacts left by prior re-run attempts
 
 concurrency:
   group: "docs"
@@ -175,6 +176,23 @@ jobs:
         run: |
           mkdir html_content
           tar -xvf docs.tar.gz -C html_content
+      # A re-run (workflow or just this job) does NOT clear artifacts uploaded by
+      # a prior attempt. upload-pages-artifact always names its artifact
+      # "github-pages", so a re-run leaves 2+ identically-named artifacts in the
+      # run and deploy-pages@v4 aborts with "Multiple artifacts named
+      # github-pages were unexpectedly found". Delete any stale one first so
+      # exactly one exists at deploy time.
+      - name: Delete stale github-pages artifacts from prior attempts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ids=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+            --paginate --jq '.artifacts[] | select(.name=="github-pages") | .id')
+          for id in $ids; do
+            echo "Deleting stale github-pages artifact $id"
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}" || true
+          done
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Problem

The `Docs` workflow's `deploy_static` job fails at **Deploy to GitHub Pages** with:

```
Error: Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
```

(e.g. [run 28795088989](https://github.com/rehosting/penguin/actions/runs/28795088989))

### Root cause

`upload-pages-artifact` always names its output `github-pages`. When a workflow — or just the `deploy_static` job — is **re-run**, GitHub does *not* delete artifacts uploaded by the prior attempt, so the run accumulates 2+ artifacts named `github-pages` and `actions/deploy-pages@v4` refuses to pick one.

This is why fresh nightly runs (attempt 1) are green but any re-run is **permanently unrecoverable** — each re-run just adds another `github-pages` artifact. Verified live: deleting the duplicate down to one and re-running `deploy_static` immediately re-uploaded a second `github-pages` and failed with the identical error.

## Fix

Before `upload-pages-artifact`, delete any pre-existing `github-pages` artifact in the current run (via `gh api`) so exactly one exists at deploy time. Adds `actions: write` to the workflow `permissions` block (required to delete artifacts). Re-runs are now self-healing.

## Note

This only takes effect once merged — the currently-stuck run can't be salvaged by a blind re-run. After merge, the next publish (or a manual `workflow_dispatch`) will exercise the fix.