### PR TITLE
tests: harden lifeguard cmdline check against exec race

### DIFF
--- a/tests/integration/test_target/patches/tests/lifeguard.yaml
+++ b/tests/integration/test_target/patches/tests/lifeguard.yaml
@@ -31,6 +31,21 @@ static_files:
       /igloo/utils/busybox mkfifo /tmp/meowmix
       /igloo/utils/busybox cat /tmp/meowmix &
       pid=$!
+
+      # The backgrounded `cat` is fork()ed but may not have finished execve()
+      # yet, so /proc/$pid/cmdline can briefly still show this script's argv
+      # (no "meowmix"). That window widens when the host/emulator is under load,
+      # which made the final grep flaky in CI. Poll until the child's cmdline
+      # reflects `cat` before proceeding, so the test measures signal handling +
+      # cmdline readout rather than racing guest scheduling. Bounded (~30s) so a
+      # genuinely broken cmdline read still fails instead of hanging forever.
+      i=0
+      while [ $i -lt 30 ]; do
+          /igloo/utils/busybox grep meowmix /proc/${pid}/cmdline >/dev/null 2>&1 && break
+          /igloo/utils/busybox sleep 1
+          i=$((i + 1))
+      done
+
       kill -15 $pid
       kill -18 $pid # Resume in background
       /igloo/utils/busybox grep meowmix /proc/${pid}/cmdline || exit 1


### PR DESCRIPTION
## Problem

`run_tests (mipseb, 4.10)` intermittently fails the `lifeguard` verifier condition (console.log missing `/tests/lifeguard.sh PASS`) — e.g. [this merge_group run](https://github.com/rehosting/penguin/actions/runs/28975189240/job/85981073697). It blocked #877 in the merge queue even though #877 (summary.json) touches nothing in this path.

## Root cause — a race, not a regression

`lifeguard.sh` backgrounds `cat /tmp/meowmix` and immediately greps `/proc/$pid/cmdline` for `meowmix`. The child is `fork()`ed but may not have finished `execve()` when the grep runs, so its cmdline still shows the launching script's argv and the grep misses → script exits 1 → no `PASS`.

Evidence it's timing, not code:
- The last **green** mipseb/4.10 run and the **red** one ran identical code/config; the only difference was wallclock (**225 s green vs 354 s red**, +57%).
- The `hypercall/portalcall 32b: failed` lines in the log are **pre-existing and non-gating** — they're present in green runs too. Red herring.
- Main has no recent hypercall/QEMU/guest changes.

The slowdown correlates with the shared per-node Docker daemon migration (more concurrent guests per node → slower emulation → the exec race trips).

## Fix

Poll `/proc/$pid/cmdline` (bounded ~30 s; checks before sleeping so the common case adds zero delay) until it reflects `cat` before the `kill` sequence. The test now exercises blocked-signal handling + cmdline readout instead of racing guest scheduling. A genuinely broken cmdline read still fails when the bound expires — no infinite hang.

Uses the same `while [ $i -lt N ]; do … sleep 1; i=$((i+1)); done` idiom already used by `owned_iface.yaml`/`kprobes.yaml`.