### PR TITLE
ci: cut redundant per-runner image work in test workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,9 @@ jobs:
     # image build) so it is a genuine fast lane.
     needs: changes
     runs-on: rehosting-arc
-    if: ${{ !github.event.pull_request.draft }}
+    # Job-level gate (not just per-step): skip allocating an ephemeral rehosting-arc
+    # runner entirely on docs-only PRs, instead of spinning one up to skip every step.
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout code
         if: ${{ needs.changes.outputs.run_tests == 'true' }}
@@ -140,7 +142,9 @@ jobs:
   build_container:
     runs-on: rehosting-arc
     needs: [changes, lint]
-    if: ${{ !github.event.pull_request.draft }}
+    # Job-level gate: don't build/push the image on docs-only PRs. lint stays
+    # ungated (this job needs it), so skipping here never cascade-skips via lint.
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.run_tests == 'true' }}
     steps:
       - name: Checkout code
         if: ${{ needs.changes.outputs.run_tests == 'true' }}
@@ -198,7 +202,9 @@ jobs:
   run_tests:
     needs: [changes, build_container]
     runs-on: rehosting-arc
-    if: ${{ !github.event.pull_request.draft }}
+    # Job-level gate: on docs-only PRs, don't allocate the 10-arch matrix of
+    # ephemeral runners just to skip every step.
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.run_tests == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -211,7 +217,9 @@ jobs:
         if: ${{ needs.changes.outputs.run_tests == 'true' }}
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0
+          # Shallow: this job only needs the tree at the PR head to run tests,
+          # not full history (×10 arch runners).
+          fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       # Acquire the prebuilt image with a plain `docker pull` via the shared
@@ -271,61 +279,38 @@ jobs:
     # the per-arch matrix instead of multiplying CI cost by 10.
     needs: [changes, build_container]
     runs-on: rehosting-arc
-    if: ${{ !github.event.pull_request.draft }}
+    # Job-level gate: skip the runner entirely on docs-only PRs.
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.run_tests == 'true' }}
     steps:
-      - name: Set up Python
-        if: ${{ needs.changes.outputs.run_tests == 'true' }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10.12"
-      - name: Install dependencies
-        if: ${{ needs.changes.outputs.run_tests == 'true' }}
-        run: pip install click pyyaml
       - name: Checkout code
-        if: ${{ needs.changes.outputs.run_tests == 'true' }}
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - name: Trust Harbor's self-signed certificate
-        if: ${{ needs.changes.outputs.run_tests == 'true' }}
-        run: |
-          echo "Fetching certificate from ${{ env.REGISTRY }}"
-          openssl s_client -showcerts -connect ${{ env.REGISTRY }}:443 < /dev/null 2>/dev/null | openssl x509 -outform PEM | sudo tee /usr/local/share/ca-certificates/harbor.crt > /dev/null
-          sudo update-ca-certificates
-
-      - name: Set up Docker Buildx
-        if: ${{ needs.changes.outputs.run_tests == 'true' }}
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: |
-            network=host
-          buildkitd-config-inline: |
-            [registry."${{ env.REGISTRY }}"]
-              insecure = true
-              http = true
-
-      - name: Log in to Rehosting Arc Registry
-        if: ${{ needs.changes.outputs.run_tests == 'true' }}
-        uses: docker/login-action@v3
+      # Acquire the prebuilt image with a plain `docker pull` via the shared org
+      # action (same as run_tests), replacing the old `buildx build --load`
+      # heredoc that cost ~5-6 min/job of GB export/import. install-python
+      # provides the click/pyyaml the compose test needs; install-cert is off
+      # because the rehosting-arc dind daemon already trusts Harbor's CA.
+      - name: Set up penguin image
+        uses: rehosting/ci/actions/pull-image@v1
         with:
           registry: ${{ env.REGISTRY }}
+          target: ${{ env.TARGET }}
+          image: rehosting/penguin
+          tag: ${{ github.sha }}
+          local-tag: rehosting/penguin:latest
           username: ${{ env.USER }}
           password: ${{ secrets.REHOSTING_ARC_REGISTRY_PASSWORD || env.EXTERNAL_REGISTRY_PASS }}
-
-      - name: Pull image via Buildx and Load to Daemon
-        if: ${{ needs.changes.outputs.run_tests == 'true' }}
-        run: |
-          echo "FROM ${{ env.TARGET }}/rehosting/penguin:${{ github.sha }}" | \
-          docker buildx build -t rehosting/penguin:latest --load -
+          install-python: "true"
+          install-cert: "false"
 
       - name: Compose test (armel)
-        if: ${{ needs.changes.outputs.run_tests == 'true' }}
         run: timeout 8m python3 $GITHUB_WORKSPACE/tests/integration/compose/test.py --arch armel
 
       - name: Compose debug info
-        if: ${{ needs.changes.outputs.run_tests == 'true' && failure() }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
           name: compose-artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,9 +43,14 @@ jobs:
               - '**/*.py'
             # Changes that should re-run the guest-test matrix even though the
             # `code` filter excludes .github/**: the test workflow and fixtures.
+            # NOTE: predicate-quantifier is `every` (required for the `code`
+            # filter's negations), which means a filter listing multiple
+            # positive patterns requires a file to match *all* of them — so a
+            # two-pattern testci was silently always-false and this filter never
+            # fired. Express the alternatives as a single brace pattern so
+            # `every` is satisfied when a file matches either one.
             testci:
-              - '.github/workflows/build.yaml'
-              - 'tests/**'
+              - '{.github/workflows/build.yaml,tests/**}'
   lint:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: rehosting-arc


### PR DESCRIPTION
## What

Optimizations to the PR **Test Container** workflow, aimed at the Docker image build/push/**pull cost paid per ephemeral runner** — the driver of recent CI slowness. Measured: the plain `docker pull` in `run_tests` takes **163–238s per arch runner** (2 GB image, ~10 MB/s = per-runner decompression bound), paid ×11 in parallel; the old `run_compose` buildx-load path took **266s**.

### 1. `run_compose`: `docker pull` instead of `buildx build --load` (the big one)
`run_tests` already uses `rehosting/ci/actions/pull-image` (plain `docker pull`), but `run_compose` still did `echo "FROM …/penguin:${sha}" | docker buildx build -t …:latest --load -`, which re-exports/imports the full multi-GB image through buildx (**266s measured**). Switched to the same `pull-image` action. Also drops the now-redundant per-job cert trust, buildx setup, registry login, and separate Python setup (the action's `install-python` provides click/pyyaml).

### 2. Job-level gating on docs-only PRs
The `run_tests` filter was applied per-*step*, so `build_container`, the 10-arch `run_tests` matrix, `run_compose`, and `unit_tests` each still **allocated an ephemeral rehosting-arc runner** only to skip every step — **~14 runners spun up to do nothing** on a docs-only PR. Moved the gate to the *job* `if:`. `lint` stays ungated so `build_container`'s `needs: lint` never cascade-skips.

### 3. Shallow checkout on test jobs
`fetch-depth: 0` → `1` on `run_tests` and `run_compose`; they only need the tree at the PR head. `build_container` keeps full history in case the build embeds it.

### 4. Fix the silently-dead `testci` paths-filter
The workflow sets `predicate-quantifier: every` (needed for `code`'s negation patterns). Under `every`, a filter with multiple positive patterns requires a file to match **all** of them — so the two-pattern `testci` was **always false**, and changes to the test workflow never triggered the matrix they govern. (This PR proved it: the first run skipped `run_tests` on a build.yaml-only change.) Collapsed to a single brace pattern so it fires on either — which also lets this PR self-validate the `run_compose` switch.

## Risk
- `run_compose` now relies on the dind daemon trusting Harbor's CA — the same assumption `run_tests` already uses (`install-cert: false`).
- No test logic changed; matrix, timeouts, and reporters are untouched.

## Follow-ups (not in this PR)
- **Harbor retention** for accumulating per-PR tags: measured `:cache-PR-N` ≈ **6.9 GB each** and `:${sha}` ≈ **2.1 GB each**, one per PR, never cleaned → prime feeder of the 300Gi registry PVC / node disk pressure. Needs a tag-retention rule + scheduled GC (Harbor admin).
- **Structural pull cost**: run tests against the node's shared containerd instead of per-runner dind, so the 2 GB image is unpacked ~once/node instead of ×11 (the 205s/runner is decompression, not bandwidth).