### PR TITLE
ci: parallelize run_tests across kernels (arch × kernel matrix)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -218,13 +218,27 @@ jobs:
   run_tests:
     needs: [changes, build_container]
     runs-on: rehosting-arc
-    # Job-level gate: on docs-only PRs, don't allocate the 10-arch matrix of
-    # ephemeral runners just to skip every step.
+    # Job-level gate: on docs-only PRs, don't allocate the matrix of ephemeral
+    # runners just to skip every step.
     if: ${{ !github.event.pull_request.draft && needs.changes.outputs.run_tests == 'true' }}
     strategy:
       fail-fast: false
       matrix:
+        # One job per (arch, kernel). Both test runners (basic_target,
+        # test_target) otherwise loop DEFAULT_KERNELS serially inside a single
+        # per-arch job — the kernel loop is the real long pole (e.g. mipsel
+        # test_target was ~438s for two kernels). Splitting the loop into the
+        # matrix runs the kernels in parallel; with the shared-daemon warm image
+        # store the extra per-job pull is ~13s, so more/smaller jobs are cheap.
         arch: ["armel", "mipsel", "mipseb", "mips64el", "mips64eb", "powerpc64", "loongarch64", "aarch64", "x86_64", "riscv64"]
+        kernel: ["4.10", "6.13"]
+        # powerpc64/loongarch64/riscv64 only support 6.13 (NONDEFAULT_KERNEL_ARCHES
+        # in the test runners); drop their 4.10 combos so those jobs don't spin
+        # up just to skip. Every other arch runs both kernels. Net: 17 jobs.
+        exclude:
+          - { arch: "powerpc64", kernel: "4.10" }
+          - { arch: "loongarch64", kernel: "4.10" }
+          - { arch: "riscv64", kernel: "4.10" }
 
     steps:
       # using the version from here https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
@@ -258,22 +272,24 @@ jobs:
           install-python: "true"
           install-cert: "false"
 
-      - name: Basic test for ${{ matrix.arch }}
+      - name: Basic test for ${{ matrix.arch }} (kernel ${{ matrix.kernel }})
         if: ${{ needs.changes.outputs.run_tests == 'true' }}
-        run: timeout 10m python3 $GITHUB_WORKSPACE/tests/integration/basic_target/test.py --arch ${{ matrix.arch }}
-          
-      - name: Test for ${{ matrix.arch }} all kernels
+        run: timeout 10m python3 $GITHUB_WORKSPACE/tests/integration/basic_target/test.py --arch ${{ matrix.arch }} --kernel ${{ matrix.kernel }}
+
+      - name: Test for ${{ matrix.arch }} kernel ${{ matrix.kernel }}
         if: ${{ needs.changes.outputs.run_tests == 'true' }}
         # 20m (was 10m): the test_target suite now drives full CPython per
         # python test instead of micropython, which pushes slow-emulated arches
-        # (powerpc64, loongarch64) past the old 10m budget.
-        run: timeout 20m python3 $GITHUB_WORKSPACE/tests/integration/test_target/test.py --arch ${{ matrix.arch }}
-      
+        # (powerpc64, loongarch64) past the old 10m budget. Now single-kernel per
+        # job (see the matrix), so this is a generous upper bound.
+        run: timeout 20m python3 $GITHUB_WORKSPACE/tests/integration/test_target/test.py --arch ${{ matrix.arch }} --kernel ${{ matrix.kernel }}
+
       - name: Test Report
         uses: dorny/test-reporter@v2.1.1
         if: ${{ needs.changes.outputs.run_tests == 'true'  && ((success() || failure()) && github.event.pull_request.head.repo.full_name == github.repository)}}
-        with: 
-          name: ${{ matrix.arch }}-test-results
+        with:
+          # Per (arch, kernel) so parallel jobs don't collide on the report name.
+          name: ${{ matrix.arch }}-${{ matrix.kernel }}-test-results
           # Update the glob pattern here to only match numbered folders
           path: ${{ github.workspace }}/tests/integration/test_target/results/[0-9]*/verifier.xml
           reporter: java-junit
@@ -282,7 +298,7 @@ jobs:
         if: ${{ needs.changes.outputs.run_tests == 'true' && failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.arch }}-artifacts
+          name: ${{ matrix.arch }}-${{ matrix.kernel }}-artifacts
           if-no-files-found: ignore
           # Capture both suites: a basic_target failure aborts before
           # test_target runs, so its results/ would otherwise never be uploaded.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -266,7 +266,13 @@ jobs:
           target: ${{ env.TARGET }}
           image: rehosting/penguin
           tag: ${{ github.sha }}
-          local-tag: rehosting/penguin:latest
+          # Immutable per-commit local tag, NOT a shared :latest. On the shared
+          # per-node daemon all jobs share one image store; retagging a mutable
+          # :latest raced across concurrent jobs (delete-and-recreate →
+          # "AlreadyExists"), which the arch×kernel fan-out below made frequent.
+          # Per-sha is idempotent within a run and distinct across PRs, so no
+          # two jobs contend on the tag.
+          local-tag: rehosting/penguin:${{ github.sha }}
           username: ${{ env.USER }}
           password: ${{ secrets.REHOSTING_ARC_REGISTRY_PASSWORD || env.EXTERNAL_REGISTRY_PASS }}
           install-python: "true"
