### PR TITLE
TEST: run penguin CI on the shared-docker runner set

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
               - '{.github/workflows/build.yaml,tests/**}'
   lint:
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: rehosting-arc
+    runs-on: rehosting-arc-shared
     needs: changes
     steps:
     - uses: actions/checkout@v5
@@ -106,7 +106,7 @@ jobs:
     # run_tests filter as the matrix, but depends only on `changes` (not on the
     # image build) so it is a genuine fast lane.
     needs: changes
-    runs-on: rehosting-arc
+    runs-on: rehosting-arc-shared
     # Job-level gate (not just per-step): skip allocating an ephemeral rehosting-arc
     # runner entirely on docs-only PRs, instead of spinning one up to skip every step.
     if: ${{ !github.event.pull_request.draft && needs.changes.outputs.run_tests == 'true' }}
@@ -156,7 +156,7 @@ jobs:
           reporter: java-junit
 
   build_container:
-    runs-on: rehosting-arc
+    runs-on: rehosting-arc-shared
     needs: [changes, lint]
     # Job-level gate: don't build/push the image on docs-only PRs. lint stays
     # ungated (this job needs it), so skipping here never cascade-skips via lint.
@@ -217,7 +217,7 @@ jobs:
 
   run_tests:
     needs: [changes, build_container]
-    runs-on: rehosting-arc
+    runs-on: rehosting-arc-shared
     # Job-level gate: on docs-only PRs, don't allocate the 10-arch matrix of
     # ephemeral runners just to skip every step.
     if: ${{ !github.event.pull_request.draft && needs.changes.outputs.run_tests == 'true' }}
@@ -294,7 +294,7 @@ jobs:
     # Compose's mcast plumbing is arch-independent, so this runs once outside
     # the per-arch matrix instead of multiplying CI cost by 10.
     needs: [changes, build_container]
-    runs-on: rehosting-arc
+    runs-on: rehosting-arc-shared
     # Job-level gate: skip the runner entirely on docs-only PRs.
     if: ${{ !github.event.pull_request.draft && needs.changes.outputs.run_tests == 'true' }}
     steps:


### PR DESCRIPTION
Live end-to-end test of the new shared-docker infra (kube shared-docker DaemonSet + `rehosting-arc-shared` scale set) against a real penguin PR.

**What this changes:** points the heavy CI jobs (lint, unit_tests, build_container, run_tests, run_compose) from `rehosting-arc` to `rehosting-arc-shared`. That scale set runs against a single per-node Docker daemon with a shared image store, instead of a per-pod ephemeral dind — so the image built by `build_container` is reused by every `run_tests` arch on the same node (no re-pull, no per-pod ephemeral-storage eviction).

**Why a PR:** the PR's own CI run *is* the test. `main` stays on `rehosting-arc` until/unless this is merged. If green, this doubles as the migration PR.

Do not automerge — hold until the run is green and reviewed.