### PR TITLE
netbinds: socket lifecycle states + announce debounce + snapshot restore (draft 05, part A)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -290,15 +290,6 @@ jobs:
         # job (see the matrix), so this is a generous upper bound.
         run: timeout 20m python3 $GITHUB_WORKSPACE/tests/integration/test_target/test.py --arch ${{ matrix.arch }} --kernel ${{ matrix.kernel }} --image rehosting/penguin:${{ github.sha }}
 
-      - name: Netbinds announce-debounce test (${{ matrix.arch }} ${{ matrix.kernel }})
-        # Standalone e2e for the real (nonzero) announce debounce -> on_bind ->
-        # VPN bridge path. The merged suite above pins announce_debounce_s to 0,
-        # so this cannot run as part of it. The debounce is arch-independent
-        # Python, so run it on one representative combo rather than multiplying
-        # it across the whole arch×kernel matrix.
-        if: ${{ needs.changes.outputs.run_tests == 'true' && matrix.arch == 'armel' && matrix.kernel == '6.13' }}
-        run: timeout 15m python3 $GITHUB_WORKSPACE/tests/integration/test_target/test.py --arch ${{ matrix.arch }} --kernel ${{ matrix.kernel }} --image rehosting/penguin:${{ github.sha }} -t netbinds_announce.yaml
-
       - name: Test Report
         uses: dorny/test-reporter@v2.1.1
         if: ${{ needs.changes.outputs.run_tests == 'true'  && ((success() || failure()) && github.event.pull_request.head.repo.full_name == github.repository)}}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -290,6 +290,15 @@ jobs:
         # job (see the matrix), so this is a generous upper bound.
         run: timeout 20m python3 $GITHUB_WORKSPACE/tests/integration/test_target/test.py --arch ${{ matrix.arch }} --kernel ${{ matrix.kernel }} --image rehosting/penguin:${{ github.sha }}
 
+      - name: Netbinds announce-debounce test (${{ matrix.arch }} ${{ matrix.kernel }})
+        # Standalone e2e for the real (nonzero) announce debounce -> on_bind ->
+        # VPN bridge path. The merged suite above pins announce_debounce_s to 0,
+        # so this cannot run as part of it. The debounce is arch-independent
+        # Python, so run it on one representative combo rather than multiplying
+        # it across the whole arch×kernel matrix.
+        if: ${{ needs.changes.outputs.run_tests == 'true' && matrix.arch == 'armel' && matrix.kernel == '6.13' }}
+        run: timeout 15m python3 $GITHUB_WORKSPACE/tests/integration/test_target/test.py --arch ${{ matrix.arch }} --kernel ${{ matrix.kernel }} --image rehosting/penguin:${{ github.sha }} -t netbinds_announce.yaml
+
       - name: Test Report
         uses: dorny/test-reporter@v2.1.1
         if: ${{ needs.changes.outputs.run_tests == 'true'  && ((success() || failure()) && github.event.pull_request.head.repo.full_name == github.repository)}}

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -123,7 +123,28 @@ are stored in `nvram.csv`
 ## Netbinds
 This plugin detects and logs network binds by guest processes. The results
 are logged into `netbinds.csv` and include a `time` column indicating how
-many seconds after boot until the bind occurred.
+many seconds after boot until the bind occurred, plus `state` and `closed_time`
+columns describing each socket's final lifecycle state:
+
+- `listening` — announced and still bound.
+- `transient` — released within the announce window; not a working service.
+- `closed` — listened, then released for good (`closed_time` set).
+- `pending` — bound when the run ended but younger than the announce window;
+  never confirmed, so not a working service either.
+
+New binds are announced to downstream plugins (VPN, Nmap, FetchWeb) only after
+an announce debounce (`announce_debounce_s`, default 2s), so short-lived binds
+never trigger VPN bridging or scans. Both the announce and the close/flap
+debounce windows use host wall-clock time, so the classification of a
+very short-lived bind can vary with emulation speed. Every open/flap/
+transient/close transition is appended to `netbind_events.csv`, and a
+per-socket lifecycle summary is written to `netbinds_lifecycle.csv` at run end.
+
+The socket lifecycle survives a VM snapshot/restore: the record is bundled with
+the snapshot and rebuilt on restore (a restored guest is already past its binds
+and would otherwise vanish from `netbinds.csv`). Already-announced services are
+rebuilt silently — downstream consumers replay their own state — while a service
+still within its announce window at snapshot time is announced on restore.
 
 ## Nmap
 This plugin runs nmap scans on all network-listening services.

--- a/pyplugins/analysis/netbinds.py
+++ b/pyplugins/analysis/netbinds.py
@@ -11,13 +11,36 @@ react to new network services.
 Lifecycle tracking
 -------------------
 
-Services frequently flap: a process may bind, close, and re-bind the same
+Each socket (keyed by IP version, socket type, address, and port) moves through
+a small state machine:
+
+- ``pending`` -- bound, but not yet announced. A new bind is held for
+  ``announce_debounce_s`` seconds before 'on_bind' is published, so
+  short-lived binds never reach downstream actuation (VPN bridging, nmap,
+  fetchweb, ...). A socket still pending when the run ends keeps this state
+  in the final CSVs: it was bound at shutdown but never confirmed as a
+  listener, so consumers should not count it as a working service.
+- ``listening`` -- bound and announced: the bind survived the announce window.
+- ``transient`` -- bound and released *within* the announce window. Transient
+  binds are never announced; they appear in ``netbinds.csv`` (state
+  ``transient``) so analyses can see them without treating them as working
+  services.
+- ``closed`` -- was listening, later released for good.
+
+Both debounce windows are measured in **host wall-clock time** (like every
+other timestamp this plugin records): guest/emulation time is not exposed to
+pyplugins, so the transient-vs-listening classification of a short-lived bind
+depends on emulation speed and is not exactly reproducible across hosts. The
+in-guest test fixtures set ``announce_debounce_s: 0`` for this reason; the
+debounce machinery itself is covered by host-side unit tests.
+
+Announced services frequently flap: a process may close and re-bind the same
 address in rapid succession (e.g. supervisord restarting a daemon, or a server
 that briefly rebinds during startup). To avoid treating every flap as a genuine
-close, NetBinds applies a *debounce period*:
+close, NetBinds also applies a *close debounce*:
 
-- When a socket is released, the close is held as *pending* rather than being
-  finalized immediately.
+- When a listening socket is released, the close is held as *pending* rather
+  than being finalized immediately.
 - If the same socket is re-bound within ``debounce_period`` seconds, the close
   is cancelled and the event is recorded as a *flap* (the service is considered
   to have stayed up continuously).
@@ -26,8 +49,28 @@ close, NetBinds applies a *debounce period*:
   unconditionally when the plugin unloads.
 
 A socket that flaps ``transient_threshold`` or more times during the run is
-labelled *transient* in the lifecycle summary, marking it as an unstable
+also flagged transient in the lifecycle summary, marking it as an unstable
 service worth attention.
+
+Known limitation: the guest kernel only reports TCP releases for sockets in
+the LISTEN state (accepted connections share the listener's local port, so
+their teardown must not be reported). A TCP socket that binds but closes
+without ever listening therefore never emits a release and remains
+``listening``/``pending`` until the end of the run.
+
+Snapshot / restore
+------------------
+
+A restored VM is already past its binds, so it never re-issues the bind
+hypercalls this plugin watches. NetBinds therefore participates in the
+snapshot host-state protocol (``save_state`` / ``load_state`` / ``on_restore``):
+the socket lifecycle is bundled with the snapshot and rebuilt on restore, so
+``netbinds.csv``, the lifecycle summary, and ``give_list`` stay accurate across
+a (possibly cross-process) restore. Already-announced services are rebuilt
+silently -- downstream consumers such as the VPN bridge replay their own saved
+state, so re-announcing would double-actuate -- while a service still within
+its announce window at snapshot time is a ground-truth listener in the restored
+guest and is announced on restore.
 
 Features
 --------
@@ -35,18 +78,25 @@ Features
 - Subscribes to low-level bind/setup/release events for IPv4 and IPv6 sockets.
 - Tracks and deduplicates first-seen binds (process name, IP version, socket
   type, IP, port), as before.
