### PR TITLE
ci: single ci_gate required check for conditional jobs + merge queue

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -331,3 +331,39 @@ jobs:
         with:
           name: compose-artifacts
           path: ${{ github.workspace }}/tests/integration/compose/compose_projects/
+
+  # Single required status check for branch protection + the merge queue.
+  #
+  # The per-arch run_tests matrix and build_container are conditionally skipped
+  # (docs-only / non-build.yaml-workflow-only PRs don't need them). A skipped
+  # matrix job never expands, so its per-arch contexts are never created — which
+  # would leave the old per-arch required contexts permanently unsatisfied and
+  # block such PRs. This gate always runs and turns "succeeded or legitimately
+  # skipped" into one green context, so branch protection should require ONLY
+  # `ci_gate` (not the individual jobs). It fails if any gated job failed or was
+  # cancelled.
+  ci_gate:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [changes, lint, unit_tests, build_container, run_tests, run_compose]
+    steps:
+      - name: Require no gated job to have failed
+        run: |
+          declare -A r=(
+            [changes]='${{ needs.changes.result }}'
+            [lint]='${{ needs.lint.result }}'
+            [unit_tests]='${{ needs.unit_tests.result }}'
+            [build_container]='${{ needs.build_container.result }}'
+            [run_tests]='${{ needs.run_tests.result }}'
+            [run_compose]='${{ needs.run_compose.result }}'
+          )
+          ok=true
+          for job in "${!r[@]}"; do
+            echo "  ${job}: ${r[$job]}"
+            case "${r[$job]}" in
+              success|skipped) ;;
+              *) echo "::error::gated job '${job}' result='${r[$job]}'"; ok=false ;;
+            esac
+          done
+          $ok || { echo "One or more gated jobs failed/cancelled."; exit 1; }
+          echo "All gated jobs passed or were legitimately skipped."


### PR DESCRIPTION
Fixes the regression that currently blocks #888 (and any docs-only / non-`build.yaml`-workflow-only PR).

## Problem
Branch protection requires the 10 per-arch contexts `run_tests (aarch64)` … `run_tests (x86_64)` plus `build_container`. #885 made those jobs **job-level** conditional (`if: … && run_tests == 'true'`). When a PR changes only docs or a workflow file other than `build.yaml`, `run_tests` is `false`, so the matrix job **skips and never expands** — the per-arch contexts are **never created**, so branch protection can never be satisfied. #888's head shows a single `run_tests = skipped` and no per-arch checks → permanent `BLOCKED`.

## Fix
Add an always-running **`ci_gate`** job that `needs` all the gated jobs and passes when each result is `success` **or** `skipped` (fails on `failure`/`cancelled`). Then branch protection should require **only `ci_gate`** — on `pull_request` and `merge_group` — instead of the per-arch + `build_container` contexts.

This keeps #885's savings (the heavy jobs still skip on docs PRs) while making docs/workflow-only PRs mergeable, and it gives the merge queue a single stable required context.

Gate logic was unit-tested locally: docs-only (`success/skipped…`) → pass; full green → pass; any `failure`/`cancelled` → fail.

## Post-merge step (needs admin)
Repoint `main` branch protection required checks to `["ci_gate"]`. After that, #888 needs a rebase onto main to pick up the gate workflow, then it goes green.
