### PR TITLE
processes: queryable guest process-tree plugin + bulk OSI walk (epic B slice 1)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -133,14 +133,14 @@
     "igloo-driver": {
       "flake": false,
       "locked": {
-        "lastModified": 1785248040,
-        "narHash": "sha256-65hJ/DUG4g2BTjUulJuqtDqvQvZ37ZfStbOIvvG9028=",
+        "lastModified": 1785782122,
+        "narHash": "sha256-n+xrWnKnts3EDN+ZorOp6dctrbDXuFYHDWYboRgmo8I=",
         "type": "tarball",
-        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.93/igloo_driver.tar.gz"
+        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94-pre.df8576ef7/igloo_driver.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.93/igloo_driver.tar.gz"
+        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94-pre.df8576ef7/igloo_driver.tar.gz"
       }
     },
     "kernels": {

--- a/flake.lock
+++ b/flake.lock
@@ -133,14 +133,14 @@
     "igloo-driver": {
       "flake": false,
       "locked": {
-        "lastModified": 1785782122,
+        "lastModified": 1786471290,
         "narHash": "sha256-n+xrWnKnts3EDN+ZorOp6dctrbDXuFYHDWYboRgmo8I=",
         "type": "tarball",
-        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94-pre.df8576ef7/igloo_driver.tar.gz"
+        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94/igloo_driver.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94-pre.df8576ef7/igloo_driver.tar.gz"
+        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94/igloo_driver.tar.gz"
       }
     },
     "kernels": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
     flake = false;
   };
   inputs.igloo-driver = {
-    url = "https://github.com/rehosting/igloo_driver/releases/download/v0.0.93/igloo_driver.tar.gz";
+    url = "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94-pre.df8576ef7/igloo_driver.tar.gz";
     flake = false;
   };
   # v0.0.25 is the slimmed penguin-tools: it no longer ships the forked guest

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
     flake = false;
   };
   inputs.igloo-driver = {
-    url = "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94-pre.df8576ef7/igloo_driver.tar.gz";
+    url = "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94/igloo_driver.tar.gz";
     flake = false;
   };
   # v0.0.25 is the slimmed penguin-tools: it no longer ships the forked guest