@@ -274,7 +280,7 @@ jobs:
 
       - name: Basic test for ${{ matrix.arch }} (kernel ${{ matrix.kernel }})
         if: ${{ needs.changes.outputs.run_tests == 'true' }}
-        run: timeout 10m python3 $GITHUB_WORKSPACE/tests/integration/basic_target/test.py --arch ${{ matrix.arch }} --kernel ${{ matrix.kernel }}
+        run: timeout 10m python3 $GITHUB_WORKSPACE/tests/integration/basic_target/test.py --arch ${{ matrix.arch }} --kernel ${{ matrix.kernel }} --image rehosting/penguin:${{ github.sha }}
 
       - name: Test for ${{ matrix.arch }} kernel ${{ matrix.kernel }}
         if: ${{ needs.changes.outputs.run_tests == 'true' }}
@@ -282,7 +288,7 @@ jobs:
         # python test instead of micropython, which pushes slow-emulated arches
         # (powerpc64, loongarch64) past the old 10m budget. Now single-kernel per
         # job (see the matrix), so this is a generous upper bound.
-        run: timeout 20m python3 $GITHUB_WORKSPACE/tests/integration/test_target/test.py --arch ${{ matrix.arch }} --kernel ${{ matrix.kernel }}
+        run: timeout 20m python3 $GITHUB_WORKSPACE/tests/integration/test_target/test.py --arch ${{ matrix.arch }} --kernel ${{ matrix.kernel }} --image rehosting/penguin:${{ github.sha }}
 
       - name: Test Report
         uses: dorny/test-reporter@v2.1.1
@@ -332,14 +338,20 @@ jobs:
           target: ${{ env.TARGET }}
           image: rehosting/penguin
           tag: ${{ github.sha }}
-          local-tag: rehosting/penguin:latest
+          # Immutable per-commit local tag, NOT a shared :latest. On the shared
+          # per-node daemon all jobs share one image store; retagging a mutable
+          # :latest raced across concurrent jobs (delete-and-recreate →
+          # "AlreadyExists"), which the arch×kernel fan-out below made frequent.
+          # Per-sha is idempotent within a run and distinct across PRs, so no
+          # two jobs contend on the tag.
+          local-tag: rehosting/penguin:${{ github.sha }}
           username: ${{ env.USER }}
           password: ${{ secrets.REHOSTING_ARC_REGISTRY_PASSWORD || env.EXTERNAL_REGISTRY_PASS }}
           install-python: "true"
           install-cert: "false"
 
       - name: Compose test (armel)
-        run: timeout 8m python3 $GITHUB_WORKSPACE/tests/integration/compose/test.py --arch armel
+        run: timeout 8m python3 $GITHUB_WORKSPACE/tests/integration/compose/test.py --arch armel --image rehosting/penguin:${{ github.sha }}
 
       - name: Compose debug info
         if: ${{ failure() }}


### PR DESCRIPTION
Splits the serial kernel loop in `run_tests` into the matrix, so kernels run as parallel jobs instead of serially inside each per-arch runner. **Also the first live PR on the migrated `rehosting-arc` shared daemon** (rehosting/kube#14).

### Why
Both test runners (`basic_target`, `test_target`) loop `DEFAULT_KERNELS` serially within one job, and that loop dominates wall-clock. From the last green run (per-step timings):

| arch | Basic (both kernels) | test_target (both kernels) |
|---|---|---|
| mipsel | 81s | **438s** |
| powerpc64 | 57s | 167s |

Promoting `kernel` to a matrix dimension runs the kernels in parallel — roughly halving the critical path for the slow-emulated arches and giving per-kernel pass/fail signal.

### Not a clean cross-product
`powerpc64`, `loongarch64`, `riscv64` are newer arches that **only support 6.13** (`NONDEFAULT_KERNEL_ARCHES` in the runners), so their 4.10 combos are `exclude`d. Net **10 → 17 jobs**: 7 default arches × 2 kernels + 3 newer arches × 6.13. Adding a future 6.13-only arch is one `arch:` entry + one `exclude:` line.

### Why this is cheap now
`rehosting-arc` runs on the shared per-node Docker daemon (kube#14): the warm image store makes each extra job's pull **~13s** vs a ~205s cold pull, so more/smaller jobs no longer multiply a per-job pull tax. Concurrency is bounded by capacity-based admission (each runner reserves 1 core), so the extra jobs queue rather than oversubscribe.

### Details
- Each job keeps `basic → test_target` ordering (basic as a fast gate) for a single kernel.
- `Test Report` and `Debug info` artifacts are keyed by `(arch, kernel)` so parallel jobs don't collide on names.
- Job name unchanged (`run_tests`), so the `ci_gate` merge-queue gate still covers the whole matrix — no branch-protection change needed.

No automerge — hold for green + review.