### PR TITLE
ci: run required checks on merge_group so the merge queue works

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
     types: [opened, synchronize, reopened, ready_for_review]
+  # Required checks (lint, build_container, run_tests) live only in this
+  # workflow. The merge queue fires a `merge_group` event and waits for those
+  # contexts to report; without this trigger they never run and GitHub evicts
+  # the PR ("no response for status checks").
+  merge_group:
 
 env:
   REGISTRY: ${{ secrets.REHOSTING_ARC_REGISTRY || 'harbor.harbor.svc.cluster.local' }}
@@ -18,15 +23,21 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     outputs:
-      run_lint: ${{ steps.filter.outputs.python }}
+      run_lint: ${{ github.event_name == 'merge_group' || steps.filter.outputs.python == 'true' }}
       # Run the guest-test matrix on code changes OR on changes to the test
       # workflow / test fixtures themselves (the `code` filter excludes
       # .github/**, so a build.yaml-only change would otherwise skip the tests
       # it governs).
-      run_tests: ${{ steps.filter.outputs.code == 'true' || steps.filter.outputs.testci == 'true' }}
+      # In the merge queue there is no PR base for paths-filter to diff, and a
+      # skipped *required* job reports no conclusion (→ another eviction), so
+      # force the full matrix on merge_group — the queue should validate the
+      # real merged result, not a path-filtered subset.
+      run_tests: ${{ github.event_name == 'merge_group' || steps.filter.outputs.code == 'true' || steps.filter.outputs.testci == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ github.event_name != 'merge_group' }}
       - id: filter
+        if: ${{ github.event_name != 'merge_group' }}
         uses: dorny/paths-filter@v3
         with:
           predicate-quantifier: 'every'  # require file to satisfy all positives and none of the negatives


### PR DESCRIPTION
## Problem

PRs put into the merge queue get evicted with:

> github-merge-queue Bot removed this pull request from the merge queue due to no response for status checks

**Root cause:** branch protection on `main` requires `lint`, `build_container`, and `run_tests (<arch>)` ×10. Those contexts are produced **only** by `build.yaml`, which triggered only on `pull_request`. The merge queue creates a temporary merge-candidate branch and fires a **`merge_group`** event, then waits for the required checks to report on it. No workflow listened for `merge_group` (confirmed: 0 `merge_group` runs in the last 40), so the checks never started, never reported, and GitHub evicted the PR after the timeout.

## Fix

- Add a `merge_group:` trigger to `build.yaml`.
- In the `changes` job, **skip the `paths-filter` step on `merge_group`** — there's no PR base to diff, which would fail the job and cascade-skip every required job (same eviction) — and **force `run_lint`/`run_tests` true** on `merge_group`. This makes the queue validate the real merged result with the full matrix rather than a hollow path-filtered skip.

The job-level `if: !github.event.pull_request.draft` guards all pass on `merge_group` (`pull_request` is null → `!null` = true), so the required jobs run.

## Note

This runs the full 10-arch matrix + container build **again** in the queue for each PR (in addition to the PR run). That's the inherent cost of gating `main` via a merge queue with these required checks — correct, but not free. If it's too heavy, the alternative is trimming the required contexts.