-- Logs first-seen binds and summary statistics to CSV files in the output
-  directory (``netbinds.csv``, ``netbinds_summary.csv``) -- unchanged format.
+- Logs announced binds and summary statistics to CSV files in the output
+  directory (``netbinds.csv``, ``netbinds_summary.csv``). ``netbinds.csv``
+  carries ``state`` and ``closed_time`` columns and is rewritten on unload with
+  each socket's final state (including never-announced transient binds).
 - Logs every open/flap/transient/close transition to ``netbind_events.csv`` and
   writes a per-socket lifecycle summary to ``netbinds_lifecycle.csv`` on unload.
-- Publishes 'on_bind' events for other plugins (such as VPN, Nmap, FetchWeb).
-- Optionally shuts down emulation when a web service (port 80) is bound.
+- Publishes 'on_bind' events for other plugins (such as VPN, Nmap, FetchWeb)
+  after the announce debounce.
+- Optionally shuts down emulation when a web service (port 80) is announced.
 
 Arguments
 ---------
 
 - shutdown_on_www (bool, optional): If True, shut down emulation when a bind
-  occurs on port 80.
+  on port 80 is announced (i.e. survives the announce debounce).
+- announce_debounce_s (float, optional): Seconds a new bind is held before
+  being announced via 'on_bind'. A release within this window marks the bind
+  transient and suppresses the announcement. <= 0 announces immediately.
+  Default: 2.0.
 - debounce_period (float, optional): Seconds a close is held pending before
   being treated as a real close. A re-bind within this window is a flap.
   Default: 2.0.
@@ -57,8 +107,8 @@ Plugin Interface
 ----------------
 
 - Publishes 'on_bind' events with (sock_type, ipvn, ip, port, procname) for
-  other plugins to consume. (Semantics unchanged: fired once per first-seen
-  unique bind.)
+  other plugins to consume. (Semantics unchanged apart from the announce
+  debounce: fired once per first-seen unique bind that survives the window.)
 - Listens to low-level system bind/setup/release events.
 - Writes bind logs, a lifecycle event log, and summaries to the output dir.
 
@@ -70,8 +120,10 @@ started -- and stopped -- by the guest, enabling automation, analysis, and
 integration with other actuation plugins.
 """
 
+import os
 import socket
 import struct
+import threading
 import time
 from os.path import join
 
@@ -83,6 +135,9 @@ SUMMARY_BINDS_FILE = "netbinds_summary.csv"
 EVENTS_FILE = "netbind_events.csv"
 LIFECYCLE_FILE = "netbinds_lifecycle.csv"
 
+BINDS_HEADER = "procname,ipvn,domain,guest_ip,guest_port,pid,time,state,closed_time\n"
+
+DEFAULT_ANNOUNCE_DEBOUNCE_S = 2.0
 DEFAULT_DEBOUNCE_PERIOD = 2.0
 DEFAULT_TRANSIENT_THRESHOLD = 3
 
@@ -90,7 +145,13 @@ DEFAULT_TRANSIENT_THRESHOLD = 3
 class NetBinds(Plugin):
     class Args(PluginArgs):
         shutdown_on_www: bool = Field(
-            default=False, description="If true, shut down emulation when a bind occurs on port 80."
+            default=False, description="If true, shut down emulation when a bind on port 80 is announced."
+        )
+        announce_debounce_s: float = Field(
+            default=DEFAULT_ANNOUNCE_DEBOUNCE_S,
+            description="Seconds a new bind is held before being announced via 'on_bind'. "
+            "A release within this window marks the bind transient and suppresses the "
+            "announcement (so e.g. the VPN never bridges it). <= 0 announces immediately.",
         )
         debounce_period: float = Field(
             default=DEFAULT_DEBOUNCE_PERIOD,
@@ -111,6 +172,8 @@ class NetBinds(Plugin):
         self.start_time = time.time()
         self.shutdown_on_www = self.get_arg_bool("shutdown_on_www")
 
+        announce = self.get_arg("announce_debounce_s")
+        self.announce_debounce_s = float(announce) if announce is not None else DEFAULT_ANNOUNCE_DEBOUNCE_S
         debounce = self.get_arg("debounce_period")
         self.debounce_period = float(debounce) if debounce is not None else DEFAULT_DEBOUNCE_PERIOD
         threshold = self.get_arg("transient_threshold")
@@ -119,8 +182,19 @@ class NetBinds(Plugin):
         # Per-socket lifecycle state, keyed by (ipvn, sock_type, normalized_ip, port).
         # This is the source of truth for currently-active binds (see give_list).
         self.sockets = {}
+        # Rows appended to netbinds.csv during the run (announced binds), kept
+        # so the file can be rewritten with final states on unload.
+        self.bind_rows = []
+        # Guards sockets/seen_binds/bind_rows and the CSV files: bind/release
+        # events arrive on the hypercall path while announce timers fire on
+        # timer threads.
+        self._lock = threading.Lock()
+        # Lifecycle state stashed by load_state() on a snapshot restore, applied
+        # in on_restore() once every plugin has loaded. None when not restoring.
+        self._restore_data = None
 
-        # The NetBinds.on_bind PPP callback happens on every first-seen bind.
+        # The NetBinds.on_bind PPP callback happens once per first-seen bind
+        # that survives the announce debounce.
         # Don't be confused by the vpn on_bind callback that happens
         # after the VPN bridges a connection. This one has the better name
         # but that one is more of a pain to change.
@@ -128,7 +202,7 @@ class NetBinds(Plugin):
         plugins.register(self, "on_bind")
 
         with open(join(self.outdir, BINDS_FILE), "w") as f:
-            f.write("procname,ipvn,domain,guest_ip,guest_port,pid,time\n")
+            f.write(BINDS_HEADER)
 
         with open(join(self.outdir, SUMMARY_BINDS_FILE), "w") as f:
             f.write("n_procs,n_sockets,bound_www,time\n")
@@ -155,7 +229,7 @@ class NetBinds(Plugin):
             sin_addr: The IPv4 address being bound, in network byte order.
         """
         if self.pending_procname is not None:
-            self.logger.error(f"Pending bind not cleared before new bind for ipv6: {self.pending_procname} vs {procname}")
+            self.logger.error(f"Pending bind not cleared before new bind for ipv4: {self.pending_procname} vs {procname}")
         self.pending_procname = procname
         self.pending_sinaddr = int.to_bytes(sin_addr, 4, "little")
 
@@ -234,14 +308,16 @@ class NetBinds(Plugin):
 
     def on_bind(self, cpu, procname, is_ipv4, is_stream, port_pid, sin_addr) -> None:
         """
-        Handle a completed bind event, log details, publish event, and optionally shut down.
+        Handle a completed bind event: decode it and feed the socket lifecycle.
+        Announcement (CSV row, 'on_bind' publication, shutdown_on_www) happens
+        after the announce debounce -- see record_open.
 
         Args:
             cpu: The CPU core where the event occurred.
             procname: The name of the process that performed the bind.
             is_ipv4: Boolean indicating if this is an IPv4 bind.
             is_stream: Boolean indicating if this is a stream (TCP) bind.
-            port: The port number being bound, in host byte order.
+            port_pid: "port:pid" string, port in network byte order.
             sin_addr: The IP address being bound, in network byte order.
         """
         now = time.time()
@@ -275,27 +351,7 @@ class NetBinds(Plugin):
                     sin_addr = struct.pack("<IIII", *(struct.unpack(">IIII", sin_addr)))
                 ip = f"[{socket.inet_ntop(socket.AF_INET6, sin_addr)}]"
 
-        # Update the socket lifecycle on every bind, including repeats, so we
-        # can observe (and debounce) flapping services. This runs before the
-        # seen_binds dedup gate below, which only governs the legacy CSV/event.
         self.record_open(now, time_delta, procname, ipvn, sock_type, ip, port, pid)
