### PR TITLE
tests/basic_target: assert no kernel oops during boot

### DIFF
--- a/tests/integration/basic_target/test.py
+++ b/tests/integration/basic_target/test.py
@@ -211,6 +211,42 @@ def assert_stubs_result(project_dir):
         )
 
 
+# Kernel-fault signatures that must never appear in a healthy boot. These are
+# a regression tripwire for the igloo driver's init/portal paths: e.g. driver
+# 0.0.75 shipped a shared-major devfs change that triggered a recursive mipsel
+# do_ade (unaligned-access) oops storm at driver init, which was reverted
+# without a test to catch it. A minimal boot must produce none of these.
+KERNEL_OOPS_SIGNATURES = (
+    "Unhandled kernel unaligned access",
+    "Unable to handle kernel",
+    "do_ade+",
+    "Oops[",
+    "Oops:",
+    "BUG: ",
+)
+
+
+def assert_no_kernel_oops(project_dir):
+    console = project_dir / "results" / "latest" / "console.log"
+    if not console.exists():
+        raise AssertionError(f"no console.log to check for kernel oops: {console}")
+    text = console.read_text(errors="replace")
+    hits = {sig for sig in KERNEL_OOPS_SIGNATURES if sig in text}
+    # basic_target's init.sh intentionally exits, so the guest ends with an
+    # expected "Kernel panic ... Attempted to kill init" and reboots. Flag any
+    # OTHER kernel panic (a genuine early fault), but not that one.
+    for line in text.splitlines():
+        if "Kernel panic" in line and "Attempted to kill init" not in line:
+            hits.add(line.strip())
+    if hits:
+        logger.error("--- console.log tail (kernel oops detected) ---")
+        for line in text.splitlines()[-60:]:
+            logger.error(line)
+        raise AssertionError(
+            f"kernel oops signature(s) {sorted(hits)} found in guest console: {console}"
+        )
+
+
 def run_test(kernel, arch, image, execution_mode="qemu"):
     id = subprocess.check_output(
         f"docker create {image}", shell=True).decode().strip()
@@ -253,6 +289,10 @@ def run_test(kernel, arch, image, execution_mode="qemu"):
         yaml.dump(bconfig, file, sort_keys=False)
 
     penguin_run(config, image, execution_mode=execution_mode)
+
+    # Guard against kernel faults during boot / driver init (e.g. the mipsel
+    # do_ade regression that got a shared-major devfs change reverted).
+    assert_no_kernel_oops(project_path)
 
     if arch in DROPIN_C_TEST_ARCHES:
         assert_dropin_c_result(project_path)


### PR DESCRIPTION
## Why

`basic_target` boots on every arch in CI (including all MIPS variants) but never inspects the guest console for **kernel faults** — it only checks that init ran and the drop-ins fired. That blind spot is exactly how the igloo driver's shared-major devfs change (0.0.75) shipped a **recursive mipsel `do_ade` unaligned-access oops storm at driver init** and was reverted without a regression test. A plain `basic_target/mipsel` boot reproduces that crash, so a console assertion would have caught it.

## What

`assert_no_kernel_oops()`, called after every `basic_target` boot (all arches):
- Fails on `Unhandled kernel unaligned access`, `Unable to handle kernel`, `do_ade+`, `Oops[` / `Oops:`, `BUG: `.
- Fails on any kernel panic **except** `basic_target`'s own expected `"Attempted to kill init"` — its `init.sh` exits on purpose, so the guest always ends with that panic + reboot.

This turns the existing per-arch matrix into a tripwire for the driver's init/portal paths.

## Verified
- **Trips** on the saved period-0.0.75 mipsel crash console (`Unhandled kernel unaligned access`, `do_ade+`).
- **Green** on a clean mipsel boot end-to-end (no false positive on the expected init-exit panic).

## Context
Companion to rehosting/igloo_driver#87, which re-lands the shared-major devfs fix (now confirmed safe: the do_ade regression was an environmental unaligned bug since fixed, not a major-sharing flaw). This test is the guard that was missing the first time.