--- a/pengutils/pengutils/events/types.py
+++ b/pengutils/pengutils/events/types.py
@@ -223,3 +223,83 @@ class Exec(Event):
             String representation.
         """
         return f'Exec: "{self.argv}" {self.calltree}'
+
+
+class ProcStart(Event):
+    """
+    ProcStart Event
+    ===============
+    A process becoming visible (via exec) to the process-tree model. Lean and
+    identity-focused -- argv/env live on :class:`Exec`; this carries only what
+    the genealogy needs. Re-exec appends another row with the same
+    ``(pid, create_time)``; consumers coalesce by that key.
+
+    Attributes
+    ----------
+    pid : int
+        Process id.
+    ppid : int
+        Parent process id (from ``osi_proc.ppid``).
+    create_time : int
+        Kernel task creation timestamp; stable across execve, so
+        ``(pid, create_time)`` is a durable process identity across pid reuse.
+    comm : str
+        Kernel ``task->comm`` at exec time (the executed program's basename may
+        differ; ``procname`` on the base row carries the fuller name).
+    uid, gid, euid, egid : int
+        Credentials at exec time.
+    """
+    __tablename__ = "proc_start"
+    id: Mapped[int] = mapped_column(ForeignKey("event.id"), primary_key=True)
+    pid: Mapped[int]
+    ppid: Mapped[int]
+    create_time: Mapped[int]
+    comm: Mapped[str]
+    uid: Mapped[int]
+    gid: Mapped[int]
+    euid: Mapped[int]
+    egid: Mapped[int]
+
+    __mapper_args__ = {
+        "polymorphic_identity": "proc_start",
+    }
+
+    def __str__(self):
+        return f"ProcStart: pid={self.pid} ppid={self.ppid} comm={self.comm}"
+
+
+class ProcExit(Event):
+    """
+    ProcExit Event
+    ==============
+    A process/thread exit, recorded from the exit/exit_group syscall. Identity
+    is denormalized from the syscall event (no memory read of the dying task).
+    Pairs with :class:`ProcStart` by ``(pid, create_time)`` to close out a
+    process in the derived tree.
+
+    Attributes
+    ----------
+    pid : int
+        Exiting process id.
+    create_time : int
+        Process identity key (see :class:`ProcStart`). May be 0 if an older
+        driver did not denormalize it, in which case consumers fall back to the
+        unique live ``(pid)``.
+    code : int
+        Exit status argument passed to exit / exit_group.
+    reason : str
+        ``"exit"`` or ``"exit_group"``.
+    """
+    __tablename__ = "proc_exit"
+    id: Mapped[int] = mapped_column(ForeignKey("event.id"), primary_key=True)
+    pid: Mapped[int]
+    create_time: Mapped[int]
+    code: Mapped[int]
+    reason: Mapped[str]
+
+    __mapper_args__ = {
+        "polymorphic_identity": "proc_exit",
+    }
+
+    def __str__(self):
+        return f"ProcExit: pid={self.pid} code={self.code} ({self.reason})"

--- a/pyplugins/analysis/processes.py
+++ b/pyplugins/analysis/processes.py
@@ -1,0 +1,475 @@
+"""
+Processes Plugin (processes.py) for Penguin
+===========================================
+
+A small, queryable model of the guest's **process tree** -- the first
+consumer of the OSI suite that builds a system-wide view rather than reading
+one pid at a time. This is *slice 1* of the "system cartography" epic
+(threads/kthreads, fd/peer graph, maps, CPU and ptregs are deliberate
+follow-ons -- see ``Follow-ons`` below).
+
+Two audiences, one model
+------------------------
+
+**AI / the MCP agent** (#835) get a stable, documented, JSON-serializable query
+API -- three **live** portal generators (drive with ``yield from`` while the
+guest runs):
+
+- ``processes.get(pid)``   -> one flat record (dict) or ``None``
+- ``processes.tree()``     -> ``{"roots": [node, ...]}`` (nested; each node has ``children``)
+- ``processes.snapshot()`` -> ``{"processes": [record, ...], "tree": {...}}``
+
+These read the whole process set in **one** kernel-side walk
+(``OSI.get_all_procs`` -> ``HYPER_OP_OSI_PROC_ALL``): the driver walks
+``for_each_process`` under ``rcu_read_lock`` and returns a slim node (pid,
+ppid, create_time, ids, comm) per process, so a tree snapshot is a single
+RCU-consistent transaction rather than 1 + N per-pid reads that could tear.
+
+**Users** get a legible artifact. Process lifecycle is recorded to the event
+**database** (``plugins.db``) as it happens, and at teardown the plugin
+materializes a derived ``system_map.yaml`` from it: structured per-process
+records plus a rendered ASCII tree embedded as a literal block::
+
+    schema_version: 1
+    generated_by: processes
+    process_count: 3
+    processes:
+    - {pid: 1, ppid: 0, name: init, create_time: 100, exec_count: 1, exit: null, ...}
+    ...
+    tree: |
+      init (1)
+      `- httpd (400)
+         `- status.cgi (517)  [exit: 0]
+
+Persistence model (DB-backed)
+-----------------------------
+
+The plugin depends on the ``DB`` logger plugin and emits two lean events
+(``pengutils.events``):
+
+- ``exec_event`` (from Execs) -> a ``ProcStart`` row (identity + genealogy:
+  pid, ppid, create_time, comm, ids). argv/env stay on the existing ``Exec``
+  event; this row carries only what the tree needs. Re-exec appends another
+  ``ProcStart`` with the same ``(pid, create_time)``; the derived view
+  coalesces by that key.
+- ``exit`` / ``exit_group`` syscalls -> a ``ProcExit`` row. Identity comes off
+  the syscall event (``syscall.pid`` / ``syscall.create_time``, denormalized by
+  the driver from ``current``), so exit recording costs **zero** portal
+  round-trips and never reads the dying task's memory.
+
+``system_map.yaml`` is the derived view: ``ProcStart LEFT JOIN ProcExit`` on
+``(pid, create_time)``, rendered at teardown. Because plugins unload in reverse
+load order (this plugin's ``uninit`` runs before the DB's own final flush), the
+teardown path calls ``plugins.db.flush()`` first to make buffered rows visible.
+
+Driver-side safety
+------------------
+
+Both the live walk and the exit path touch only kernel ``task_struct`` state --
+``get_all_procs`` copies ``task->comm`` (like ``get_proc``) and skips
+``!task->mm`` (kthreads = slice 2); the exit path reads a denormalized pid. No
+``access_remote_vm`` on userspace, so nothing faults on an exiting/stopped
+context (the class of bug behind the rv130 ``read_procargs`` panic).
+
+Arguments
+---------
+
+- ``outdir`` (str): output directory (supplied by the framework).
+- ``write_map`` (bool, default True): write ``system_map.yaml`` at teardown.
+
+Follow-ons (out of scope for slice 1)
+-------------------------------------
+
+Threads + kernel threads (the one further driver change), fd + peer/resource
+graph, maps + loaded-lib inventory, CPU/scheduling, ``get_ptregs`` -- slices
+2-6 of the epic.
+"""
+
+import os
+from collections import defaultdict
+from os.path import basename, join
+from typing import Any, Dict, Generator, List, Optional, Tuple
+
+import yaml
+
+from penguin import Plugin, plugins, getColoredLogger
+from pengutils.events import ProcStart, ProcExit
+
+MAP_FILE = "system_map.yaml"
+SCHEMA_VERSION = 1
+
+# A process identity: (pid, create_time). create_time is the kernel task
+# creation timestamp -- stable across execve, distinct across pid reuse.
+ProcKey = Tuple[int, int]
+
+
+def _int(obj: Any, name: str, default: int = 0) -> int:
+    """Read an integer field from an osi_proc wrapper (or any attr holder),
+    tolerating missing attributes so real wrappers and test doubles both work."""
+    val = getattr(obj, name, default)
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return default
+
+
+class Processes(Plugin):
+    """Maintains and queries the guest process tree (slice 1: tree + get)."""
+
+    def __init__(self) -> None:
+        self.logger = getColoredLogger("plugins.processes")
+        self.outdir = self.get_arg("outdir")
+        self.write_map = self.get_arg_bool("write_map", True)
+
+        # Hard dependency: lifecycle is recorded to the event DB.
+        self.DB = plugins.DB
+
+        plugins.subscribe(plugins.Execs, "exec_event", self.on_exec_event)
+
+        # Seed an (empty) map so downstream consumers can rely on the file.
+        self._write_map_file({})
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle -> event DB
+    # ------------------------------------------------------------------ #
+    def on_exec_event(self, event: Any) -> None:
+        """Record a process from an ``exec_event`` as a ``ProcStart`` row.
+
+        The payload carries ``proc`` (osi_proc: pid/ppid/create_time/ids) and
+        the new program's ``procname``/``argv``; identity is from ``proc``
+        (stable kernel fields), the display name from the exec payload.
+        """
+        proc = getattr(event, "proc", None)
+        if proc is None:
+            self.logger.warning("processes: exec_event with no proc; ignoring")
+            return
+
+        exe = getattr(event, "procname", None) or ""
+        argv = list(getattr(event, "argv", None) or [])
+        comm = getattr(proc, "name", "") or ""
+        name = basename(exe) if exe else (basename(argv[0]) if argv else comm)
+        if not name:
+            name = "[???]"
+
+        pid = _int(proc, "pid")
+        self.DB.add_event(ProcStart, {
+            "proc_id": pid,
+            "procname": name,
+            "pid": pid,
+            "ppid": _int(proc, "ppid"),
+            "create_time": _int(proc, "create_time"),
+            "comm": comm or name,
+            "uid": _int(proc, "uid"),
+            "gid": _int(proc, "gid"),
+            "euid": _int(proc, "euid"),
+            "egid": _int(proc, "egid"),
+        })
+        self.logger.info(f"processes: exec pid={pid} ppid={_int(proc, 'ppid')} "
+                         f"name={name!r}")
+
+    def _record_exit(self, syscall: Any, error_code: int, reason: str) -> None:
+        """Emit a ``ProcExit`` row for the current process.
+
+        Identity is read straight off the syscall event (``syscall.pid`` /
+        ``syscall.create_time``), which the driver denormalizes from
+        ``current`` -- zero portal round-trips, no read of the dying task. The
+        derived view pairs it with a ``ProcStart`` by ``(pid, create_time)``.
+        """
+        pid = getattr(syscall, "pid", None)
+        if pid is None:
+            self.logger.debug(
+                f"processes: {reason} without syscall.pid (old driver?); skip")
+            return
+        pid = int(pid)
+        self.DB.add_event(ProcExit, {
+            "proc_id": pid,
+            "procname": "",  # name is carried by the paired ProcStart
+            "pid": pid,
+            "create_time": int(getattr(syscall, "create_time", 0) or 0),
+            "code": int(error_code),
+            "reason": reason,
+        })
+        self.logger.info(f"processes: {reason} pid={pid} status={error_code}")
+
+    @plugins.syscalls.syscall("on_sys_exit_enter")
+    def on_exit(self, regs: Any, proto: Any, syscall: Any,
+                error_code: int) -> Generator[Any, None, None]:
+        """Thread exit -> ProcExit row."""
+        self._record_exit(syscall, error_code, "exit")
+        yield from ()  # exit tracking needs no portal call; stay a generator
+
+    @plugins.syscalls.syscall("on_sys_exit_group_enter")
+    def on_exit_group(self, regs: Any, proto: Any, syscall: Any,
+                      error_code: int) -> Generator[Any, None, None]:
+        """Whole-process exit -> ProcExit row."""
+        self._record_exit(syscall, error_code, "exit_group")
+        yield from ()
+
+    # ------------------------------------------------------------------ #
+    # Live query API (MCP / interactive). Portal generators -- ``yield from``.
+    # ------------------------------------------------------------------ #
+    def get(self, pid: Optional[int] = None) -> Generator[Any, None, Optional[Dict[str, Any]]]:
+        """Return a flat record for ``pid`` (or the current process if None).
+
+        Live read via ``get_proc`` -- kernel ``task_struct``/``comm`` only, safe
+        against exiting contexts. Returns ``None`` if the pid is not present.
+
+        Return schema (all ints except ``name``)::
+
+            {pid, ppid, name, create_time, start_time, uid, gid, euid, egid}
+        """
+        proc = yield from plugins.OSI.get_proc(pid)
+        if proc is None:
+            return None
+        return _flatten_proc(proc)
+
+    def _live_records(self) -> Generator[Any, None, Dict[int, Dict[str, Any]]]:
+        """{pid -> live record} for every user process, via one kernel-side
+        walk (``get_all_procs``) -- a single RCU-consistent snapshot rather than
+        1 + N per-pid reads."""
+        procs = yield from plugins.OSI.get_all_procs()
+        records: Dict[int, Dict[str, Any]] = {}
+        for proc in procs or []:
+            rec = _flatten_proc(proc)
+            records[rec["pid"]] = rec
+        return records
+
+    def tree(self) -> Generator[Any, None, Dict[str, Any]]:
+        """Return the live process tree as ``{"roots": [node, ...]}``.
+
+        Each node is a ``get()`` record plus a ``children`` list. A process
+        whose parent is not among the reported leaders (or ``ppid`` 0) becomes a
+        root. Cycles and self-parenting are broken defensively.
+        """
+        records = yield from self._live_records()
+        return _build_tree(records)
+
+    def snapshot(self) -> Generator[Any, None, Dict[str, Any]]:
+        """Return ``{"processes": [flat records], "tree": {...}}`` -- the live
+        "dump the whole process view" call for MCP/tooling."""
+        records = yield from self._live_records()
+        flat = [records[pid] for pid in sorted(records)]
+        return {"processes": flat, "tree": _build_tree(records)}
+
+    # ------------------------------------------------------------------ #
+    # Derived artifact (materialized from the DB at teardown)
+    # ------------------------------------------------------------------ #
+    def _write_map_file(self, procs: Dict[ProcKey, Dict[str, Any]]) -> None:
+        if not self.write_map or not self.outdir:
+            return
+        flat = _cache_flat(procs)
+        header = {
+            "schema_version": SCHEMA_VERSION,
+            "generated_by": "processes",
+            "process_count": len(flat),
+            "processes": flat,
+        }
+        ascii_tree = _render_cache_tree(procs)
+        tmp = join(self.outdir, MAP_FILE + ".tmp")
+        try:
+            with open(tmp, "w") as f:
+                f.write(yaml.safe_dump(header, sort_keys=False, default_flow_style=False))
+                # Embed the rendered tree as a YAML literal block so the file is
+                # both machine-parseable and readable at a glance.
+                f.write("tree: |\n")
+                for line in (ascii_tree.splitlines() or [""]):
+                    f.write(f"  {line}\n")
+            os.replace(tmp, join(self.outdir, MAP_FILE))
+        except OSError as e:
+            self.logger.warning(f"processes: could not write {MAP_FILE}: {e}")
+
+    def uninit(self) -> None:
+        """Materialize ``system_map.yaml`` from the DB on unload.
+
+        Flushes the DB first (plugins unload in reverse load order, so our
+        ``uninit`` runs before the DB's own final flush) then derives the tree
+        from the ``ProcStart``/``ProcExit`` rows.
+        """
+        if not self.write_map:
+            return
+        try:
+            self.DB.flush()
+            starts = self.DB.query(ProcStart)
+            exits = self.DB.query(ProcExit)
+        except Exception as e:  # DB unavailable / query failed -- keep the seed
+            self.logger.warning(f"processes: could not read DB for map: {e}")
+            return
+        procs = _genealogy_from_rows(starts, exits)
+        self._write_map_file(procs)
+
+
+# ---------------------------------------------------------------------- #
+# Pure helpers (host-only; unit-tested directly)
+# ---------------------------------------------------------------------- #
+def _flatten_proc(proc: Any) -> Dict[str, Any]:
+    """One flat, JSON-serializable record from an osi_proc / osi_proc_node.
+
+    Return schema (all ints except ``name``)::
+
+        {pid, ppid, name, create_time, start_time, uid, gid, euid, egid}
+    """
+    ct = _int(proc, "create_time")
+    return {
+        "pid": _int(proc, "pid"),
+        "ppid": _int(proc, "ppid"),
+        "name": getattr(proc, "name", "") or "[???]",
+        "create_time": ct,
+        # Slim nodes carry only create_time; full osi_proc also has start_time.
+        "start_time": _int(proc, "start_time", ct),
+        "uid": _int(proc, "uid"),
+        "gid": _int(proc, "gid"),
+        "euid": _int(proc, "euid"),
+        "egid": _int(proc, "egid"),
+    }
+
+
+def _genealogy_from_rows(starts: List[Any], exits: List[Any]) -> Dict[ProcKey, Dict[str, Any]]:
+    """Derive the process genealogy from ``ProcStart``/``ProcExit`` rows.
+
+    Coalesces ``ProcStart`` by ``(pid, create_time)`` (re-exec bumps
+    ``exec_count``, latest name wins), resolves each process's parent identity
+    by matching ``ppid`` to the parent ``ProcStart`` with the greatest
+    ``create_time`` not after the child's, and applies ``ProcExit`` rows.
+    """
+    procs: Dict[ProcKey, Dict[str, Any]] = {}
+    for s in sorted(starts, key=lambda r: getattr(r, "id", 0)):
+        key: ProcKey = (int(s.pid), int(s.create_time))
+        rec = procs.get(key)
+        if rec is None:
+            procs[key] = {
+                "pid": int(s.pid),
+                "ppid": int(s.ppid),
+                "parent_create_time": 0,  # resolved below
+                "name": s.procname or s.comm or "[???]",
+                "create_time": int(s.create_time),
+                "uid": int(s.uid), "gid": int(s.gid),
+                "euid": int(s.euid), "egid": int(s.egid),
+                "exec_count": 1,
+                "exit": None,
+            }
+        else:
+            rec["exec_count"] += 1
+            rec["name"] = s.procname or s.comm or rec["name"]
+            rec["ppid"] = int(s.ppid)
+
+    # Resolve parent identity: the parent (ppid) instance that predates the child.
+    cts_by_pid: Dict[int, List[int]] = defaultdict(list)
+    for (pid, ct) in procs:
+        cts_by_pid[pid].append(ct)
+    for key, rec in procs.items():
+        _pid, ct = key
+        cands = [c for c in cts_by_pid.get(rec["ppid"], []) if c <= ct]
+        rec["parent_create_time"] = max(cands) if cands else 0
+
+    # Apply exits: exact (pid, create_time), else fall back to the pid.
+    for e in exits:
+        key = (int(e.pid), int(e.create_time))
+        if key not in procs:
+            same_pid = [k for k in procs if k[0] == int(e.pid)]
+            if not same_pid:
+                continue
+            key = max(same_pid, key=lambda k: k[1])
+        if procs[key]["exit"] is None:
+            procs[key]["exit"] = {"code": int(e.code), "reason": e.reason}
+    return procs
+
+
+def _cache_flat(procs: Dict[ProcKey, Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Public-shaped flat records from a genealogy dict, pid-sorted."""
+    out = []
+    for rec in procs.values():
+        out.append({
+            "pid": rec["pid"],
+            "ppid": rec["ppid"],
+            "name": rec["name"],
+            "create_time": rec["create_time"],
+            "uid": rec["uid"], "gid": rec["gid"],
+            "euid": rec["euid"], "egid": rec["egid"],
+            "exec_count": rec["exec_count"],
+            "exit": rec["exit"],
+        })
+    out.sort(key=lambda r: (r["pid"], r["create_time"]))
+    return out
+
+
+def _build_tree(records: Dict[int, Dict[str, Any]]) -> Dict[str, Any]:
+    """Join live ``{pid -> record}`` into ``{"roots": [node...]}`` via ppid.
+
+    Nodes are shallow copies with a ``children`` list. Roots are processes
+    whose ppid is absent/0/self. A cycle (should not happen with real kernel
+    data) is broken by treating the first-visited node as the ancestor.
+    """
+    nodes: Dict[int, Dict[str, Any]] = {
+        pid: {**rec, "children": []} for pid, rec in records.items()
+    }
+    roots: List[Dict[str, Any]] = []
+    for pid in sorted(nodes):
+        node = nodes[pid]
+        ppid = node["ppid"]
+        parent = nodes.get(ppid)
+        if parent is None or ppid == pid or _would_cycle(nodes, pid, ppid):
+            roots.append(node)
+        else:
+            parent["children"].append(node)
+    for node in nodes.values():
+        node["children"].sort(key=lambda c: c["pid"])
+    return {"roots": roots}
+
+
+def _would_cycle(nodes: Dict[int, Dict[str, Any]], pid: int, ppid: int) -> bool:
+    """True if attaching ``pid`` under ``ppid`` would form a cycle."""
+    seen = {pid}
+    cur = ppid
+    while cur in nodes:
+        if cur in seen:
+            return True
+        seen.add(cur)
+        cur = nodes[cur]["ppid"]
+    return False
+
+
+def _render_cache_tree(procs: Dict[ProcKey, Dict[str, Any]]) -> str:
+    """Render a genealogy dict (keyed by (pid, create_time)) as ASCII."""
+    if not procs:
+        return "(no processes observed)"
+
+    children: Dict[ProcKey, List[ProcKey]] = {k: [] for k in procs}
+    roots: List[ProcKey] = []
+    for key, rec in procs.items():
+        pkey: ProcKey = (rec["ppid"], rec["parent_create_time"])
+        if pkey in procs and pkey != key:
+            children[pkey].append(key)
+        else:
+            roots.append(key)
+    for kids in children.values():
+        kids.sort()
+    roots.sort()
+
+    lines: List[str] = []
+
+    def label(key: ProcKey) -> str:
+        rec = procs[key]
+        s = f"{rec['name']} ({rec['pid']})"
+        if rec["exec_count"] > 1:
+            s += f" [execs: {rec['exec_count']}]"
+        if rec["exit"] is not None:
+            s += f" [exit: {rec['exit']['code']}]"
+        return s
+
+    def walk(key: ProcKey, prefix: str, is_last: bool, is_root: bool,
+             stack: frozenset) -> None:
+        if is_root:
+            lines.append(label(key))
+        else:
+            lines.append(f"{prefix}{'`- ' if is_last else '|- '}{label(key)}")
+        if key in stack:  # defensive cycle guard
+            return
+        stack = stack | {key}
+        kids = children.get(key, [])
+        child_prefix = prefix + ("" if is_root else ("   " if is_last else "|  "))
+        for i, child in enumerate(kids):
+            walk(child, child_prefix, i == len(kids) - 1, False, stack)
+
+    for i, root in enumerate(roots):
+        walk(root, "", i == len(roots) - 1, True, frozenset())
+    return "\n".join(lines)

--- a/pyplugins/analysis/processes.py
+++ b/pyplugins/analysis/processes.py
@@ -126,6 +126,69 @@ class Processes(Plugin):
 
         plugins.subscribe(plugins.Execs, "exec_event", self.on_exec_event)
 
+        # pid -> create_time, learned at exec, so a signal death (which carries
+        # only a pid) can be paired with its ProcStart by (pid, create_time).
+        self._create_time: Dict[int, int] = {}
+
+        # Authoritative exit source: the igloo_driver do_exit kprobe (via
+        # exit_monitor) fires on EVERY user-process death -- exit, exit_group,
+        # AND fatal signals -- with the real wait(2)-status-encoded code. When
+        # enabled it supersedes both the exit/exit_group syscall hooks and the
+        # signal heuristic below: no caught-signal false positives, no missed
+        # signal deaths, real exit codes, and create_time straight off the dying
+        # task (pairs exactly with ProcStart). Opt-in until the driver carrying
+        # the hook is the pinned release.
+        self._use_do_exit = self.get_arg_bool("use_do_exit", False)
+        if self._use_do_exit:
+            try:
+                plugins.exit_monitor.enable()
+                plugins.subscribe(plugins.exit_monitor, "proc_exit",
+                                  self.on_proc_exit)
+            except Exception as e:
+                self.logger.warning(
+                    f"processes: do_exit hook unavailable ({e}); falling back "
+                    "to syscall + signal exit tracking")
+                self._use_do_exit = False
+
+        # exit/exit_group syscall hooks: the cheap default exit source -- they
+        # piggyback on already-firing syscall instrumentation and append a row
+        # with no portal round-trip. Registered ONLY when the do_exit hook is not
+        # active; otherwise do_exit owns every exit, so installing these would
+        # both double-count and waste a hook firing per exit. Registered
+        # imperatively (bound methods) so it can be conditional -- a class-body
+        # decorator would always install them.
+        if not self._use_do_exit:
+            plugins.syscalls.syscall("on_sys_exit_enter")(self.on_exit)
+            plugins.syscalls.syscall("on_sys_exit_group_enter")(self.on_exit_group)
+
+        # A process killed by a fatal signal dies via the kernel's do_exit path
+        # and calls neither exit nor exit_group, so the syscall hooks above miss
+        # it -- it would look permanently alive. Close those out via the signal
+        # monitor. Restricted by default to signals whose default action is
+        # terminate and that are essentially never caught-and-survived (the
+        # synchronous faults + abort/kill family); SIGTERM/SIGINT/SIGHUP are
+        # excluded as they are commonly handled. Hooked by name for arch
+        # portability (signal numbers differ on MIPS etc.).
+        self.track_signal_exits = (self.get_arg_bool("track_signal_exits", True)
+                                   and not self._use_do_exit)
+        self._signal_exited: set = set()
+        self._fatal_signums: Dict[int, str] = {}
+        if self.track_signal_exits:
+            names = self.get_arg("fatal_signals") or [
+                "SIGILL", "SIGABRT", "SIGFPE", "SIGSEGV", "SIGBUS",
+                "SIGSYS", "SIGXCPU", "SIGXFSZ", "SIGKILL", "SIGQUIT"]
+            for name in names:
+                num = plugins.signals.signal_name_to_num(name)
+                # isinstance guard (not `is not None`) so the host test harness,
+                # where signals is an undoubled stub, degrades to no-op cleanly.
+                if isinstance(num, int):
+                    self._fatal_signums[int(num)] = name
+            if self._fatal_signums:
+                plugins.subscribe(plugins.signal_monitor, "signal_deliver",
+                                  self.on_signal_deliver)
+                for num in self._fatal_signums:
+                    plugins.signal_monitor.register_hook(sig=num)
+
         # Seed an (empty) map so downstream consumers can rely on the file.
         self._write_map_file({})
 
@@ -152,6 +215,8 @@ class Processes(Plugin):
             name = "[???]"
 
         pid = _int(proc, "pid")
+        self._create_time[pid] = _int(proc, "create_time")
+        self._signal_exited.discard(pid)  # a reused pid can die again
         self.DB.add_event(ProcStart, {
             "proc_id": pid,
             "procname": name,
@@ -191,17 +256,81 @@ class Processes(Plugin):
         })
         self.logger.info(f"processes: {reason} pid={pid} status={error_code}")
 
-    @plugins.syscalls.syscall("on_sys_exit_enter")
+    def on_signal_deliver(self, cpu: Any, event: Any) -> None:
+        """Fatal-signal death -> ProcExit row.
+
+        Covers the process kills that ``exit``/``exit_group`` never see (SIGSEGV
+        and friends). Runs in the signal_monitor's (non-portal) publish, so it
+        only appends a buffered row -- no guest read. ``event.drop`` means
+        another subscriber bypassed the delivery (e.g. SIGILL emulation), so the
+        process is not dying; skip it. Deduped per pid: the first fatal delivery
+        wins (a dying process may be hit more than once)."""
+        sig = int(getattr(event, "sig", 0))
+        name = self._fatal_signums.get(sig)
+        if name is None or getattr(event, "drop", False):
+            return
+        pid = getattr(event, "pid", None)
+        if pid is None:
+            return
+        pid = int(pid)
+        if pid in self._signal_exited:
+            return
+        self._signal_exited.add(pid)
+        self.DB.add_event(ProcExit, {
+            "proc_id": pid,
+            "procname": "",
+            "pid": pid,
+            "create_time": int(self._create_time.get(pid, 0)),
+            "code": 128 + sig,  # shell convention for signal death
+            "reason": f"signal:{name}",
+        })
+        self.logger.info(f"processes: {name} killed pid={pid} (ProcExit)")
+
+    def on_proc_exit(self, cpu: Any, event: Any) -> None:
+        """Authoritative task-exit -> ``ProcExit`` row (do_exit kprobe).
+
+        Fires once per user-process death for exit, exit_group, AND fatal
+        signals alike, carrying the real exit code (wait-status encoded) and the
+        dying task's ``create_time`` -- so it needs no ``(pid, create_time)``
+        reconstruction and cannot false-positive on a caught-and-survived
+        signal. Active only when ``use_do_exit`` is set; supersedes the syscall
+        hooks and the signal heuristic."""
+        pid = int(getattr(event, "pid", 0) or 0)
+        if not pid:
+            return
+        if getattr(event, "signaled", False):
+            sig = int(event.termsig)
+            name = None
+            try:
+                name = plugins.signals.signal_num_to_name(sig)
+            except Exception:
+                pass
+            if not isinstance(name, str):  # undoubled stub in the test harness
+                name = None
+            reason, code = f"signal:{name or sig}", 128 + sig
+        else:
+            reason, code = "exit", int(getattr(event, "exit_status", 0))
+        self.DB.add_event(ProcExit, {
+            "proc_id": pid,
+            "procname": "",  # name is carried by the paired ProcStart
+            "pid": pid,
+            "create_time": int(getattr(event, "create_time", 0) or 0),
+            "code": int(code),
+            "reason": reason,
+        })
+        self.logger.info(f"processes: {reason} pid={pid} code={code}")
+
     def on_exit(self, regs: Any, proto: Any, syscall: Any,
                 error_code: int) -> Generator[Any, None, None]:
-        """Thread exit -> ProcExit row."""
+        """Thread exit -> ProcExit row. Registered in ``__init__`` only when the
+        do_exit hook is not in use; do_exit supersedes it otherwise."""
         self._record_exit(syscall, error_code, "exit")
         yield from ()  # exit tracking needs no portal call; stay a generator
 
-    @plugins.syscalls.syscall("on_sys_exit_group_enter")
     def on_exit_group(self, regs: Any, proto: Any, syscall: Any,
                       error_code: int) -> Generator[Any, None, None]:
-        """Whole-process exit -> ProcExit row."""
+        """Whole-process exit -> ProcExit row. Registered in ``__init__`` only
+        when the do_exit hook is not in use."""
         self._record_exit(syscall, error_code, "exit_group")
         yield from ()
 

--- a/pyplugins/apis/exit_monitor.py
+++ b/pyplugins/apis/exit_monitor.py
@@ -1,0 +1,116 @@
+"""
+Exit Monitor Plugin (exit_monitor.py)
+=====================================
+
+Surfaces guest task-exit events from the igloo_driver ``do_exit`` kprobe. Unlike
+the exit/exit_group *syscall* hooks, this fires on the kernel task-exit path, so
+it also captures deaths that never issue an exit syscall -- fatal signals
+(SIGSEGV/SIGKILL/...), OOM kills, kernel-forced exits -- each with the real,
+wait(2)-status-encoded exit code. One event per user process (reported at
+thread-group-leader death), so it maps 1:1 onto the leader-only process model.
+
+This is the authoritative process-exit source: it replaces the host-side
+signal-death heuristic (which cannot distinguish a caught SIGSEGV from a fatal
+one) and needs no per-signal guesswork.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from penguin import plugins
+
+    @plugins.subscribe(plugins.exit_monitor, "proc_exit")
+    def on_exit(cpu, event):
+        # event.code is the raw do_exit() code in wait-status encoding.
+        print(f"pid {event.pid} ({event.comm}) exited, code={event.code:#x}")
+
+    plugins.exit_monitor.enable()   # opt in; costs nothing until enabled
+"""
+
+from penguin import plugins, Plugin
+from hyper.consts import igloo_hypercall_constants as iconsts
+from hyper.consts import HYPER_OP as hop
+from hyper.portal import PortalCmd
+
+
+class ExitEvent:
+    """Wrapper for struct exit_event from the guest driver."""
+    __slots__ = ('_ee', 'comm')
+
+    def __init__(self, ee):
+        self._ee = ee
+        raw = bytes(ee.comm)
+        self.comm = raw.split(b'\x00', 1)[0].decode('utf-8', errors='replace')
+
+    def __getattr__(self, attr):
+        return getattr(self._ee, attr)
+
+    def __bytes__(self) -> bytes:
+        return bytes(self._ee)
+
+    # --- wait(2) status decoding of the raw do_exit() code ------------- #
+    @property
+    def signaled(self) -> bool:
+        """True if the process was killed by a signal (WIFSIGNALED)."""
+        return (int(self.code) & 0x7f) not in (0, 0x7f)
+
+    @property
+    def termsig(self) -> int:
+        """Signal number that killed the process, or 0 (WTERMSIG)."""
+        return int(self.code) & 0x7f if self.signaled else 0
+
+    @property
+    def core_dumped(self) -> bool:
+        return bool(int(self.code) & 0x80) if self.signaled else False
+
+    @property
+    def exit_status(self) -> int:
+        """Normal-exit status (WEXITSTATUS); meaningful only if not signaled."""
+        return (int(self.code) >> 8) & 0xff
+
+
+class ExitMonitor(Plugin):
+    """Interacts with the igloo_driver do_exit kprobe to surface task exits."""
+
+    def __init__(self):
+        super().__init__()
+        self._enabled = False
+        self._pending = 0   # net enable(+1)/disable(-1) requests to flush
+        plugins.portal.register_interrupt_handler(
+            "exit_monitor", self._interrupt_handler)
+        plugins.hypercall.hypercall(iconsts.IGLOO_HYP_PROC_EXIT)(
+            self._on_proc_exit)
+        plugins.register(self, "proc_exit")
+
+    def _interrupt_handler(self):
+        """Flush queued enable/disable toggles to the guest driver."""
+        want = self._enabled
+        # collapse to a single op reflecting the desired state
+        op = (hop.HYPER_OP_REGISTER_EXIT_HOOK if want
+              else hop.HYPER_OP_UNREGISTER_EXIT_HOOK)
+        yield PortalCmd(op)
+        return False
+
+    def _on_proc_exit(self, cpu):
+        """Hypercall handler: guest driver reports a task exit."""
+        ptr = self.panda.arch.get_arg(cpu, 1, convention="syscall")
+        try:
+            ee_raw = plugins.kffi.read_type_panda(cpu, ptr, "exit_event")
+            if not ee_raw:
+                self.logger.error(f"Failed to read exit_event at {ptr:#x}")
+            else:
+                plugins.publish(self, "proc_exit", cpu, ExitEvent(ee_raw))
+        except Exception as e:
+            self.logger.error(f"Error handling proc_exit hypercall: {e}")
+        self.panda.arch.set_retval(cpu, 0)
+
+    def enable(self) -> bool:
+        """Enable the guest do_exit hook (idempotent). Opt-in: nothing fires
+        until at least one plugin calls this."""
+        self._enabled = True
+        return plugins.portal.queue_interrupt("exit_monitor")
+
+    def disable(self) -> bool:
+        self._enabled = False
+        return plugins.portal.queue_interrupt("exit_monitor")

--- a/pyplugins/apis/osi.py
+++ b/pyplugins/apis/osi.py
@@ -408,6 +408,66 @@ class OSI(Plugin):
         self.logger.debug(f"Retrieved {len(handles)} process handles")
         return handles
 
+    def get_all_procs(self) -> Generator[Any, None, List[Wrapper]]:
+        """
+        Retrieve full ``osi_proc`` records for every user process in one
+        kernel-side walk (``HYPER_OP_OSI_PROC_ALL``).
+
+        This is the bulk equivalent of calling :meth:`get_proc` for each pid
+        from :meth:`get_proc_handles`: the driver walks ``for_each_process``
+        under ``rcu_read_lock`` and returns the whole set (paginated), so a
+        process-tree snapshot costs ``ceil(N / procs-per-page)`` round-trips and
+        is internally consistent rather than torn across N separate reads. Names
+        come from ``task->comm`` (kernel memory only), so it is safe against
+        exiting contexts. Kernel threads are omitted (they have no ``mm``).
+
+        Returns
+        -------
+        List[Wrapper]
+            One wrapper per process, each carrying the ``osi_proc`` fields
+            (``pid``, ``ppid``, ``uid`` ...) plus a decoded ``.name`` (comm).
+        """
+        self.logger.debug("get_all_procs called")
+        all_procs: List[Wrapper] = []
+        skip = 0
+        header_size = kffi.sizeof("osi_result_header")
+        node_size = kffi.sizeof("osi_proc_node")
+
+        while True:
+            buf = yield PortalCmd(hop.HYPER_OP_OSI_PROC_ALL, skip, 0)
+            if not buf or len(buf) < header_size:
+                break
+
+            orh = kffi.from_buffer("osi_result_header", buf)
+            count = orh.result_count
+            total_count = orh.total_count
+            total_size = len(buf)
+
+            offset = header_size
+            page: List[Wrapper] = []
+            for i in range(count):
+                if offset + node_size > total_size:
+                    self.logger.error(
+                        f"get_all_procs: buffer short for node {i} at {offset}")
+                    break
+                nb = kffi.from_buffer(
+                    "osi_proc_node", buf, instance_offset_in_buffer=offset)
+                wrap = Wrapper(nb)
+                # comm is inlined in the struct (fixed 16 bytes, NUL-padded).
+                raw = bytes(nb.comm)
+                wrap.name = raw.split(b'\0', 1)[0].decode('latin-1', errors='replace')
+                page.append(wrap)
+                offset += node_size
+
+            all_procs.extend(page)
+            # Stop when this page was empty or we've collected everything.
+            if not page or len(all_procs) >= total_count:
+                break
+            skip += len(page)
+
+        self.logger.debug(f"get_all_procs retrieved {len(all_procs)} procs")
+        return all_procs
+
     def get_fds(self, pid: Optional[int] = None, start_fd: int = 0,
                 count: Optional[int] = None) -> Generator[Any, None, List[Wrapper]]:
         """

--- a/pyplugins/loggers/db.py
+++ b/pyplugins/loggers/db.py
@@ -35,6 +35,7 @@ Arguments
 """
 
 from sqlalchemy import create_engine, insert, inspect
+from sqlalchemy.orm import Session
 from os.path import join
 from pengutils.events import Base
 # Import the Base Event class for inheritance checks (aliased to avoid conflict with threading.Event)
@@ -74,6 +75,9 @@ class DB(Plugin):
         self.queued_events: list = []
         self.buffer_size: int = int(self.get_arg("bufsize") or 100000)
         self.queue_lock = Lock()
+        # Serializes actual flushes so the background worker and a synchronous
+        # flush() cannot run _perform_flush (and mutate id_counter) concurrently.
+        self.flush_lock = Lock()
         self.flush_event = Event()
         self.stop_event = Event()
         self.finished_worker = Event()
@@ -119,7 +123,33 @@ class DB(Plugin):
                 self.queued_events = []  # allocate new list
 
         if to_flush:
-            self._perform_flush(to_flush)
+            # Serialize with the background worker so id_counter / the write
+            # transaction are never touched by two threads at once.
+            with self.flush_lock:
+                self._perform_flush(to_flush)
+
+    def flush(self) -> None:
+        """Synchronously drain the queued events to the database.
+
+        Unlike setting ``flush_event`` (which only *signals* the worker), this
+        returns once the currently-queued events are written. Consumers that
+        read the DB back during teardown (e.g. the process-tree derived view)
+        must call this first, because plugins unload in reverse load order --
+        so a downstream plugin's ``uninit`` runs before this plugin's own final
+        flush. Safe to call from any thread; serialized via ``flush_lock``.
+        """
+        self._swap_and_flush()
+
+    def query(self, table_cls) -> list:
+        """Return all rows of ``table_cls`` as ORM objects.
+
+        Ensures the schema exists first (so querying a table that never
+        received a row yields ``[]`` instead of raising). Call :meth:`flush`
+        beforehand if you need events buffered during the run to be visible.
+        """
+        Base.metadata.create_all(self.engine)
+        with Session(self.engine) as session:
+            return list(session.query(table_cls).all())
 
     def _get_table_info(self, table_cls):
         """Cached introspection of table metadata"""

--- a/src/penguin/testing/harness.py
+++ b/src/penguin/testing/harness.py
@@ -307,10 +307,16 @@ def resolve_igloo_ko_isf(arch: str = _ISF_ARCH,
 
     Resolution order:
       1. ``PENGUIN_TEST_IGLOO_KO_ISF`` env var (explicit path).
-      2. The local cache (a prior download).
+      2. The local cache for *this exact version* (a prior download).
       3. Download ``igloo_driver.tar.gz`` for the Dockerfile-pinned
          ``IGLOO_DRIVER_VERSION`` (or ``version``) and extract the one ISF.
       4. The nix store (dev machines).
+
+    The cache is keyed by version (``.isf_cache/<version>/igloo.ko.<arch>...``),
+    not by arch alone: a stale ISF from an *earlier* pin must never satisfy a
+    lookup after ``IGLOO_DRIVER_VERSION`` is bumped, or a bump would be silently
+    masked (the test would run against the wrong ABI). A bump simply misses the
+    old cache entry and re-downloads.
 
     Returns None (rather than raising) when offline with nothing cached, so tests
     can ``skip`` cleanly.
@@ -319,12 +325,15 @@ def resolve_igloo_ko_isf(arch: str = _ISF_ARCH,
     if env and os.path.isfile(env):
         return env
 
+    version = version or _pinned_driver_version()
     member = f"kernels/{_ISF_KVER}/igloo.ko.{arch}.json.xz"
-    cache = os.path.join(_isf_cache_dir(), f"igloo.ko.{arch}.json.xz")
+    # Version-keyed cache path; "unpinned" bucket when the pin is unreadable so
+    # we still never collide with a real version's cache.
+    cache = os.path.join(_isf_cache_dir(), version or "unpinned",
+                         f"igloo.ko.{arch}.json.xz")
     if os.path.isfile(cache):
         return cache
 
-    version = version or _pinned_driver_version()
     if version:
         tag = "v" + version.lstrip("v")
         url = ("https://github.com/rehosting/igloo_driver/releases/download/"

--- a/src/penguin/testing/harness.py
+++ b/src/penguin/testing/harness.py
@@ -244,7 +244,7 @@ def drive(gen: Any, responses: Optional[List[Any]] = None,
 # and can't drift — the ISF is pinned to the driver release, not a checked-in
 # copy. See RealKffi / install_real_consts.
 #
-# The ISF is pulled for the exact IGLOO_DRIVER_VERSION pinned in the Dockerfile
+# The ISF is pulled for the exact igloo_driver release pinned in flake.nix
 # (not :latest), so host tests see the same enums the built image would.
 _ISF_ARCH = "armel"     # enums/most driver types are arch-invariant; one suffices
 _ISF_KVER = "6.13"      # kernel tree inside the driver tarball
@@ -280,18 +280,27 @@ class RealKffi:
 
 
 def _pinned_driver_version() -> Optional[str]:
-    """Read ``IGLOO_DRIVER_VERSION`` from the repo Dockerfile so the ISF pull is
-    pinned to the same release the image uses (not :latest). None if unreadable."""
+    """Read the igloo_driver release tag from ``flake.nix`` so the ISF pull is
+    pinned to the same release the image uses (not :latest). None if unreadable.
+
+    The pin used to live in a Dockerfile ``ARG IGLOO_DRIVER_VERSION``; the image
+    is now built solely from the flake, so ``inputs.igloo-driver.url`` is the one
+    place the version exists. Parsed from ``flake.nix`` rather than ``flake.lock``
+    because the lock records the resolved URL/narHash, and the tag in the URL is
+    what a human bumps.
+    """
     # harness.py -> testing/ -> penguin/ -> src/ -> repo root
-    dockerfile = os.path.join(
-        os.path.dirname(__file__), "..", "..", "..", "Dockerfile")
+    flake = os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "flake.nix")
     try:
-        with open(os.path.realpath(dockerfile)) as f:
+        with open(os.path.realpath(flake)) as f:
             text = f.read()
     except OSError:
         return None
     import re
-    m = re.search(r'^ARG\s+IGLOO_DRIVER_VERSION="?([^"\s]+)"?', text, re.M)
+    m = re.search(
+        r'github\.com/rehosting/igloo_driver/releases/download/'
+        r'v?([^/"\s]+)/igloo_driver\.tar\.gz', text)
     return m.group(1) if m else None
 
 
@@ -308,8 +317,8 @@ def resolve_igloo_ko_isf(arch: str = _ISF_ARCH,
     Resolution order:
       1. ``PENGUIN_TEST_IGLOO_KO_ISF`` env var (explicit path).
       2. The local cache for *this exact version* (a prior download).
-      3. Download ``igloo_driver.tar.gz`` for the Dockerfile-pinned
-         ``IGLOO_DRIVER_VERSION`` (or ``version``) and extract the one ISF.
+      3. Download ``igloo_driver.tar.gz`` for the flake.nix-pinned
+         igloo_driver release (or ``version``) and extract the one ISF.
       4. The nix store (dev machines).
 
     The cache is keyed by version (``.isf_cache/<version>/igloo.ko.<arch>...``),

--- a/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
+++ b/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
@@ -331,6 +331,31 @@ regress.
    get confidence the KVM path is wired without launching KVM or crossing the
    boundary. 1 xfail → 4 passing tests.
 
+## Cross-repo ABI tests that depend on an *unreleased* driver op
+
+`test_osi_bulk.py` covers `OSI.get_all_procs` (the bulk process walk behind
+`HYPER_OP_OSI_PROC_ALL`) against the **real** driver ISF. That op is added by
+igloo_driver #88; a host plugin that calls it is *incompatible with any pinned
+driver release that predates it*.
+
+**Rule (matches the "ISF is source of truth" doctrine in `docs/testing.md`):**
+such a test **FAILS, it does not skip**, when the pinned ISF lacks the op. A skip
+reads as green and would let host code that can't run against its own pinned
+driver merge silently. The failure is the forcing function — bump
+`IGLOO_DRIVER_VERSION` (Dockerfile) to a release carrying the op and the test
+goes green with no edit. See `_assert_pinned_driver_has_bulk_op`.
+
+- **Expected state on branch `workspace/proctree-ux` / PR #897:** these 2 tests
+  are **intentionally RED** until (a) a driver release is cut from igloo_driver
+  `main` (post-#88-merge) carrying the op and (b) #897 bumps the pin to it. Do
+  not "fix" them by reverting to a skip. As of the last check, released tags
+  (≤ v0.0.88) predate the op, so a new release must be cut first.
+- Only a *totally unresolvable* ISF (offline, nothing cached) skips — that is
+  genuinely untestable and distinct from "pinned driver predates the op".
+- We deliberately did **not** add a fake-enum "logic only" variant that always
+  runs (purist call): no checked-in/faked enum values, the real ISF stays the
+  single source of truth.
+
 ## Open questions
 
 - **Null-backend fidelity:** how far can identity decorators + test doubles go

--- a/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
+++ b/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
@@ -287,8 +287,8 @@ same path `apis.kffi` uses at runtime. No checked-in fixture: the ISF is the
 source of truth, pinned to the driver release, so it can't drift. The
 `igloo_ko_isf` pytest fixture (in `conftest.py`) resolves the ISF via
 `penguin.testing.resolve_igloo_ko_isf` — env `PENGUIN_TEST_IGLOO_KO_ISF` → local
-cache → **download `igloo_driver.tar.gz` for the Dockerfile-pinned
-`IGLOO_DRIVER_VERSION`** (not `:latest`) and extract one arch → nix store — and
+cache → **download `igloo_driver.tar.gz` for the flake.nix-pinned
+igloo_driver release** (not `:latest`) and extract one arch → nix store — and
 `skip`s cleanly when offline with nothing cached. The one enum absent from the
 driver ISF (`igloo_base_hypercalls`) is supplied by `RealKffi` as a single
 ABI-fixed constant. Enums/most driver types are arch-invariant, so one arch
@@ -342,7 +342,7 @@ driver release that predates it*.
 such a test **FAILS, it does not skip**, when the pinned ISF lacks the op. A skip
 reads as green and would let host code that can't run against its own pinned
 driver merge silently. The failure is the forcing function — bump
-`IGLOO_DRIVER_VERSION` (Dockerfile) to a release carrying the op and the test
+the `igloo-driver` pin (flake.nix) to a release carrying the op and the test
 goes green with no edit. See `_assert_pinned_driver_has_bulk_op`.
 
 - **Expected state on branch `workspace/proctree-ux` / PR #897:** these 2 tests

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 @pytest.fixture(scope="session")
 def igloo_ko_isf():
-    """Path to a real ``igloo.ko`` ISF for the Dockerfile-pinned driver release.
+    """Path to a real ``igloo.ko`` ISF for the flake.nix-pinned driver release.
 
     Resolves (and, if needed, downloads once to a local cache) via
     :func:`penguin.testing.resolve_igloo_ko_isf`; skips the test when offline with

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -60,3 +60,35 @@ def test_db_defaults_proc_id_when_missing(tmp_path):
 
     sess = _read_back(tmp_path)
     assert sess.query(Event).one().proc_id == 0
+
+
+def test_db_flush_then_query_is_visible(tmp_path):
+    """flush() drains buffered events synchronously so query() can read them
+    back mid-run -- the path the processes plugin uses at teardown."""
+    from pengutils.events import ProcStart, ProcExit
+    lp = load_pyplugin(str(DB), outdir=tmp_path)
+
+    lp.plugin.add_event(ProcStart, {"procname": "httpd", "proc_id": 400,
+                                    "pid": 400, "ppid": 1, "create_time": 200,
+                                    "comm": "httpd", "uid": 0, "gid": 0,
+                                    "euid": 0, "egid": 0})
+    lp.plugin.add_event(ProcExit, {"procname": "", "proc_id": 400, "pid": 400,
+                                   "create_time": 200, "code": 0,
+                                   "reason": "exit_group"})
+
+    lp.plugin.flush()  # synchronous drain
+    starts = lp.plugin.query(ProcStart)
+    exits = lp.plugin.query(ProcExit)
+    assert [s.pid for s in starts] == [400]
+    assert starts[0].ppid == 1 and starts[0].comm == "httpd"
+    assert [(e.pid, e.code, e.reason) for e in exits] == [(400, 0, "exit_group")]
+    lp.finalize()
+
+
+def test_db_query_empty_table_returns_list(tmp_path):
+    """query() of a table that never received a row yields [] (schema is
+    ensured), not an error."""
+    from pengutils.events import ProcExit
+    lp = load_pyplugin(str(DB), outdir=tmp_path)
+    assert lp.plugin.query(ProcExit) == []
+    lp.finalize()

--- a/tests/unit/test_exit_hook_abi.py
+++ b/tests/unit/test_exit_hook_abi.py
@@ -1,0 +1,52 @@
+"""ABI compatibility gate for the do_exit process-exit hook.
+
+``exit_monitor.py`` and ``processes.py`` (``use_do_exit``) arm the igloo_driver
+do_exit kprobe via ``HYPER_OP_REGISTER_EXIT_HOOK``, receive the
+``IGLOO_HYP_PROC_EXIT`` hypercall, and decode ``struct exit_event``. This asserts
+the *pinned* driver ISF carries all three. If it does not, penguin's host code is
+incompatible with the driver it ships against, so we FAIL loudly rather than
+``skip`` (a skip reads green and lets incompatible code merge). The failure is
+the forcing function: bump the ``igloo-driver`` pin (flake.nix) to a release
+carrying the do_exit hook and the test goes green with no edit here.
+
+Mirrors ``test_osi_bulk._assert_pinned_driver_has_bulk_op``. The ``igloo_ko_isf``
+fixture still skips cleanly when no ISF resolves at all (offline).
+"""
+from pathlib import Path
+
+from penguin.testing import RealKffi, load_pyplugin
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OSI = str(REPO_ROOT / "pyplugins" / "apis" / "osi.py")
+
+
+class _KFFI(RealKffi):
+    """Real dwarffi-backed kffi exposing ``sizeof`` for the struct check."""
+
+    def sizeof(self, type_name):
+        return self.ffi.sizeof(type_name)
+
+
+def test_pinned_driver_has_do_exit_hook(tmp_path, igloo_ko_isf):
+    # Bootstrap real hyper.consts + kffi against the pinned driver ISF (loading
+    # any plugin with real_isf wires plugins.kffi to it, as test_osi_bulk does).
+    kffi = _KFFI([igloo_ko_isf])
+    load_pyplugin(OSI, outdir=tmp_path, real_isf=igloo_ko_isf,
+                  doubles={"kffi": kffi})
+    import hyper.consts as consts
+
+    assert hasattr(consts.HYPER_OP, "HYPER_OP_REGISTER_EXIT_HOOK"), (
+        "pinned igloo_driver ISF lacks HYPER_OP_REGISTER_EXIT_HOOK: penguin's "
+        "exit_monitor cannot arm the do_exit hook against the pinned driver. "
+        "Bump the igloo-driver pin (flake.nix) to a release carrying the hook.")
+    assert hasattr(consts.igloo_hypercall_constants, "IGLOO_HYP_PROC_EXIT"), (
+        "pinned igloo_driver ISF lacks IGLOO_HYP_PROC_EXIT: bump the "
+        "igloo-driver pin to a release carrying the do_exit hook.")
+
+    try:
+        size = kffi.sizeof("exit_event")
+    except Exception:
+        size = 0
+    assert size > 0, (
+        "pinned igloo_driver ISF lacks struct exit_event: bump the "
+        "igloo-driver pin to a release carrying the do_exit hook.")

--- a/tests/unit/test_osi_bulk.py
+++ b/tests/unit/test_osi_bulk.py
@@ -1,0 +1,94 @@
+"""Real-ISF coverage for OSI.get_all_procs (the bulk process-tree walk behind
+HYPER_OP_OSI_PROC_ALL), driven host-side with no PANDA/guest.
+
+This is the host<->driver ABI contract test: we pack a portal response the way
+the driver's handle_op_osi_proc_all does (osi_result_header + a fixed-size
+osi_proc_node array with inline comm) and assert the plugin decodes it back to
+the right fields via the *real* driver ISF (dwarffi). It complements the pure
+join-logic tests in test_processes.py, which stub OSI entirely.
+
+Requires a driver ISF that actually carries the OSI_PROC_ALL op + osi_proc_node
+struct. The Dockerfile-pinned release predates this feature, so the test skips
+unless pointed (via PENGUIN_TEST_IGLOO_KO_ISF) at a driver build that has it;
+once the driver pin is bumped it runs in CI automatically.
+"""
+import struct
+from pathlib import Path
+
+import pytest
+
+from penguin.testing import RealKffi, drive, load_pyplugin
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OSI = str(REPO_ROOT / "pyplugins" / "apis" / "osi.py")
+
+
+class _KFFI(RealKffi):
+    """Real dwarffi-backed kffi exposing the sizeof/from_buffer that osi.py
+    uses (RealKffi itself only supplies enums)."""
+
+    def sizeof(self, type_name):
+        return self.ffi.sizeof(type_name)
+
+    def from_buffer(self, type_name, buf, instance_offset_in_buffer=0):
+        return self.ffi.from_buffer(type_name, bytearray(buf),
+                                    offset=instance_offset_in_buffer)
+
+
+def _node(pid, ppid, create_time, comm, uid=0, gid=0, euid=0, egid=0):
+    # struct osi_proc_node { u64 pid, ppid, create_time; u32 uid,gid,euid,egid;
+    #                        char comm[16]; }  -- little-endian, packed 56 bytes.
+    return struct.pack("<QQQIIII16s", pid, ppid, create_time,
+                       uid, gid, euid, egid, comm.encode())
+
+
+def _load(tmp_path, isf):
+    return load_pyplugin(OSI, outdir=tmp_path, real_isf=isf,
+                         doubles={"kffi": _KFFI([isf])})
+
+
+def _require_bulk_op(isf):
+    import hyper.consts as consts
+    if not hasattr(consts.HYPER_OP, "HYPER_OP_OSI_PROC_ALL"):
+        pytest.skip("driver ISF predates HYPER_OP_OSI_PROC_ALL; point "
+                    "PENGUIN_TEST_IGLOO_KO_ISF at a driver build that has it")
+    return consts
+
+
+def test_get_all_procs_decodes_real_node_layout(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf)
+    consts = _require_bulk_op(igloo_ko_isf)
+
+    # One page carrying the whole set (result_count == total_count == 2).
+    buf = (struct.pack("<QQ", 2, 2)
+           + _node(1, 0, 100, "init")
+           + _node(400, 1, 200, "httpd", uid=33))
+
+    procs, yielded = drive(lp.plugin.get_all_procs(), responses=[buf], collect=True)
+
+    # Right op issued, and the slim nodes decode to the right fields + comm.
+    assert yielded[0].op == consts.HYPER_OP.HYPER_OP_OSI_PROC_ALL
+    got = [(int(p.pid), int(p.ppid), int(p.create_time), int(p.uid), p.name)
+           for p in procs]
+    assert got == [(1, 0, 100, 0, "init"), (400, 1, 200, 33, "httpd")]
+
+
+def test_get_all_procs_paginates(tmp_path, igloo_ko_isf):
+    lp = _load(tmp_path, igloo_ko_isf)
+    consts = _require_bulk_op(igloo_ko_isf)
+
+    # total_count 3, but the first page returns only 2 -> host must ask again
+    # (skip=2) for the remainder.
+    page1 = struct.pack("<QQ", 2, 3) + _node(1, 0, 10, "init") + _node(2, 1, 20, "sh")
+    page2 = struct.pack("<QQ", 1, 3) + _node(3, 1, 30, "httpd")
+
+    procs, yielded = drive(lp.plugin.get_all_procs(),
+                           responses=[page1, page2], collect=True)
+
+    assert [c.op for c in yielded] == [
+        consts.HYPER_OP.HYPER_OP_OSI_PROC_ALL,
+        consts.HYPER_OP.HYPER_OP_OSI_PROC_ALL,
+    ]
+    # second request advanced skip past the first page
+    assert yielded[1].addr == 2
+    assert [int(p.pid) for p in procs] == [1, 2, 3]

--- a/tests/unit/test_osi_bulk.py
+++ b/tests/unit/test_osi_bulk.py
@@ -8,14 +8,15 @@ the right fields via the *real* driver ISF (dwarffi). It complements the pure
 join-logic tests in test_processes.py, which stub OSI entirely.
 
 Requires a driver ISF that actually carries the OSI_PROC_ALL op + osi_proc_node
-struct. The Dockerfile-pinned release predates this feature, so the test skips
-unless pointed (via PENGUIN_TEST_IGLOO_KO_ISF) at a driver build that has it;
-once the driver pin is bumped it runs in CI automatically.
+struct. This is a hard requirement, not an optional one: if the pinned driver
+lacks the op, penguin's get_all_procs is incompatible with the driver it ships
+against, so the test FAILS (it does not skip -- see
+_assert_pinned_driver_has_bulk_op). Bumping IGLOO_DRIVER_VERSION to a release
+carrying the op turns it green with no edit here. Only a totally unresolvable
+ISF (offline, nothing cached) skips, via the igloo_ko_isf fixture.
 """
 import struct
 from pathlib import Path
-
-import pytest
 
 from penguin.testing import RealKffi, drive, load_pyplugin
 
@@ -47,17 +48,34 @@ def _load(tmp_path, isf):
                          doubles={"kffi": _KFFI([isf])})
 
 
-def _require_bulk_op(isf):
+def _assert_pinned_driver_has_bulk_op(isf):
+    """The pinned igloo_driver ISF MUST carry HYPER_OP_OSI_PROC_ALL.
+
+    If it does not, penguin's OSI.get_all_procs is *incompatible with the driver
+    it ships against* -- ``hop.HYPER_OP_OSI_PROC_ALL`` would ``AttributeError``
+    at runtime. That is a real defect, not a "feature not built yet", so we FAIL
+    loudly rather than ``skip`` (a skip reads as green and let the incompatible
+    code merge). The failure is the forcing function: bump IGLOO_DRIVER_VERSION
+    to a release carrying the op (this is exactly what PR #897 does), and the
+    test goes green on its own with no edit here.
+
+    Note the *fixture* still skips cleanly when no ISF resolves at all (offline,
+    nothing cached) -- that is genuinely untestable, distinct from "ISF resolved
+    but the pinned driver predates the op", which is the incompatibility we fail
+    on.
+    """
     import hyper.consts as consts
-    if not hasattr(consts.HYPER_OP, "HYPER_OP_OSI_PROC_ALL"):
-        pytest.skip("driver ISF predates HYPER_OP_OSI_PROC_ALL; point "
-                    "PENGUIN_TEST_IGLOO_KO_ISF at a driver build that has it")
+    assert hasattr(consts.HYPER_OP, "HYPER_OP_OSI_PROC_ALL"), (
+        "pinned igloo_driver ISF lacks HYPER_OP_OSI_PROC_ALL: penguin's "
+        "OSI.get_all_procs cannot run against the pinned driver. Bump "
+        "IGLOO_DRIVER_VERSION (Dockerfile) to a release carrying the op -- "
+        "see PR #897.")
     return consts
 
 
 def test_get_all_procs_decodes_real_node_layout(tmp_path, igloo_ko_isf):
     lp = _load(tmp_path, igloo_ko_isf)
-    consts = _require_bulk_op(igloo_ko_isf)
+    consts = _assert_pinned_driver_has_bulk_op(igloo_ko_isf)
 
     # One page carrying the whole set (result_count == total_count == 2).
     buf = (struct.pack("<QQ", 2, 2)
@@ -75,7 +93,7 @@ def test_get_all_procs_decodes_real_node_layout(tmp_path, igloo_ko_isf):
 
 def test_get_all_procs_paginates(tmp_path, igloo_ko_isf):
     lp = _load(tmp_path, igloo_ko_isf)
-    consts = _require_bulk_op(igloo_ko_isf)
+    consts = _assert_pinned_driver_has_bulk_op(igloo_ko_isf)
 
     # total_count 3, but the first page returns only 2 -> host must ask again
     # (skip=2) for the remainder.

--- a/tests/unit/test_osi_bulk.py
+++ b/tests/unit/test_osi_bulk.py
@@ -11,7 +11,7 @@ Requires a driver ISF that actually carries the OSI_PROC_ALL op + osi_proc_node
 struct. This is a hard requirement, not an optional one: if the pinned driver
 lacks the op, penguin's get_all_procs is incompatible with the driver it ships
 against, so the test FAILS (it does not skip -- see
-_assert_pinned_driver_has_bulk_op). Bumping IGLOO_DRIVER_VERSION to a release
+_assert_pinned_driver_has_bulk_op). Bumping the igloo-driver pin to a release
 carrying the op turns it green with no edit here. Only a totally unresolvable
 ISF (offline, nothing cached) skips, via the igloo_ko_isf fixture.
 """
@@ -68,7 +68,7 @@ def _assert_pinned_driver_has_bulk_op(isf):
     assert hasattr(consts.HYPER_OP, "HYPER_OP_OSI_PROC_ALL"), (
         "pinned igloo_driver ISF lacks HYPER_OP_OSI_PROC_ALL: penguin's "
         "OSI.get_all_procs cannot run against the pinned driver. Bump "
-        "IGLOO_DRIVER_VERSION (Dockerfile) to a release carrying the op -- "
+        "the igloo-driver pin (flake.nix) to a release carrying the op -- "
         "see PR #897.")
     return consts
 

--- a/tests/unit/test_processes.py
+++ b/tests/unit/test_processes.py
@@ -1,0 +1,264 @@
+"""Host-side test of the processes plugin (pyplugins/analysis/processes.py)
+driven through the `penguin.testing` harness -- no PANDA, no guest, no per-arch
+boot.
+
+Three host-side surfaces are exercised:
+
+* **lifecycle -> event DB**: exec_event -> ProcStart, exit syscalls -> ProcExit.
+  We stub the DB plugin and assert the rows the plugin emits.
+* **derived artifact**: uninit() flushes + queries the DB and renders
+  system_map.yaml. We feed canned ProcStart/ProcExit rows through the DB stub
+  and assert the structured records + ASCII tree.
+* **live query API** (get/tree/snapshot): portal generators whose only guest
+  edge is plugins.OSI (get_proc / get_all_procs). Stubbed with a generator
+  double so the ppid-join logic is tested without a real portal.
+"""
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+from penguin.testing import load_pyplugin, drive
+from pengutils.events import ProcStart, ProcExit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROCESSES = REPO_ROOT / "pyplugins" / "analysis" / "processes.py"
+
+
+# --------------------------------------------------------------------------- #
+# Doubles
+# --------------------------------------------------------------------------- #
+def _proc(pid, ppid, create_time, name="", **extra):
+    """An osi_proc-shaped attribute holder (for get_proc / get_all_procs)."""
+    return SimpleNamespace(pid=pid, ppid=ppid, create_time=create_time,
+                           name=name, uid=extra.get("uid", 0),
+                           gid=extra.get("gid", 0), euid=extra.get("euid", 0),
+                           egid=extra.get("egid", 0))
+
+
+def _exec_event(pid, ppid, create_time, procname, argv, **kw):
+    return SimpleNamespace(
+        proc=_proc(pid, ppid, create_time, name=Path(procname).name, **kw),
+        procname=procname, argv=argv)
+
+
+def _syscall_evt(pid, create_time):
+    """The syscall-event arg the driver denormalizes identity into."""
+    return SimpleNamespace(pid=pid, create_time=create_time)
+
+
+class FakeOSI:
+    """Generator double for the OSI sibling used by the live query API."""
+
+    def __init__(self, procs):
+        self._procs = procs  # {pid -> osi_proc-shaped object}
+
+    def get_proc(self, pid=None):
+        yield from ()
+        return self._procs.get(pid)
+
+    def get_all_procs(self):
+        # Bulk kernel-side walk: every proc in one shot.
+        yield from ()
+        return [self._procs[p] for p in sorted(self._procs)]
+
+
+class FakeDB:
+    """Double for the DB logger plugin: records add_event calls and serves
+    canned rows back from query()."""
+
+    def __init__(self, rows=None):
+        self.events = []          # [(table_cls, data_dict)]
+        self._rows = rows or {}   # {table_cls: [row_obj, ...]}
+        self.flushed = 0
+
+    def add_event(self, table_cls, data):
+        self.events.append((table_cls, data))
+
+    def flush(self):
+        self.flushed += 1
+
+    def query(self, table_cls):
+        return self._rows.get(table_cls, [])
+
+    def rows(self, table_cls):
+        return [d for (c, d) in self.events if c is table_cls]
+
+
+def _start_row(rid, pid, ppid, create_time, name, comm=None, **ids):
+    return SimpleNamespace(id=rid, pid=pid, ppid=ppid, create_time=create_time,
+                           procname=name, comm=comm or name,
+                           uid=ids.get("uid", 0), gid=ids.get("gid", 0),
+                           euid=ids.get("euid", 0), egid=ids.get("egid", 0))
+
+
+def _exit_row(rid, pid, create_time, code, reason):
+    return SimpleNamespace(id=rid, pid=pid, create_time=create_time,
+                           code=code, reason=reason)
+
+
+def _load(tmp_path, db=None, osi=None, **args):
+    doubles = {"DB": db if db is not None else FakeDB()}
+    if osi is not None:
+        doubles["OSI"] = osi
+    return load_pyplugin(str(PROCESSES), outdir=tmp_path, args=args,
+                         doubles=doubles)
+
+
+# --------------------------------------------------------------------------- #
+# Lifecycle -> event DB
+# --------------------------------------------------------------------------- #
+def test_seed_map_written_on_init(tmp_path):
+    _load(tmp_path)
+    doc = yaml.safe_load((tmp_path / "system_map.yaml").read_text())
+    assert doc["schema_version"] == 1
+    assert doc["process_count"] == 0 and doc["processes"] == []
+    assert "no processes observed" in doc["tree"]
+
+
+def test_exec_event_emits_procstart(tmp_path):
+    db = FakeDB()
+    lp = _load(tmp_path, db=db)
+    assert "exec_event" in {ev for (_p, ev, _c) in lp.subscriptions}
+
+    lp.dispatch("exec_event", _exec_event(412, 1, 200, "/usr/sbin/httpd",
+                                          ["httpd", "-f", "/etc/httpd.conf"],
+                                          uid=33))
+    starts = db.rows(ProcStart)
+    assert len(starts) == 1
+    row = starts[0]
+    assert row["pid"] == 412 and row["ppid"] == 1
+    assert row["create_time"] == 200 and row["procname"] == "httpd"
+    assert row["uid"] == 33 and row["proc_id"] == 412
+
+
+def test_exit_group_emits_procexit(tmp_path):
+    db = FakeDB()
+    lp = _load(tmp_path, db=db)
+    lp.dispatch_syscall("exit_group", None, None, _syscall_evt(412, 200), 0)
+    exits = db.rows(ProcExit)
+    assert len(exits) == 1
+    assert exits[0] == {"proc_id": 412, "procname": "", "pid": 412,
+                        "create_time": 200, "code": 0, "reason": "exit_group"}
+
+
+def test_exit_without_pid_is_skipped(tmp_path):
+    # Older driver: syscall event lacks a denormalized pid -> nothing to record.
+    db = FakeDB()
+    lp = _load(tmp_path, db=db)
+    lp.dispatch_syscall("exit", None, None, SimpleNamespace(), 3)
+    assert db.rows(ProcExit) == []
+
+
+# --------------------------------------------------------------------------- #
+# Derived artifact: uninit() materializes system_map.yaml from the DB
+# --------------------------------------------------------------------------- #
+def test_uninit_materializes_map_from_db(tmp_path):
+    starts = [
+        _start_row(1, 1, 0, 100, "init"),
+        _start_row(2, 400, 1, 200, "httpd"),
+        _start_row(3, 517, 400, 300, "status.cgi"),
+        # re-exec of pid 400 identity (same create_time) -> exec_count 2
+        _start_row(4, 400, 1, 200, "httpd-worker"),
+    ]
+    exits = [_exit_row(5, 517, 300, 0, "exit_group")]
+    db = FakeDB(rows={ProcStart: starts, ProcExit: exits})
+    lp = _load(tmp_path, db=db)
+    lp.finalize()  # uninit(): flush + query + render
+
+    assert db.flushed >= 1  # flushed before querying
+    doc = yaml.safe_load((tmp_path / "system_map.yaml").read_text())
+    by_pid = {p["pid"]: p for p in doc["processes"]}
+    assert doc["process_count"] == 3
+    assert by_pid[400]["name"] == "httpd-worker"   # latest exec name wins
+    assert by_pid[400]["exec_count"] == 2
+    assert by_pid[517]["exit"] == {"code": 0, "reason": "exit_group"}
+
+    tree = doc["tree"]
+    lines = {ln.strip(): ln for ln in tree.splitlines()}
+    assert "init (1)" in lines
+    indent = {lbl: len(ln) - len(ln.lstrip()) for lbl, ln in lines.items()}
+    assert indent["init (1)"] == 0
+    assert indent["`- httpd-worker (400) [execs: 2]"] < \
+        indent["`- status.cgi (517) [exit: 0]"]
+
+
+# --------------------------------------------------------------------------- #
+# Live query API: get / tree / snapshot (ppid join over the bulk walk)
+# --------------------------------------------------------------------------- #
+def test_live_get_returns_flat_record(tmp_path):
+    osi = FakeOSI({412: _proc(412, 1, 200, name="httpd", uid=33)})
+    lp = _load(tmp_path, osi=osi)
+    rec = drive(lp.plugin.get(412))
+    assert rec == {"pid": 412, "ppid": 1, "name": "httpd", "create_time": 200,
+                   "start_time": 200, "uid": 33, "gid": 0, "euid": 0, "egid": 0}
+    assert drive(lp.plugin.get(9999)) is None
+
+
+def test_live_tree_joins_on_ppid(tmp_path):
+    osi = FakeOSI({
+        1: _proc(1, 0, 10, name="init"),
+        412: _proc(412, 1, 20, name="httpd"),
+        517: _proc(517, 412, 30, name="cgi"),
+        900: _proc(900, 1, 40, name="telnetd"),
+    })
+    lp = _load(tmp_path, osi=osi)
+    tree = drive(lp.plugin.tree())
+    assert [r["pid"] for r in tree["roots"]] == [1]
+    init = tree["roots"][0]
+    assert [c["pid"] for c in init["children"]] == [412, 900]
+    httpd = next(c for c in init["children"] if c["pid"] == 412)
+    assert [c["pid"] for c in httpd["children"]] == [517]
+
+
+def test_live_tree_orphan_becomes_root(tmp_path):
+    osi = FakeOSI({
+        412: _proc(412, 1, 20, name="httpd"),   # ppid 1 not present
+        517: _proc(517, 412, 30, name="cgi"),
+    })
+    lp = _load(tmp_path, osi=osi)
+    tree = drive(lp.plugin.tree())
+    assert [r["pid"] for r in tree["roots"]] == [412]
+    assert [c["pid"] for c in tree["roots"][0]["children"]] == [517]
+
+
+def test_live_snapshot_shape(tmp_path):
+    osi = FakeOSI({1: _proc(1, 0, 10, name="init"), 2: _proc(2, 1, 20, name="sh")})
+    lp = _load(tmp_path, osi=osi)
+    snap = drive(lp.plugin.snapshot())
+    assert [p["pid"] for p in snap["processes"]] == [1, 2]
+    assert [r["pid"] for r in snap["tree"]["roots"]] == [1]
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+def _helpers(tmp_path):
+    lp = _load(tmp_path)
+    g = type(lp.plugin).tree.__globals__
+    return g["_genealogy_from_rows"], g["_build_tree"]
+
+
+def test_genealogy_resolves_parent_and_exit(tmp_path):
+    _genealogy_from_rows, _ = _helpers(tmp_path)
+    starts = [
+        _start_row(1, 1, 0, 100, "init"),
+        _start_row(2, 50, 1, 200, "sh"),
+        _start_row(3, 50, 1, 200, "busybox"),   # re-exec, same identity
+    ]
+    exits = [_exit_row(4, 50, 0, 7, "exit")]     # create_time 0 -> pid fallback
+    procs = _genealogy_from_rows(starts, exits)
+    assert procs[(50, 200)]["exec_count"] == 2
+    assert procs[(50, 200)]["name"] == "busybox"
+    assert procs[(50, 200)]["parent_create_time"] == 100  # under init
+    assert procs[(50, 200)]["exit"] == {"code": 7, "reason": "exit"}
+
+
+def test_build_tree_breaks_cycles(tmp_path):
+    _, _build_tree = _helpers(tmp_path)
+    records = {
+        5: {"pid": 5, "ppid": 6, "name": "a"},
+        6: {"pid": 6, "ppid": 5, "name": "b"},
+    }
+    tree = _build_tree(records)
+    assert {r["pid"] for r in tree["roots"]} == {5, 6}

--- a/tests/unit/test_processes.py
+++ b/tests/unit/test_processes.py
@@ -150,6 +150,97 @@ def test_exit_without_pid_is_skipped(tmp_path):
     assert db.rows(ProcExit) == []
 
 
+def _sig_evt(sig, pid, drop=False):
+    return SimpleNamespace(sig=sig, pid=pid, drop=drop)
+
+
+def _exit_evt(pid, create_time, signaled, termsig=0, exit_status=0):
+    """An exit_event-shaped holder (do_exit kprobe path)."""
+    return SimpleNamespace(pid=pid, create_time=create_time, signaled=signaled,
+                           termsig=termsig, exit_status=exit_status)
+
+
+def test_do_exit_normal_exit_emits_procexit(tmp_path):
+    # With the do_exit hook active, a normal exit is recorded from the kprobe
+    # event (real status), and the exit/exit_group syscall hooks stand down.
+    db = FakeDB()
+    lp = _load(tmp_path, db=db, use_do_exit=True)
+    lp.plugin.on_proc_exit(None, _exit_evt(412, 200, signaled=False,
+                                           exit_status=7))
+    exits = db.rows(ProcExit)
+    assert len(exits) == 1
+    assert exits[0] == {"proc_id": 412, "procname": "", "pid": 412,
+                        "create_time": 200, "code": 7, "reason": "exit"}
+
+
+def test_do_exit_signal_death_emits_procexit(tmp_path):
+    # A fatal signal death is captured by the same hook with the real code --
+    # no signal heuristic needed. (signals is stubbed, so the name falls back to
+    # the number; on silicon it resolves to e.g. SIGSEGV.)
+    db = FakeDB()
+    lp = _load(tmp_path, db=db, use_do_exit=True)
+    lp.plugin.on_proc_exit(None, _exit_evt(412, 200, signaled=True, termsig=11))
+    exits = db.rows(ProcExit)
+    assert len(exits) == 1
+    assert exits[0] == {"proc_id": 412, "procname": "", "pid": 412,
+                        "create_time": 200, "code": 128 + 11,
+                        "reason": "signal:11"}
+
+
+def test_do_exit_supersedes_syscall_hooks(tmp_path):
+    # When use_do_exit is set, the exit/exit_group syscall hooks are not even
+    # registered (do_exit owns exits) -- so dispatch finds no hook. This proves
+    # we don't pay a redundant per-exit hook firing, not merely that it no-ops.
+    import pytest
+    lp = _load(tmp_path, use_do_exit=True)
+    with pytest.raises(KeyError):
+        lp.dispatch_syscall("exit_group", None, None, _syscall_evt(412, 200), 0)
+    with pytest.raises(KeyError):
+        lp.dispatch_syscall("exit", None, None, _syscall_evt(412, 200), 0)
+
+
+def test_syscall_exit_hooks_registered_by_default(tmp_path):
+    # With the default (do_exit off) the syscall exit hooks ARE registered.
+    db = FakeDB()
+    lp = _load(tmp_path, db=db)  # use_do_exit defaults False
+    lp.dispatch_syscall("exit_group", None, None, _syscall_evt(412, 200), 0)
+    assert len(db.rows(ProcExit)) == 1
+
+
+def test_fatal_signal_emits_procexit(tmp_path):
+    # A process killed by a fatal signal never calls exit/exit_group; the signal
+    # monitor path must still close it out. (signals is stubbed in the harness,
+    # so populate the watched set directly.)
+    db = FakeDB()
+    lp = _load(tmp_path, db=db)
+    lp.plugin._fatal_signums = {11: "SIGSEGV"}
+    # create_time is learned at exec, so the ProcExit pairs by (pid, create_time)
+    lp.dispatch("exec_event", _exec_event(412, 1, 200, "/hard/faulter",
+                                          ["faulter"]))
+    lp.plugin.on_signal_deliver(None, _sig_evt(11, 412))
+    exits = db.rows(ProcExit)
+    assert len(exits) == 1
+    assert exits[0] == {"proc_id": 412, "procname": "", "pid": 412,
+                        "create_time": 200, "code": 128 + 11,
+                        "reason": "signal:SIGSEGV"}
+
+
+def test_fatal_signal_deduped_and_drop_skipped(tmp_path):
+    db = FakeDB()
+    lp = _load(tmp_path, db=db)
+    lp.plugin._fatal_signums = {11: "SIGSEGV"}
+    # a dropped delivery (another plugin bypassed it) is not a death
+    lp.plugin.on_signal_deliver(None, _sig_evt(11, 500, drop=True))
+    assert db.rows(ProcExit) == []
+    # a non-watched signal is ignored
+    lp.plugin.on_signal_deliver(None, _sig_evt(2, 500))
+    assert db.rows(ProcExit) == []
+    # first fatal delivery records; a second for the same pid is deduped
+    lp.plugin.on_signal_deliver(None, _sig_evt(11, 500))
+    lp.plugin.on_signal_deliver(None, _sig_evt(11, 500))
+    assert len(db.rows(ProcExit)) == 1
+
+
 # --------------------------------------------------------------------------- #
 # Derived artifact: uninit() materializes system_map.yaml from the DB
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_real_consts.py
+++ b/tests/unit/test_real_consts.py
@@ -2,7 +2,7 @@
 ``real_isf=``).
 
 Instead of a checked-in fixture, the harness loads the *real* published driver
-ISF (``igloo.ko.<arch>.json.xz`` for the Dockerfile-pinned ``IGLOO_DRIVER_VERSION``)
+ISF (``igloo.ko.<arch>.json.xz`` for the flake.nix-pinned igloo_driver release)
 through ``dwarffi`` — the same artifact ``apis.kffi`` reads at runtime. This
 exercises ``dwarffi`` for real, exposes the whole driver type universe (not just
 seven enums), and can't drift: the ISF is pinned to the release, not a copy in the


### PR DESCRIPTION
## What

Slice 1 of the "system cartography" epic (epic B): a genuinely usable way for both **users** and the **MCP agent** to engage with the guest's **process tree**. Inspired by #699 (Proctree) but a cleaner, DB-backed design.

### Two surfaces

**AI / MCP** — stable, documented, JSON-serializable live query API (portal generators, `yield from`):
- `processes.get(pid)` → flat record or `None`
- `processes.tree()` → `{"roots": [node, …]}` (nested)
- `processes.snapshot()` → `{"processes": […], "tree": {…}}`

These read the whole process set in **one** kernel-side bulk walk (`osi.get_all_procs` → `HYPER_OP_OSI_PROC_ALL`) — one RCU-consistent snapshot instead of `1 + N` per-pid `get_proc` reads that could tear.

**Users** — a legible artifact. Lifecycle is recorded to the event DB and `system_map.yaml` is materialized at teardown: structured per-process records plus an embedded ASCII tree.

```
schema_version: 1
generated_by: processes
process_count: 72
processes: [{pid, ppid, name, create_time, uid…, exec_count, exit}, …]
tree: |
  init (1)
  `- httpd (400)
     `- status.cgi (517)  [exit: 0]
```

### Persistence (DB-backed)
- `exec_event` → `ProcStart` (identity/genealogy: pid, ppid, create_time, comm, ids). argv/env stay on the existing `Exec` event.
- `exit` / `exit_group` → `ProcExit`. Identity comes off `syscall.pid` / `syscall.create_time` (denormalized by the driver) — **zero portal round-trips, no read of the dying task**.
- `system_map.yaml` = `ProcStart LEFT JOIN ProcExit` on `(pid, create_time)`, re-exec coalesced. Because plugins unload in reverse load order (this plugin's `uninit` runs before the DB's final flush), teardown calls a new synchronous `DB.flush()` then `DB.query()`.

### Supporting changes
- `osi.get_all_procs()` — paginated decode of the slim `osi_proc_node` array.
- `pengutils.events` — lean `ProcStart` / `ProcExit`.
- `loggers/db.py` — synchronous `flush()` + `query()`.

### Driver-side safety
Live walk + exit path touch only kernel `task_struct` (`comm`, skip `!mm`); never `access_remote_vm` on userspace, so nothing faults on an exiting/stopped context.

## Tests (host-side, `penguin.testing`; no PANDA/guest)
- `tests/unit/test_processes.py` — event→DB emission, DB→render, live tree/get/snapshot join (via doubles).
- `tests/unit/test_osi_bulk.py` — real-ISF ABI roundtrip of `get_all_procs` (skips unless pointed at a driver build carrying the op).
- `tests/unit/test_db.py` — `flush()` / `query()`.

Full `tests/unit` suite green.

## Live validation
Booted an armel/6.13 guest with the driver from rehosting/igloo_driver#88: `system_map.yaml` captured 72 real processes with correct genealogy, re-exec, and exit codes (proving the `syscall_event.pid` path), and a probe exercised `get_all_procs`/`snapshot()` live through `HYPER_OP_OSI_PROC_ALL`.

## Dependency
Requires **rehosting/igloo_driver#88** (`HYPER_OP_OSI_PROC_ALL` + `syscall_event.pid`). The live query API needs that driver; the DB-backed `system_map.yaml` works today. Follow-up: bump `IGLOO_DRIVER_VERSION` once #88 is released (then `test_osi_bulk` runs unskipped in CI).

## Scope / follow-ons
Slice 1 only. Deferred: thread/kernel-thread enumeration, fd/peer graph, maps/lib inventory, CPU/scheduling, `get_ptregs`.