-
-        # Only report each bind once, if it's identical
-        # VPN / stats will just get confused if we report the same bind twice
-        if (procname, ipvn, sock_type, ip, port) in self.seen_binds:
-            return
-        self.seen_binds.add((procname, ipvn, sock_type, ip, port))
-
-        # Log details to disk
-        self.report_bind_info(time_delta, procname, ipvn, sock_type, ip, port, pid)
-
-        # Trigger our callback
-        plugins.publish(self, "on_bind", sock_type, ipvn, ip, port, procname)
-
-        # If bind is 80 and we have shutdown_www option, end the emulation
-        if port == 80 and self.shutdown_on_www:
-            self.logger.info("Shutting down emulation due to bind on port 80")
-            self.panda.end_analysis()
 
     @staticmethod
     def _norm_ip(ip) -> str:
@@ -333,25 +389,141 @@ class NetBinds(Plugin):
         rec["pending_close_delta"] = None
         self._log_event("close", rec, close_delta)
 
+    def _schedule_announce(self, key, rec, now, time_delta):
+        """Hold the socket in 'pending' for the announce window. A release that
+        arrives first cancels the announcement (transient bind); otherwise the
+        socket is promoted to 'listening' and announced.
+
+        Promotion happens on whichever comes first: the announce sweep run on
+        the hypercall path by later bind/release events, or this backup timer.
+        The timer alone is not enough -- under heavy instrumentation the vCPU
+        thread spends nearly all its time in Python callbacks and background
+        threads can be GIL-starved for many seconds -- while the sweep alone
+        would never announce a quiet guest's only service. Together they
+        cover both cases.
+
+        Returns the announcement payload when announcing inline
+        (announce_debounce_s <= 0), else None."""
+        if self.announce_debounce_s <= 0:
+            return self._promote_to_listening(rec, time_delta)
+        rec["pending_since"] = now
+        timer = threading.Timer(self.announce_debounce_s, self._announce_cb, args=(key,))
+        timer.daemon = True
+        rec["announce_timer"] = timer
+        timer.start()
+        return None
+
+    def _sweep_pending_announces(self, now):
+        """Promote any pending sockets whose announce window has elapsed.
+        Runs on the hypercall path (see _schedule_announce). Caller holds
+        _lock. Returns the announcement payloads to publish."""
+        time_delta = now - self.start_time
+        announcements = []
+        for rec in list(self.sockets.values()):
+            if rec["state"] != "pending" or rec["pending_since"] is None:
+                continue
+            if (now - rec["pending_since"]) >= self.announce_debounce_s:
+                if rec["announce_timer"] is not None:
+                    rec["announce_timer"].cancel()
+                    rec["announce_timer"] = None
+                announcement = self._promote_to_listening(rec, time_delta)
+                if announcement is not None:
+                    announcements.append(announcement)
+        return announcements
+
+    def _announce_cb(self, key) -> None:
+        """Timer callback: the bind survived the announce window."""
+        now = time.time()
+        time_delta = now - self.start_time
+        with self._lock:
+            rec = self.sockets.get(key)
+            if rec is None or rec["state"] != "pending":
+                return
+            rec["announce_timer"] = None
+            announcement = self._promote_to_listening(rec, time_delta)
+        if announcement is not None:
+            self._publish_announcements([announcement])
+
+    def _promote_to_listening(self, rec, time_delta):
+        """Mark a pending socket listening and record its announcement.
+        Caller holds _lock. Returns the announcement payload to publish
+        (after releasing _lock -- see _publish_announcements), or None for a
+        duplicate."""
+        rec["state"] = "listening"
+        rec["pending_since"] = None
+        return self._record_announcement(rec, time_delta)
+
+    def _record_announcement(self, rec, time_delta):
+        """Record an announced bind: netbinds.csv row, summary stats, and the
+        bind_rows bookkeeping for the final rewrite. Deduplicated per unique
+        (procname, ipvn, sock_type, ip, port) as before. Caller holds _lock.
+        Returns the 'on_bind' payload to publish, or None for a duplicate."""
+        rec["announced"] = True
+
+        # Only report each bind once, if it's identical
+        # VPN / stats will just get confused if we report the same bind twice
+        ident = (rec["procname"], rec["ipvn"], rec["sock_type"], rec["ip"], rec["port"])
+        if ident in self.seen_binds:
+            return None
+        self.seen_binds.add(ident)
+
+        # Log details to disk
+        self.report_bind_info(time_delta, rec["procname"], rec["ipvn"],
+                              rec["sock_type"], rec["ip"], rec["port"], rec["pid"])
+        self.bind_rows.append({
+            "procname": rec["procname"], "ipvn": rec["ipvn"], "sock_type": rec["sock_type"],
+            "ip": rec["ip"], "port": rec["port"], "pid": rec["pid"], "time": time_delta,
+            "key": self._socket_key(rec["ipvn"], rec["sock_type"], rec["ip"], rec["port"]),
+        })
+        return (rec["sock_type"], rec["ipvn"], rec["ip"], rec["port"], rec["procname"])
+
+    def _publish_announcements(self, announcements) -> None:
+        """Publish 'on_bind' for recorded announcements and handle
+        shutdown_on_www. Must be called WITHOUT _lock held: subscribers run
+        arbitrary code (VPN bridging, probes) and must be able to call back
+        into this plugin (e.g. give_list) without deadlocking."""
+        for sock_type, ipvn, ip, port, procname in announcements:
+            plugins.publish(self, "on_bind", sock_type, ipvn, ip, port, procname)
+
+            # If an announced bind is on 80 and we have the shutdown_www
+            # option, end the emulation. Announce-debounced on purpose: a
+            # transient www bind should not end the run before the real
+            # service comes up.
+            if port == 80 and self.shutdown_on_www:
+                self.logger.info("Shutting down emulation due to bind on port 80")
+                self.panda.end_analysis()
+
     def record_open(self, now, time_delta, procname, ipvn, sock_type, ip, port, pid) -> None:
         """
-        Record a bind (open) in the socket lifecycle, applying debounce so a
-        re-bind shortly after a close is treated as a flap rather than a new
-        service.
+        Record a bind (open) in the socket lifecycle. New sockets are held in
+        'pending' for the announce debounce; re-binds shortly after a close are
+        treated as flaps rather than new services.
         """
+        with self._lock:
+            announcements = self._record_open_locked(
+                now, time_delta, procname, ipvn, sock_type, ip, port, pid)
+        self._publish_announcements(announcements)
+
+    def _record_open_locked(self, now, time_delta, procname, ipvn, sock_type, ip, port, pid):
+        """State-machine half of record_open; caller holds _lock. Returns the
+        announcement payloads to publish once the lock is released."""
         self._sweep_pending_closes(now)
+        announcements = self._sweep_pending_announces(now)
         key = self._socket_key(ipvn, sock_type, ip, port)
         rec = self.sockets.get(key)
 
         if rec is None:
-            self.sockets[key] = {
+            rec = {
                 "procname": procname,
                 "pid": pid,
                 "ipvn": ipvn,
                 "sock_type": sock_type,
                 "ip": ip,
                 "port": port,
-                "state": "open",
+                "state": "pending",
+                "announced": False,
+                "announce_timer": None,
+                "pending_since": None,
                 "open_count": 1,
                 "close_count": 0,
                 "flap_count": 0,
@@ -363,8 +535,12 @@ class NetBinds(Plugin):
                 "total_uptime": 0.0,
                 "transient": False,
             }
-            self._log_event("open", self.sockets[key], time_delta)
-            return
+            self.sockets[key] = rec
+            self._log_event("open", rec, time_delta)
+            announcement = self._schedule_announce(key, rec, now, time_delta)
+            if announcement is not None:
+                announcements.append(announcement)
+            return announcements
 
         # Refresh identity from the latest binder.
         rec["procname"] = procname
@@ -378,7 +554,7 @@ class NetBinds(Plugin):
             rec["pending_close_delta"] = None
             rec["flap_count"] += 1
             rec["open_count"] += 1
-            rec["state"] = "open"
+            rec["state"] = "listening"
             self._log_event("flap", rec, time_delta)
             if rec["flap_count"] >= self.transient_threshold and not rec["transient"]:
                 rec["transient"] = True
@@ -390,63 +566,177 @@ class NetBinds(Plugin):
                 # it is observable incrementally (the per-socket summary is only
                 # written at unload).
                 self._log_event("transient", rec, time_delta)
-        elif rec["state"] == "closed":
-            # Genuine re-open after a finalized close (outside the debounce
-            # window) -- a spaced restart, not rapid flapping.
+        elif rec["state"] in ("closed", "transient"):
+            # Genuine re-open after a finalized close or a transient bind
+            # (outside any debounce window) -- a spaced restart.
             rec["open_count"] += 1
             rec["last_open"] = time_delta
-            rec["state"] = "open"
             self._log_event("open", rec, time_delta)
-        # else: already open and not pending close -> duplicate bind, no change.
+            if rec["announced"]:
+                # Already survived the announce window once; no need to
+                # debounce the restart. (A new procname on an announced
+                # socket still publishes, via the seen_binds dedup.)
+                rec["state"] = "listening"
+                announcement = self._record_announcement(rec, time_delta)
+                if announcement is not None:
+                    announcements.append(announcement)
+            else:
+                rec["state"] = "pending"
+                announcement = self._schedule_announce(key, rec, now, time_delta)
+                if announcement is not None:
+                    announcements.append(announcement)
+        # else: pending or listening and not pending close -> duplicate
+        # bind, no change.
+        return announcements
 
     def record_close(self, ipvn, sock_type, ip, port) -> None:
         """
-        Record a release (close) in the socket lifecycle. The close is held
-        pending until the debounce period elapses (see _sweep_pending_closes
-        and uninit), so a quick re-bind can cancel it as a flap.
+        Record a release (close) in the socket lifecycle. A release within the
+        announce window marks the bind transient (never announced); a release
+        of a listening socket is held pending until the close debounce elapses
+        (see _sweep_pending_closes and uninit), so a quick re-bind can cancel
+        it as a flap.
         """
         now = time.time()
         time_delta = now - self.start_time
-        self._sweep_pending_closes(now)
+        with self._lock:
+            self._sweep_pending_closes(now)
+            announcements = self._sweep_pending_announces(now)
 
-        key = self._socket_key(ipvn, sock_type, ip, port)
-        rec = self.sockets.get(key)
-        if rec is None or rec["state"] != "open":
-            # Release for a socket we never saw bound, or already closed/pending.
-            return
-        rec["pending_close"] = now
-        rec["pending_close_delta"] = time_delta
+            key = self._socket_key(ipvn, sock_type, ip, port)
+            rec = self.sockets.get(key)
+            if rec is None or rec["state"] in ("closed", "transient"):
+                # Release for a socket we never saw bound, or already closed.
+                pass
+            elif rec["state"] == "pending":
+                # Released before the announce window elapsed: a transient
+                # bind. Cancel the announcement -- downstream plugins (VPN,
+                # nmap, ...) never hear about it.
+                if rec["announce_timer"] is not None:
+                    rec["announce_timer"].cancel()
+                    rec["announce_timer"] = None
+                rec["pending_since"] = None
+                rec["state"] = "transient"
+                rec["transient"] = True
+                rec["close_count"] += 1
+                rec["last_close"] = time_delta
+                if rec["last_open"] is not None:
+                    rec["total_uptime"] += max(0.0, time_delta - rec["last_open"])
+                self._log_event("transient", rec, time_delta)
+            else:
+                # Listening: hold the close pending for the debounce window.
+                rec["pending_close"] = now
+                rec["pending_close_delta"] = time_delta
+        self._publish_announcements(announcements)
 
     def give_list(self):
         """
-        Return the list of currently-active binds (open, or closed-but-pending
-        within the debounce window).
+        Return the list of currently-active binds: listening, pending
+        announcement, or closed-but-pending within the close debounce window.
 
         Returns:
             list: A list of dictionaries, each representing an active bind.
         """
-        active = []
-        for rec in self.sockets.values():
-            if rec["state"] == "open":
-                active.append({
-                    "Process Name": rec["procname"],
-                    "IPvN": rec["ipvn"],
-                    "Socket Type": rec["sock_type"],
-                    "IP": rec["ip"],
-                    "Port": rec["port"],
-                    "PID": rec["pid"],
-                    "Time": rec["first_open"],
-                    "State": "transient" if rec["transient"] else "open",
-                    "Flaps": rec["flap_count"],
-                })
-        return active
+        with self._lock:
+            active = []
+            for rec in self.sockets.values():
+                if rec["state"] in ("pending", "listening"):
+                    active.append({
+                        "Process Name": rec["procname"],
+                        "IPvN": rec["ipvn"],
+                        "Socket Type": rec["sock_type"],
+                        "IP": rec["ip"],
+                        "Port": rec["port"],
+                        "PID": rec["pid"],
+                        "Time": rec["first_open"],
+                        "State": "transient" if rec["transient"] else rec["state"],
+                        "Flaps": rec["flap_count"],
+                    })
+            return active
+
+    def save_state(self):
+        """Capture the socket lifecycle so a cross-process snapshot restore can
+        reproduce netbinds.csv, the lifecycle summary, and give_list().
+
+        A VM snapshot restores the *guest*, which is then already past its
+        binds, so it never re-issues the bind hypercalls NetBinds reacts to.
+        Without this, a restored run would start blank and every pre-snapshot
+        service would vanish from the record. Non-serialisable / host-clock
+        fields (the announce timer thread and the absolute pending_since /
+        pending_close instants) are dropped -- they cannot survive a
+        cross-process, possibly cross-host restore; see on_restore.
+        """
+        with self._lock:
+            if not self.sockets:
+                return None
+            drop = ("announce_timer", "pending_since",
+                    "pending_close", "pending_close_delta")
+            sockets = [
+                {k: v for k, v in rec.items() if k not in drop}
+                for rec in self.sockets.values()
+            ]
+            return {
+                "sockets": sockets,
+                "seen_binds": [list(b) for b in self.seen_binds],
+                "bind_rows": [{**r, "key": list(r["key"])} for r in self.bind_rows],
+            }
+
+    def load_state(self, data) -> None:
+        """Stash lifecycle state captured at snapshot time. Applied in
+        on_restore(), which runs after every plugin has loaded."""
+        self._restore_data = data or None
+
+    def on_restore(self, tag: str) -> None:
+        """Rehydrate the socket lifecycle after a snapshot restore.
+
+        Already-announced sockets (listening/closed) are restored *silently*:
+        downstream consumers such as the VPN bridge replay their own saved
+        state on restore, so re-publishing 'on_bind' for them would
+        double-actuate. Sockets still 'pending' (bound but never announced)
+        at snapshot time are ground-truth listeners in the restored guest that
+        no downstream plugin saved, so they are promoted to 'listening' and
+        announced now.
+        """
+        data = self._restore_data
+        self._restore_data = None
+        if not data:
+            return
+        time_delta = time.time() - self.start_time
+        with self._lock:
+            announcements = self._rehydrate_locked(data, time_delta)
+        self._publish_announcements(announcements)
+
+    def _rehydrate_locked(self, data, time_delta):
+        """Rebuild sockets/seen_binds/bind_rows from saved state and rewrite
+        netbinds.csv. Caller holds _lock. Returns announcements to publish for
+        pending sockets promoted to listening on restore."""
+        self.seen_binds = {tuple(b) for b in data.get("seen_binds", [])}
+        self.bind_rows = [{**r, "key": tuple(r["key"])} for r in data.get("bind_rows", [])]
+        self.sockets = {}
+        announcements = []
+        for saved in data.get("sockets", []):
+            rec = dict(saved)
+            rec["announce_timer"] = None
+            rec["pending_since"] = None
+            rec["pending_close"] = None
+            rec["pending_close_delta"] = None
+            key = self._socket_key(rec["ipvn"], rec["sock_type"], rec["ip"], rec["port"])
+            self.sockets[key] = rec
+            if rec["state"] == "pending" and not rec.get("announced"):
+                announcement = self._promote_to_listening(rec, time_delta)
+                if announcement is not None:
+                    announcements.append(announcement)
+        self._rewrite_binds_file()
+        return announcements
 
     def report_bind_info(self, time_delta, procname, ipvn, sock_type, ip, port, pid) -> None:
         """
-        Log bind details and summary statistics to disk.
+        Log bind details and summary statistics to disk. Called at announce
+        time, so the row is written with state 'listening'; final states are
+        filled in when the file is rewritten on unload.
 
         Args:
-            time_delta: The time since emulation start when the bind occurred.
+            time_delta: The time since emulation start when the bind was announced.
             procname: The name of the process that performed the bind.
             ipvn: The IP version (4 or 6) of the bind.
             sock_type: The type of socket (TCP or UDP).
@@ -460,7 +750,7 @@ class NetBinds(Plugin):
 
         # Report this specific bind
         with open(join(self.outdir, BINDS_FILE), "a") as f:
-            f.write(f"{procname},{ipvn},{sock_type},{ip},{port},{pid},{time_delta:.3f}\n")
+            f.write(f"{procname},{ipvn},{sock_type},{ip},{port},{pid},{time_delta:.3f},listening,\n")
 
         # Look through self.seen_binds, count unique procnames, total binds, and bound_www
         for data in self.seen_binds:
@@ -476,35 +766,91 @@ class NetBinds(Plugin):
         with open(join(self.outdir, SUMMARY_BINDS_FILE), "a") as f:
             f.write(f"{n_procs},{n_sockets},{bound_www},{time_delta:.3f}\n")
 
+    def _rewrite_binds_file(self) -> None:
+        """Rewrite netbinds.csv with final lifecycle states.
+
+        Rows appended during the run always carry state 'listening' (only
+        announced binds get rows); on unload the file is rewritten so each row
+        shows its final state and closed_time, plus one row per socket that
+        was never announced (transient binds, and still-pending binds younger
+        than the announce window at shutdown). Written to a temp file and
+        renamed so a crash mid-rewrite cannot destroy the data accumulated
+        during the run.
+        """
+        tmp_path = join(self.outdir, BINDS_FILE + ".tmp")
+        with open(tmp_path, "w") as f:
+            f.write(BINDS_HEADER)
+            for row in self.bind_rows:
+                rec = self.sockets.get(row["key"])
+                state = rec["state"] if rec is not None else "listening"
+                closed_time = ""
+                if rec is not None and state == "closed" and rec["last_close"] is not None:
+                    closed_time = f"{rec['last_close']:.3f}"
+                f.write(
+                    f"{row['procname']},{row['ipvn']},{row['sock_type']},{row['ip']},"
+                    f"{row['port']},{row['pid']},{row['time']:.3f},{state},{closed_time}\n"
+                )
+            for rec in self.sockets.values():
+                if rec["announced"]:
+                    continue
+                closed_time = "" if rec["last_close"] is None else f"{rec['last_close']:.3f}"
+                f.write(
+                    f"{rec['procname']},{rec['ipvn']},{rec['sock_type']},{rec['ip']},"
+                    f"{rec['port']},{rec['pid']},{rec['first_open']:.3f},{rec['state']},{closed_time}\n"
+                )
+        os.replace(tmp_path, join(self.outdir, BINDS_FILE))
+
     def uninit(self) -> None:
         """
         Finalize the socket lifecycle on unload and write the lifecycle summary.
 
-        Any pending closes are finalized at their real (pending) close time, and
-        any sockets still open at shutdown have their uptime closed out at the
-        end of the run.
+        Announce timers are cancelled; sockets still pending announcement keep
+        the 'pending' state in the final CSVs -- they were bound when the run
+        ended but never confirmed as listeners (and never published).
+        Any pending closes are finalized at their real (pending) close time,
+        and any sockets still open at shutdown have their uptime closed out at
+        the end of the run.
         """
         now = time.time()
         final_delta = now - self.start_time
 
-        for rec in self.sockets.values():
-            if rec["pending_close"] is not None:
-                # A close that never got a re-bind: it was real.
-                self._finalize_close(rec)
-            elif rec["state"] == "open" and rec["last_open"] is not None:
-                # Still up at shutdown: count uptime through end of run.
-                rec["total_uptime"] += max(0.0, final_delta - rec["last_open"])
-
-        with open(join(self.outdir, LIFECYCLE_FILE), "w") as f:
-            f.write(
-                "procname,ipvn,domain,guest_ip,guest_port,pid,state,transient,"
-                "open_count,close_count,flap_count,first_open,last_close,total_uptime\n"
-            )
+        with self._lock:
             for rec in self.sockets.values():
-                last_close = "" if rec["last_close"] is None else f"{rec['last_close']:.3f}"
+                if rec["announce_timer"] is not None:
+                    rec["announce_timer"].cancel()
+                    rec["announce_timer"] = None
+                if rec["pending_close"] is not None:
+                    # A close that never got a re-bind: it was real.
+                    self._finalize_close(rec)
+                elif rec["state"] == "pending":
+                    # Still bound at shutdown but younger than the announce
+                    # window: never confirmed as a listener. Keep the honest
+                    # 'pending' state rather than promoting -- promoting would
+                    # also affirmatively mislabel a socket whose release was
+                    # missed (TCP bind-without-listen; see module docstring).
+                    # A pid-exit fallback was considered and rejected:
+                    # daemonizing services bind in a parent that exits while a
+                    # child keeps the socket, so pid-exit would mark real
+                    # listeners closed.
+                    rec["pending_since"] = None
+                    if rec["last_open"] is not None:
+                        rec["total_uptime"] += max(0.0, final_delta - rec["last_open"])
+                elif rec["state"] == "listening" and rec["last_open"] is not None:
+                    # Still up at shutdown: count uptime through end of run.
+                    rec["total_uptime"] += max(0.0, final_delta - rec["last_open"])
+
+            self._rewrite_binds_file()
+
+            with open(join(self.outdir, LIFECYCLE_FILE), "w") as f:
                 f.write(
-                    f"{rec['procname']},{rec['ipvn']},{rec['sock_type']},{rec['ip']},"
-                    f"{rec['port']},{rec['pid']},{rec['state']},{rec['transient']},"
-                    f"{rec['open_count']},{rec['close_count']},{rec['flap_count']},"
-                    f"{rec['first_open']:.3f},{last_close},{rec['total_uptime']:.3f}\n"
+                    "procname,ipvn,domain,guest_ip,guest_port,pid,state,transient,"
+                    "open_count,close_count,flap_count,first_open,last_close,total_uptime\n"
                 )
+                for rec in self.sockets.values():
+                    last_close = "" if rec["last_close"] is None else f"{rec['last_close']:.3f}"
+                    f.write(
+                        f"{rec['procname']},{rec['ipvn']},{rec['sock_type']},{rec['ip']},"
+                        f"{rec['port']},{rec['pid']},{rec['state']},{rec['transient']},"
+                        f"{rec['open_count']},{rec['close_count']},{rec['flap_count']},"
+                        f"{rec['first_open']:.3f},{last_close},{rec['total_uptime']:.3f}\n"
+                    )

--- a/tests/integration/test_target/base_config.yaml
+++ b/tests/integration/test_target/base_config.yaml
@@ -76,6 +76,7 @@ patches:
   - ./patches/tests/pseudofile_ext_ops.yaml
   - ./patches/tests/signal_interception.yaml
   - ./patches/tests/crashes.yaml
+  - ./patches/tests/netbinds-announce.yaml
   # - ./patches/tests/uboot_env_cmp.yaml
 
 

--- a/tests/integration/test_target/patches/tests/netbinds.yaml
+++ b/tests/integration/test_target/patches/tests/netbinds.yaml
@@ -1,4 +1,11 @@
 plugins:
+  netbinds:
+    # Announce immediately: this test's guest is instrumented heavily enough
+    # that background threads (the announce backup timer, vpn_test's probe
+    # threads) can be GIL-starved for many seconds, which makes a nonzero
+    # announce window nondeterministic here. The nonzero-window debounce path
+    # is covered separately by netbinds_announce.yaml.
+    announce_debounce_s: 0
   verifier:
     conditions:
       netbinds+console:

--- a/tests/integration/test_target/patches/tests/netbinds_announce.yaml
+++ b/tests/integration/test_target/patches/tests/netbinds_announce.yaml
@@ -1,0 +1,80 @@
+# End-to-end coverage of the announce debounce -> on_bind -> VPN bridge path
+# with a real (nonzero) announce window. NOT included in base_config.yaml's
+# patch list: the merged suite pins announce_debounce_s to 0 (see
+# netbinds_lifecycle.yaml / netbinds.yaml), so this runs standalone via
+#   python3 test.py -a <arch> -k <kernel> -t netbinds_announce.yaml
+#
+# A persistent httpd on 8500 must survive the window, get announced, and be
+# bridged by the VPN. A "ticker" that binds/closes 8501 once a second must be
+# classified transient and never bridged; the ticker's bind/release events
+# also drive the hypercall-path announce sweep, so the 8500 announcement does
+# not depend on the backup timer thread (which can be GIL-starved under heavy
+# instrumentation).
+plugins:
+  netbinds:
+    # Same code path as the shipped 2s default; 5s adds margin so a slow
+    # emulated guest cannot stretch a ticker's bind->close beyond the window
+    # (which would wrongly announce it). Host wall-clock, see plugin docs.
+    announce_debounce_s: 5
+  verifier:
+    conditions:
+      # The persistent service survives the window and is announced...
+      netbinds_announce+listening:
+        type: file_contains
+        file: netbinds.csv
+        strings:
+          - ",8500,"
+          - "listening"
+      # ...and actually bridged by the VPN (real debounce->announce->bridge).
+      netbinds_announce+bridged:
+        type: file_contains
+        file: vpn_bridges.csv
+        string: ",8500,"
+      # The flapping ticker is transient...
+      netbinds_announce+transient:
+        type: file_contains
+        file: netbinds.csv
+        strings:
+          - ",8501,"
+          - "transient"
+      # ...and transient binds must never trigger VPN bridging.
+      netbinds_announce+not_bridged:
+        type: file_not_contains
+        file: vpn_bridges.csv
+        string: ",8501,"
+static_files:
+  # One tick: bind 8501, listen (so the release fires even with the driver's
+  # TCP listener-only release guard), close, exit. Well inside the announce
+  # window -> transient.
+  /tests/netbinds_announce_tick.py:
+    type: inline_file
+    contents: |
+      #!/igloo/utils/python3
+      import socket
+      s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+      try:
+          s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+      except Exception:
+          pass
+      s.bind(("0.0.0.0", 8501))
+      s.listen(1)
+      s.close()
+    mode: 73
+  /tests/netbinds_announce.sh:
+    type: inline_file
+    contents: |
+      #!/igloo/utils/sh
+      set -ex
+
+      # Persistent service: stays bound past the announce window.
+      /igloo/utils/busybox httpd -f -p 8500 -h / &
+
+      # Ticker: transient bind once a second. Uses busybox sleep (not guest
+      # python time.sleep, which is unreliable on some arch/kernel combos)
+      # and keeps the guest alive well past 8500's announce deadline.
+      for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
+        /tests/netbinds_announce_tick.py
+        /igloo/utils/busybox sleep 1
+      done
+      exit 0
+    mode: 73

--- a/tests/integration/test_target/patches/tests/netbinds_lifecycle.yaml
+++ b/tests/integration/test_target/patches/tests/netbinds_lifecycle.yaml
@@ -5,6 +5,13 @@
 # flaps enough to mark a service transient.
 plugins:
   netbinds:
+    # Announce immediately: these tests drive rapid bind/close cycles through
+    # the post-announce flap machinery; with a nonzero announce window they
+    # would be swallowed as pre-announce transients instead. (The announce
+    # debounce path itself is covered by the host-side pytest in
+    # tests/unit/test_netbinds_lifecycle.py and the netbinds_announce.yaml
+    # in-guest fixture.)
+    announce_debounce_s: 0
     debounce_period: 3600
     transient_threshold: 2
   verifier:

--- a/tests/unit/test_netbinds_lifecycle.py
+++ b/tests/unit/test_netbinds_lifecycle.py
@@ -12,10 +12,7 @@ The zero-window immediate-announce behaviour and the netbinds.csv shape are
 covered in test_pyplugin_harness.py; the in-guest path is covered by the
 tests/integration/test_target netbinds*.yaml fixtures.
 """
-import sys
 from pathlib import Path
-
-import pytest
 
 from penguin.testing import load_pyplugin
 

--- a/tests/unit/test_netbinds_lifecycle.py
+++ b/tests/unit/test_netbinds_lifecycle.py
@@ -1,0 +1,287 @@
+"""Host-side tests for the NetBinds announce debounce / lifecycle state machine
+and its snapshot-restore support.
+
+These drive the real analysis/netbinds.py plugin through the penguin.testing
+harness (load_pyplugin -> null backend, no PANDA/guest). Time is controlled with
+a fake clock and the announce backup timer is replaced with a no-op, so the
+debounce/flap machinery is exercised deterministically with no sleeps and no
+background threads (which can be GIL-starved under real emulation anyway -- the
+production code promotes via a hypercall-path sweep for exactly that reason).
+
+The zero-window immediate-announce behaviour and the netbinds.csv shape are
+covered in test_pyplugin_harness.py; the in-guest path is covered by the
+tests/integration/test_target netbinds*.yaml fixtures.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+from penguin.testing import load_pyplugin
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NETBINDS = REPO_ROOT / "pyplugins" / "analysis" / "netbinds.py"
+
+
+class FakeClock:
+    """A controllable stand-in for the module's ``time``: only ``time()`` is used."""
+
+    def __init__(self, t=1000.0):
+        self.t = float(t)
+
+    def time(self):
+        return self.t
+
+    def advance(self, dt):
+        self.t += dt
+
+
+class DeadTimer:
+    """A threading.Timer that never fires. Promotion then happens solely via the
+    hypercall-path sweep (deterministic), never a background thread."""
+
+    def __init__(self, *a, **k):
+        self.daemon = False
+
+    def start(self):
+        pass
+
+    def cancel(self):
+        pass
+
+
+def _load(tmp_path, monkeypatch, clock=None, **args):
+    """Load a fresh netbinds plugin with a fake clock and dead announce timer.
+
+    Returns ``(lp, g, clock)`` where ``g`` is the plugin module's global
+    namespace (the harness execs the module under an internal name that isn't in
+    sys.modules, so we reach ``time`` / ``threading`` / ``plugins`` through a
+    method's __globals__)."""
+    clock = clock or FakeClock()
+    args.setdefault("shutdown_on_www", False)
+    args.setdefault("announce_debounce_s", 0.2)
+    args.setdefault("debounce_period", 0.2)
+    args.setdefault("transient_threshold", 3)
+    Path(tmp_path).mkdir(parents=True, exist_ok=True)
+    # endianness="big" keeps "port:pid" ports un-swapped so f"{port}:{pid}" reads back as `port`.
+    lp = load_pyplugin(str(NETBINDS), outdir=tmp_path, args=args, endianness="big")
+    g = type(lp.plugin).save_state.__globals__
+    monkeypatch.setitem(g, "time", clock)
+    monkeypatch.setattr(g["threading"], "Timer", DeadTimer)
+    lp.plugin.start_time = clock.t  # rebase deltas onto the fake clock
+    return lp, g, clock
+
+
+def _bind(lp, port, proc="daemon", stream=True, pid=42):
+    lp.dispatch("igloo_ipv4_setup", None, proc, 0)  # sin_addr 0 -> 0.0.0.0
+    lp.dispatch("igloo_ipv4_bind", None, f"{port}:{pid}", stream)
+
+
+def _close(lp, port, stream=True):
+    lp.dispatch("igloo_ipv4_release", None, f"0.0.0.0:{port}", stream)
+
+
+def _rec(lp, port, ip="0.0.0.0", sock_type="tcp", ipvn=4):
+    return lp.plugin.sockets[(ipvn, sock_type, ip, port)]
+
+
+def _read(tmp_path, name):
+    p = Path(tmp_path) / name
+    return p.read_text() if p.exists() else ""
+
+
+def _on_binds(lp):
+    return [p[2] for p in lp.published if p[1] == "on_bind"]
+
+
+# --------------------------------------------------------------------------- #
+# Announce debounce
+# --------------------------------------------------------------------------- #
+def test_transient_bind_never_announced(tmp_path, monkeypatch):
+    lp, _mod, _clk = _load(tmp_path, monkeypatch)
+    _bind(lp, 8401)
+    _close(lp, 8401)  # released within the announce window -> transient
+
+    assert _on_binds(lp) == []
+    assert _rec(lp, 8401)["state"] == "transient"
+
+    lp.finalize()
+    row = [r for r in _read(tmp_path, "netbinds.csv").splitlines() if ",8401," in r]
+    assert len(row) == 1
+    fields = row[0].split(",")
+    assert fields[7] == "transient"
+    assert fields[8] != ""  # closed_time recorded
+    assert _on_binds(lp) == []
+
+
+def test_bind_announced_after_debounce(tmp_path, monkeypatch):
+    lp, _mod, clk = _load(tmp_path, monkeypatch)
+    _bind(lp, 8402)
+    assert _on_binds(lp) == []  # held pending, not announced synchronously
+
+    clk.advance(0.3)      # past the 0.2s announce window
+    _bind(lp, 9999)       # any later event drives the hypercall-path sweep
+
+    assert ("tcp", 4, "0.0.0.0", 8402, "daemon") in _on_binds(lp)
+    assert _rec(lp, 8402)["state"] == "listening"
+    assert ",8402,42," in _read(tmp_path, "netbinds.csv")
+
+
+def test_timer_callback_announces(tmp_path, monkeypatch):
+    """The backup timer path (used for a quiet guest with no later events)
+    promotes and publishes when it fires."""
+    lp, _mod, clk = _load(tmp_path, monkeypatch)
+    _bind(lp, 8411)
+    key = (4, "tcp", "0.0.0.0", 8411)
+    clk.advance(0.3)
+    lp.plugin._announce_cb(key)  # what the (dead) Timer would have called
+
+    assert ("tcp", 4, "0.0.0.0", 8411, "daemon") in _on_binds(lp)
+    assert _rec(lp, 8411)["state"] == "listening"
+
+
+def test_announced_bind_closes_for_good(tmp_path, monkeypatch):
+    lp, _mod, clk = _load(tmp_path, monkeypatch)
+    _bind(lp, 8403)
+    clk.advance(0.3)
+    _bind(lp, 9999)                 # sweep -> 8403 listening
+    assert _rec(lp, 8403)["state"] == "listening"
+
+    _close(lp, 8403)               # held pending-close
+    clk.advance(0.3)               # past debounce_period (0.2)
+    lp.finalize()
+
+    assert _rec(lp, 8403)["state"] == "closed"
+    fields = [r for r in _read(tmp_path, "netbinds.csv").splitlines()
+              if ",8403," in r][0].split(",")
+    assert fields[7] == "closed"
+    assert fields[8] != ""
+    life = [r for r in _read(tmp_path, "netbinds_lifecycle.csv").splitlines() if ",8403," in r]
+    assert life and "closed" in life[0]
+
+
+def test_flap_after_announce_is_not_a_close(tmp_path, monkeypatch):
+    lp, _mod, clk = _load(tmp_path, monkeypatch)
+    _bind(lp, 8404)
+    clk.advance(0.3)
+    _bind(lp, 9999)                 # 8404 -> listening
+    _close(lp, 8404)               # pending-close (within debounce)
+    _bind(lp, 8404)                 # re-bind inside the window -> flap
+
+    rec = _rec(lp, 8404)
+    assert rec["state"] == "listening"
+    assert rec["flap_count"] == 1
+    assert len(_on_binds(lp)) == 1
+    assert "flap," in _read(tmp_path, "netbind_events.csv")
+
+
+def test_pending_at_shutdown_stays_pending(tmp_path, monkeypatch):
+    lp, _mod, _clk = _load(tmp_path, monkeypatch)
+    _bind(lp, 8405)
+    lp.finalize()  # younger than the announce window when the run ends
+
+    assert _on_binds(lp) == []
+    assert _rec(lp, 8405)["state"] == "pending"
+    row = [r for r in _read(tmp_path, "netbinds.csv").splitlines() if ",8405," in r]
+    assert len(row) == 1
+    assert row[0].split(",")[7] == "pending"
+
+
+def test_zero_debounce_announces_synchronously(tmp_path, monkeypatch):
+    lp, _mod, _clk = _load(tmp_path, monkeypatch, announce_debounce_s=0)
+    _bind(lp, 8406)
+    assert ("tcp", 4, "0.0.0.0", 8406, "daemon") in _on_binds(lp)
+    assert _rec(lp, 8406)["state"] == "listening"
+
+
+def test_shutdown_on_www_fires_only_after_debounce(tmp_path, monkeypatch):
+    lp, _mod, clk = _load(tmp_path, monkeypatch, shutdown_on_www=True)
+    ended = []
+    lp.plugin.panda.end_analysis = lambda: ended.append(True)
+
+    # Transient www bind must NOT end the run.
+    _bind(lp, 80, proc="flaky_httpd")
+    _close(lp, 80)
+    assert ended == []
+
+    # A www bind that survives the window must end the run.
+    _bind(lp, 80, proc="httpd")
+    clk.advance(0.3)
+    _bind(lp, 9999)  # sweep promotes/announces 80
+    assert ended == [True]
+
+
+def test_transient_rebind_can_still_become_listening(tmp_path, monkeypatch):
+    lp, _mod, clk = _load(tmp_path, monkeypatch)
+    _bind(lp, 8407)
+    _close(lp, 8407)
+    assert _rec(lp, 8407)["state"] == "transient"
+
+    _bind(lp, 8407)      # genuine re-open -> pending again
+    clk.advance(0.3)
+    _bind(lp, 9999)      # sweep -> listening
+    assert _rec(lp, 8407)["state"] == "listening"
+    assert len(_on_binds(lp)) == 1
+
+
+def test_subscriber_may_reenter_plugin_during_publish(tmp_path, monkeypatch):
+    """on_bind is published without _lock held, so a subscriber can call back
+    into the plugin (e.g. give_list) without deadlocking."""
+    lp, g, _clk = _load(tmp_path, monkeypatch, announce_debounce_s=0)
+    reentered = []
+    monkeypatch.setattr(
+        g["plugins"], "publish",
+        lambda src, event, *a: reentered.append(lp.plugin.give_list()),
+    )
+    _bind(lp, 8410)
+    assert len(reentered) == 1
+    assert reentered[0][0]["Port"] == 8410
+
+
+# --------------------------------------------------------------------------- #
+# Snapshot / restore
+# --------------------------------------------------------------------------- #
+def test_save_state_is_none_when_idle(tmp_path, monkeypatch):
+    lp, _mod, _clk = _load(tmp_path, monkeypatch)
+    assert lp.plugin.save_state() is None  # nothing bound -> nothing to carry
+
+
+def test_snapshot_restores_listening_silently(tmp_path, monkeypatch):
+    # Producer: a listening service is captured in save_state.
+    src = _load(tmp_path / "a", monkeypatch, announce_debounce_s=0)[0]
+    _bind(src, 8500, proc="httpd")  # announced immediately, stays listening
+    assert _rec(src, 8500)["state"] == "listening"
+    state = src.plugin.save_state()
+    assert state is not None
+
+    # Consumer: a fresh restored run rebuilds the record from the snapshot.
+    dst, _mod, _clk = _load(tmp_path / "b", monkeypatch, announce_debounce_s=0)
+    dst.plugin.load_state(state)
+    dst.plugin.on_restore("boot")
+
+    assert _rec(dst, 8500)["state"] == "listening"
+    row = [r for r in _read(tmp_path / "b", "netbinds.csv").splitlines() if ",8500," in r]
+    assert len(row) == 1 and row[0].split(",")[7] == "listening"
+    assert {b["Port"] for b in dst.plugin.give_list()} == {8500}
+    # Already-announced: consumers (VPN) replay their own bridges, so NetBinds
+    # must NOT re-publish on_bind for it (that would double-actuate).
+    assert _on_binds(dst) == []
+
+
+def test_snapshot_promotes_pending_on_restore(tmp_path, monkeypatch):
+    # Producer: a bind still inside its announce window at snapshot time.
+    src = _load(tmp_path / "a", monkeypatch)[0]  # nonzero announce window
+    _bind(src, 8501, proc="slowsvc")
+    assert _rec(src, 8501)["state"] == "pending"
+    state = src.plugin.save_state()
+
+    # Consumer: the restored guest genuinely holds that socket -> promote and
+    # announce it (nobody downstream saved it, so it must be published now).
+    dst, _mod, _clk = _load(tmp_path / "b", monkeypatch)
+    dst.plugin.load_state(state)
+    dst.plugin.on_restore("boot")
+
+    assert _rec(dst, 8501)["state"] == "listening"
+    assert ("tcp", 4, "0.0.0.0", 8501, "slowsvc") in _on_binds(dst)
+    row = [r for r in _read(tmp_path / "b", "netbinds.csv").splitlines() if ",8501," in r]
+    assert len(row) == 1 and row[0].split(",")[7] == "listening"

--- a/tests/unit/test_pyplugin_harness.py
+++ b/tests/unit/test_pyplugin_harness.py
@@ -111,6 +111,11 @@ def test_sibling_package_import_resolved(tmp_path):
 # --------------------------------------------------------------------------- #
 def _load_netbinds(tmp_path, **args):
     args.setdefault("shutdown_on_www", False)
+    # announce_debounce_s=0 announces synchronously (the historical immediate
+    # behavior), so a single bind writes its row and publishes on_bind right
+    # away -- what these reference tests assert. The nonzero-window debounce is
+    # covered in test_netbinds_lifecycle.py.
+    args.setdefault("announce_debounce_s", 0)
     # endianness="big" keeps the port value un-swapped so "80:123" -> port 80.
     return load_pyplugin(str(NETBINDS), outdir=tmp_path, args=args, endianness="big")
 
@@ -127,9 +132,12 @@ def test_netbinds_writes_bind_row(tmp_path):
     lp.dispatch("igloo_ipv4_bind", None, "80:123", True)   # port:pid, TCP
 
     rows = (tmp_path / "netbinds.csv").read_text().splitlines()
-    assert rows[0] == "procname,ipvn,domain,guest_ip,guest_port,pid,time"
+    assert rows[0] == "procname,ipvn,domain,guest_ip,guest_port,pid,time,state,closed_time"
     fields = rows[1].split(",")
     assert fields[:6] == ["httpd", "4", "tcp", "0.0.0.0", "80", "123"]
+    # Announced (survived the zero-length window) -> state listening, no close.
+    assert fields[7] == "listening"
+    assert fields[8] == ""
 
     # The plugin published an on_bind event for downstream consumers (VPN/Nmap).
     on_binds = [p for p in lp.published if p[1] == "on_bind"]
@@ -170,7 +178,8 @@ def test_netbinds_ipv6_uses_mem_double(tmp_path):
     # plugins.mem, which the harness resolves to our fake instead of a stub.
     raw = socket.inet_pton(socket.AF_INET6, "fe80::1")
     lp = load_pyplugin(
-        str(NETBINDS), outdir=tmp_path, args={"shutdown_on_www": False},
+        str(NETBINDS), outdir=tmp_path,
+        args={"shutdown_on_www": False, "announce_debounce_s": 0},
         endianness="little", doubles={"mem": _FakeMem(raw)},
     )
     lp.dispatch("igloo_ipv6_setup", None, "dnsd", 0)  # addr arg -> read via mem double

--- a/tests/unit/test_run_summary.py
+++ b/tests/unit/test_run_summary.py
@@ -124,7 +124,11 @@ def test_summary_aggregates_real_netbinds_output(tmp_path):
     # endianness="big" keeps the "port:pid" port value un-swapped).
     lp = load_pyplugin(
         str(NETBINDS), outdir=tmp_path,
-        args={"shutdown_on_www": False}, endianness="big",
+        # announce_debounce_s=0: announce synchronously so the bind is recorded
+        # (state listening) at dispatch time rather than held pending until a
+        # timer/sweep -- otherwise finalize() with no elapsed time would leave
+        # it pending and run_summary would (correctly) filter it as non-working.
+        args={"shutdown_on_www": False, "announce_debounce_s": 0}, endianness="big",
     )
     lp.dispatch("igloo_ipv4_setup", None, "httpd", 0)     # sin_addr 0 -> 0.0.0.0
     lp.dispatch("igloo_ipv4_bind", None, "80:123", True)  # port:pid, TCP
@@ -141,10 +145,14 @@ def test_summary_aggregates_real_netbinds_output(tmp_path):
     assert summary["score"] == float(sum(SCORES.values()))
     assert summary["scores"] == SCORES
 
-    # The binds come from the CSV the plugin actually wrote.
+    # The binds come from the CSV the plugin actually wrote. It now emits the
+    # draft-05 lifecycle columns: both binds were announced synchronously
+    # (announce_debounce_s=0) and never released -> state listening, no close.
     for bind, expected in zip(summary["binds"], [
-        {"proc": "httpd", "proto": "tcp", "ipvn": 4, "ip": "0.0.0.0", "port": 80, "pid": 123},
-        {"proc": "dnsd", "proto": "udp", "ipvn": 4, "ip": "0.0.0.0", "port": 53, "pid": 99},
+        {"proc": "httpd", "proto": "tcp", "ipvn": 4, "ip": "0.0.0.0", "port": 80,
+         "pid": 123, "state": "listening", "closed_time": None},
+        {"proc": "dnsd", "proto": "udp", "ipvn": 4, "ip": "0.0.0.0", "port": 53,
+         "pid": 99, "state": "listening", "closed_time": None},
     ]):
         time = bind.pop("time")
         assert isinstance(time, float)


### PR DESCRIPTION
## Part A of 2 — netbinds socket lifecycle states + announce debounce + snapshot restore

Implements the netbinds side of iglootodo draft 05 (feeds `run_summary`'s
`summary.json` `binds`). **Part B** (`connect.sh`/`endpoints.txt`/`guest_ip`)
stacks on this: #896.

### What it does
A per-socket state machine — `pending → listening | transient | closed` — on top
of the existing close-debounce/flap tracking, plus `state` and `closed_time`
columns in `netbinds.csv`.

- **`announce_debounce_s`** (default 2s): a new bind is held `pending` and only
  announced via `on_bind` (VPN/Nmap/FetchWeb) once it survives the window, so a
  short-lived bind never triggers bridging or scans. Promotion runs on the
  **hypercall-path sweep** (a background timer gets GIL-starved under heavy
  instrumentation), with the timer as a quiet-guest fallback. `<=0` = immediate
  (historical behavior).
- A bind still `pending` when the run ends keeps `pending` (never affirmatively
  labelled `listening`); `shutdown_on_www` fires at announce time so a transient
  www bind can't end the run early.
- **Snapshot/restore**: netbinds now implements `save_state`/`load_state`/
  `on_restore`, so the socket lifecycle is bundled with the snapshot and rebuilt
  on restore. A restored guest is already past its binds, so without this every
  pre-snapshot service vanished from `netbinds.csv`. Already-announced sockets
  rebuild silently (consumers like VPN replay their own state — re-announcing
  would double-actuate); a socket still inside its announce window at snapshot
  time is ground-truth-listening and is announced on restore.
- CSV rewrite is atomic (temp + `os.replace`); `on_bind` is published outside the
  non-reentrant lock so a subscriber may re-enter (e.g. `give_list`).

### Downstream
`run_summary` already filters `transient`/`pending` as non-working
(`tests/unit/test_run_summary.py::test_lifecycle_netbinds_filters_non_working`);
this PR makes netbinds produce that exact 9-column shape.

### Tests
- `tests/unit/test_netbinds_lifecycle.py`: drives the real plugin via the
  `penguin.testing` harness with a **fake clock** (deterministic, no sleeps) —
  debounce, flap, transient, pending-at-shutdown, and snapshot round-trip.
- Updates the existing harness/run_summary reference tests for the 9-column format.
- `netbinds_announce.yaml`: standalone in-guest fixture for the real nonzero-window
  → announce → VPN-bridge path, wired into CI on one representative arch/kernel.
