### PR TITLE
core: add allow_reboot option to control -no-reboot

### DIFF
--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -707,6 +707,23 @@ false
 true
 ```
 
+### `core.allow_reboot` Allow the guest to reboot
+
+|||
+|-|-|
+|__Type__|boolean|
+|__Default__|`false`|
+
+If False (default), QEMU is launched with '-no-reboot' so a guest-initiated reboot terminates the emulation (one boot per run). If True, '-no-reboot' is omitted so QEMU resets the machine in place and the guest reboots within the same run. Persistent drives and host-file-backed MTD devices survive the reset; stateful plugins must tolerate a second guest init.
+
+```yaml
+false
+```
+
+```yaml
+true
+```
+
 ### `core.startup_script` Inline guest startup script
 
 |||

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -614,6 +614,22 @@ class Core(PartialModelMixin, BaseModel):
             examples=[False, True],
         ),
     ]
+    allow_reboot: Annotated[
+        bool,
+        Field(
+            False,
+            title="Allow the guest to reboot",
+            description=" ".join((
+                "If False (default), QEMU is launched with '-no-reboot' so a",
+                "guest-initiated reboot terminates the emulation (one boot per run).",
+                "If True, '-no-reboot' is omitted so QEMU resets the machine in place",
+                "and the guest reboots within the same run. Persistent drives and",
+                "host-file-backed MTD devices survive the reset; stateful plugins must",
+                "tolerate a second guest init.",
+            )),
+            examples=[False, True],
+        ),
+    ]
     startup_script: Annotated[
         Optional[str],
         Field(

--- a/src/penguin/penguin_run.py
+++ b/src/penguin/penguin_run.py
@@ -553,7 +553,11 @@ def run_config(
     if q_config["arch"] == "loongarch64":
         args += ["-bios", "/usr/local/share/qemu/edk2-loongarch64-code.fd"]
 
-    args += ["-no-reboot"]
+    if not conf["core"].get("allow_reboot", False):
+        # Default: a guest-initiated reboot terminates the VM (one boot per run).
+        # With core.allow_reboot=True we omit -no-reboot so QEMU resets in place
+        # and the guest reboots within the run (drives + backing files persist).
+        args += ["-no-reboot"]
 
     if snapshot_enabled and snapshot_boot_from:
         # Restore device + RAM state from the named internal snapshot at boot.


### PR DESCRIPTION
## What

Adds a `core.allow_reboot` config option (default `False`) that controls whether QEMU is launched with `-no-reboot`.

- **`False` (default)** — unchanged behavior: `-no-reboot` is passed, so a guest-initiated reboot terminates the emulation (one boot per run).
- **`True`** — `-no-reboot` is omitted, so QEMU resets the machine in place and the guest can reboot within a single run. Persistent drives and host-file-backed MTD devices survive the reset.

## Why

Some workflows want the guest to reboot and come back up within one run (e.g. exercising firmware that reboots itself, or validating that state committed to a persistent/MTD-backed store survives a reboot in place). `-no-reboot` was previously unconditional, so any guest reboot ended the run.

## Changes

- `src/penguin/penguin_config/structure.py` — new `Core.allow_reboot` bool field.
- `src/penguin/penguin_run.py` — append `-no-reboot` only when `allow_reboot` is false.
- `docs/schema_doc.md` — regenerated.

## Notes / scope

This adds the switch and the QEMU-level behavior only (verified: with `allow_reboot: true` QEMU omits `-no-reboot` and warm-resets in place on a guest reboot). It does **not** make every guest-init path idempotent across an in-place reset — targets whose init consumes one-shot host-staged files on first boot may not survive a warm reset yet. Making guest-init re-entrant across a reset (or an orchestrated relaunch loop) is a follow-on; this option is the primitive both approaches build on. Default is unchanged, so existing configs are unaffected.