### PR TITLE
Add `run_on_bind` plugin for bind-triggered command execution

### DIFF
--- a/pyplugins/actuation/fetch_web.py
+++ b/pyplugins/actuation/fetch_web.py
@@ -295,17 +295,13 @@ class FetchWeb(Plugin):
                             check=False,
                             cwd=cwd,
                         )
-                        self.logger.info(
-                            f"Host command output:\n{
-                                result.stdout}")
+                        self.logger.info(f"Host command output:\n{result.stdout}")
                         if result.stderr:
                             self.logger.warning(
                                 f"Host command stderr:\n{result.stderr}"
                             )
                         if result.returncode != 0:
-                            self.logger.warning(
-                                f"Host command failed with code {
-                                    result.returncode}")
+                            self.logger.warning(f"Host command failed with code {result.returncode}")
                             overall_success = False
                     except Exception as exc:
                         import traceback

--- a/pyplugins/actuation/fetch_web.py
+++ b/pyplugins/actuation/fetch_web.py
@@ -93,20 +93,20 @@ def calculate_entropy(buffer: bytes) -> float:
 class FetchWeb(Plugin):
     class Args(PluginArgs):
         fetch_delay: Optional[int] = Field(
-            default=None, description="Seconds to wait before fetching a newly bound web service. Defaults to 20 when unset."
-        )
+            default=None,
+            description="Seconds to wait before fetching a newly bound web service. Defaults to 20 when unset.")
         shutdown_after_www: bool = Field(
-            default=False, description="If true, shut down emulation after a successful web fetch."
-        )
+            default=False,
+            description="If true, shut down emulation after a successful web fetch.")
         shutdown_on_failure: bool = Field(
-            default=False, description="If true, shut down emulation if no responsive servers are found."
-        )
+            default=False,
+            description="If true, shut down emulation if no responsive servers are found.")
         shutdown_after_cmd: bool = Field(
-            default=False, description="If true, shut down emulation after cmd_on_bind commands complete."
-        )
+            default=False,
+            description="If true, shut down emulation after cmd_on_bind commands complete.")
         cmd_on_bind: Optional[Any] = Field(
-            default=None, description="Command(s) to run after bind. Supports string, list, or structured format with mode (host/guest)."
-        )
+            default=None,
+            description="Command(s) to run after bind. Supports string, list, or structured format with mode (host/guest).")
 
     def __init__(self) -> None:
         """
@@ -122,7 +122,9 @@ class FetchWeb(Plugin):
 
         if self.cmd_on_bind is not None:
             # Check if it's list of dicts with mode/cmd
-            if isinstance(self.cmd_on_bind, list) and len(self.cmd_on_bind) > 0:
+            if isinstance(
+                    self.cmd_on_bind, list) and len(
+                    self.cmd_on_bind) > 0:
                 if isinstance(self.cmd_on_bind[0], dict):
                     self.cmd_on_bind_structured = self.cmd_on_bind
                     self.logger.info(
@@ -145,13 +147,14 @@ class FetchWeb(Plugin):
 
             # Guest-cmd must be enabled if any guest commands exist
             has_guest_cmds = any(
-                entry.get("mode") == "guest" for entry in self.cmd_on_bind_structured
-            )
-            if has_guest_cmds and not self.get_arg("conf")["core"]["guest_cmd"]:
+                entry.get("mode") == "guest" for entry in self.cmd_on_bind_structured)
+            if has_guest_cmds and not self.get_arg(
+                    "conf")["core"]["guest_cmd"]:
                 self.logger.error(
                     "cmd_on_bind with guest mode requires guest_cmd: true in config.yaml"
                 )
-                raise ValueError("guest_cmd must be enabled for guest mode commands")
+                raise ValueError(
+                    "guest_cmd must be enabled for guest mode commands")
         else:
             self.cmd_on_bind_structured = []
 
@@ -193,19 +196,21 @@ class FetchWeb(Plugin):
         if self.shutting_down or proto != "tcp" or guest_port not in [80, 443]:
             return
 
-        # Only trigger cmd_on_bind for 0.0.0.0 to avoid running commands multiple times
+        # Only trigger cmd_on_bind for 0.0.0.0 to avoid running commands
+        # multiple times
         if self.cmd_on_bind_structured and guest_ip == "0.0.0.0":
             self.logger.info(
-                f"Bind detected on {guest_ip}:{guest_port}, spawning cmd_on_bind thread"
-            )
+                f"Bind detected on {guest_ip}:{guest_port}, spawning cmd_on_bind thread")
             t = threading.Thread(
                 target=self._delayed_bind_workflow, args=(guest_ip, guest_port)
             )
             t.daemon = True
             t.start()
 
-        log_file_name = os.path.join(self.outdir, f"web_{guest_ip}_{guest_port}")
-        self.task_queue.put((guest_ip, host_ip, guest_port, host_port, log_file_name))
+        log_file_name = os.path.join(
+            self.outdir, f"web_{guest_ip}_{guest_port}")
+        self.task_queue.put(
+            (guest_ip, host_ip, guest_port, host_port, log_file_name))
 
     def worker(self) -> None:
         """
@@ -239,8 +244,7 @@ class FetchWeb(Plugin):
             self.shutting_down = True
             timestamp = f"{(time.time() - self.start_time):.02f}s"
             self.logger.info(
-                f"Shutting down after fetching {guest_ip}:{guest_port} ({timestamp} after boot)"
-            )
+                f"Shutting down after fetching {guest_ip}:{guest_port} ({timestamp} after boot)")
             self.panda.end_analysis()
 
     def _run_on_bind_command(self) -> bool:
@@ -265,12 +269,15 @@ class FetchWeb(Plugin):
                     self.logger.info(f"Running HOST command: {cmd}")
                     try:
                         # Split the command string into a list for subprocess
-                        cmd_list = shlex.split(cmd) if isinstance(cmd, str) else cmd
+                        cmd_list = shlex.split(
+                            cmd) if isinstance(cmd, str) else cmd
 
                         # Determine working directory for host mode
                         if self.outdir:
-                            cwd = os.path.abspath(os.path.join(self.outdir, "../.."))
-                            self.logger.info(f"Derived project root from outdir: {cwd}")
+                            cwd = os.path.abspath(
+                                os.path.join(self.outdir, "../.."))
+                            self.logger.info(
+                                f"Derived project root from outdir: {cwd}")
                             if not os.path.isdir(cwd):
                                 self.logger.warning(
                                     f"Project root does not exist: {cwd}"
@@ -288,26 +295,32 @@ class FetchWeb(Plugin):
                             check=False,
                             cwd=cwd,
                         )
-                        self.logger.info(f"Host command output:\n{result.stdout}")
+                        self.logger.info(
+                            f"Host command output:\n{
+                                result.stdout}")
                         if result.stderr:
                             self.logger.warning(
                                 f"Host command stderr:\n{result.stderr}"
                             )
                         if result.returncode != 0:
                             self.logger.warning(
-                                f"Host command failed with code {result.returncode}"
-                            )
+                                f"Host command failed with code {
+                                    result.returncode}")
                             overall_success = False
                     except Exception as exc:
                         import traceback
 
-                        self.logger.warning(f"Host command execution error: {exc}")
-                        self.logger.warning(f"Traceback:\n{traceback.format_exc()}")
+                        self.logger.warning(
+                            f"Host command execution error: {exc}")
+                        self.logger.warning(
+                            f"Traceback:\n{
+                                traceback.format_exc()}")
                         overall_success = False
 
                 elif mode == "guest":
                     # Run in guest via guest_cmd.py wrapper
-                    # Pass the command as a single string to guest_cmd.py, don't split it
+                    # Pass the command as a single string to guest_cmd.py,
+                    # don't split it
                     full_cmd = [
                         "python3",
                         "/igloo_static/guesthopper/guest_cmd.py",
@@ -321,31 +334,36 @@ class FetchWeb(Plugin):
                             text=True,
                             check=False,
                         )
-                        self.logger.info(f"Guest command output:\n{result.stdout}")
+                        self.logger.info(
+                            f"Guest command output:\n{
+                                result.stdout}")
                         if result.stderr:
                             self.logger.warning(
                                 f"Guest command stderr:\n{result.stderr}"
                             )
                         if result.returncode != 0:
                             self.logger.warning(
-                                f"Guest command failed with code {result.returncode}"
-                            )
+                                f"Guest command failed with code {
+                                    result.returncode}")
                             overall_success = False
-                        
+
                         # Append guest command output to a single file
-                        output_file = os.path.join(self.outdir, "guest_commands_output.txt")
+                        output_file = os.path.join(
+                            self.outdir, "guest_commands_output.txt")
                         with open(output_file, 'a') as f:
-                            f.write(f"\n{'='*60}\n")
+                            f.write(f"\n{'=' * 60}\n")
                             f.write(f"Command: {cmd}\n")
                             f.write(f"Return code: {result.returncode}\n")
-                            f.write(f"{'='*60}\n")
+                            f.write(f"{'=' * 60}\n")
                             f.write(f"STDOUT:\n{result.stdout}\n")
                             if result.stderr:
                                 f.write(f"STDERR:\n{result.stderr}\n")
-                        self.logger.info(f"Guest command output appended to: {output_file}")
-                        
+                        self.logger.info(
+                            f"Guest command output appended to: {output_file}")
+
                     except Exception as exc:
-                        self.logger.warning(f"Guest command execution error: {exc}")
+                        self.logger.warning(
+                            f"Guest command execution error: {exc}")
                         overall_success = False
                 else:
                     self.logger.error(
@@ -357,8 +375,11 @@ class FetchWeb(Plugin):
 
     def _delayed_bind_workflow(self, guest_ip: str, guest_port: int) -> None:
         """Execute cmd_on_bind commands after a delay"""
-        self.logger.info(f"cmd_on_bind thread started for {guest_ip}:{guest_port}")
-        self.logger.info(f"Sleeping {self.fetch_delay}s before running commands")
+        self.logger.info(
+            f"cmd_on_bind thread started for {guest_ip}:{guest_port}")
+        self.logger.info(
+            f"Sleeping {
+                self.fetch_delay}s before running commands")
 
         time.sleep(self.fetch_delay)
 
@@ -417,14 +438,14 @@ class FetchWeb(Plugin):
             return False
         except subprocess.TimeoutExpired:
             self.logger.warning(
-                f"{timestamp}: No response to wget for {host_ip}:{host_port} after 30s"
-            )
+                f"{timestamp}: No response to wget for {host_ip}:{host_port} after 30s")
             return False
 
         with open(log_file_name, "rb") as f:
             buffer = f.read()
             entropy = calculate_entropy(buffer)
             self.logger.info(
-                f"Service on {guest_ip}:{guest_port} responds with {len(buffer)} bytes, entropy {entropy:.02f}"
-            )
+                f"Service on {guest_ip}:{guest_port} responds with {
+                    len(buffer)} bytes, entropy {
+                    entropy:.02f}")
         return True

--- a/pyplugins/actuation/fetch_web.py
+++ b/pyplugins/actuation/fetch_web.py
@@ -18,6 +18,33 @@ Arguments
 - outdir (str): Output directory for storing fetched web content.
 - shutdown_after_www (bool, optional): If True, shut down emulation after a successful fetch.
 - shutdown_on_failure (bool, optional): If True, shut down emulation if no responsive servers are found.
+- shutdown_after_cmd (bool, optional): If True, shut down emulation after cmd_on_bind commands complete.
+- fetch_delay (int, optional): Delay in seconds before fetching/running commands after bind. Default: 20.
+- cmd_on_bind (str, list, or dict, optional): Command(s) to run after bind-triggered fetch.
+    Supports three formats:
+
+    1. Single string (runs in guest mode by default):
+        cmd_on_bind: python3 example.py
+
+    2. List of strings (runs in guest mode by default):
+        cmd_on_bind:
+            - python3 analyze.py
+            - python3 report.py
+
+    3. Structured format with explicit mode specification:
+        cmd_on_bind:
+            - mode: host
+              cmd:
+                  - python3 ./exploit.py
+            - mode: guest
+              cmd:
+                  - echo "test" > /tmp/test.txt
+
+    Mode options:
+        - host: Run command on the host system (inside container, working directory is project root)
+        - guest: Run command inside the emulated guest system via guest_cmd.py (DEFAULT)
+
+    Note: If mode is not specified, defaults to 'guest'. Guest mode requires guest_cmd: true in config.yaml core settings.
 
 Plugin Interface
 ----------------
@@ -39,9 +66,10 @@ import queue
 from collections import Counter
 import math
 import time
-from typing import Optional
+from typing import Optional, Any
 from pydantic import Field
 from penguin import plugins, Plugin, PluginArgs
+import shlex
 
 
 def calculate_entropy(buffer: bytes) -> float:
@@ -55,7 +83,10 @@ def calculate_entropy(buffer: bytes) -> float:
     """
     byte_counts = Counter(buffer)
     total_bytes = len(buffer)
-    entropy = -sum((count / total_bytes) * math.log2(count / total_bytes) for count in byte_counts.values())
+    entropy = -sum(
+        (count / total_bytes) * math.log2(count / total_bytes)
+        for count in byte_counts.values()
+    )
     return entropy
 
 
@@ -70,6 +101,12 @@ class FetchWeb(Plugin):
         shutdown_on_failure: bool = Field(
             default=False, description="If true, shut down emulation if no responsive servers are found."
         )
+        shutdown_after_cmd: bool = Field(
+            default=False, description="If true, shut down emulation after cmd_on_bind commands complete."
+        )
+        cmd_on_bind: Optional[Any] = Field(
+            default=None, description="Command(s) to run after bind. Supports string, list, or structured format with mode (host/guest)."
+        )
 
     def __init__(self) -> None:
         """
@@ -78,7 +115,47 @@ class FetchWeb(Plugin):
         self.outdir = self.get_arg("outdir")
         self.shutdown_after_www = self.get_arg_bool("shutdown_after_www")
         self.shutdown_on_failure = self.get_arg_bool("shutdown_on_failure")
-        if (delay := self.get_arg("fetch_delay")):
+        self.shutdown_after_cmd = self.get_arg_bool("shutdown_after_cmd")
+
+        # Parse cmd_on_bind properly
+        self.cmd_on_bind = self.get_arg("cmd_on_bind")
+
+        if self.cmd_on_bind is not None:
+            # Check if it's list of dicts with mode/cmd
+            if isinstance(self.cmd_on_bind, list) and len(self.cmd_on_bind) > 0:
+                if isinstance(self.cmd_on_bind[0], dict):
+                    self.cmd_on_bind_structured = self.cmd_on_bind
+                    self.logger.info(
+                        "Using structured cmd_on_bind with mode specification"
+                    )
+                else:
+                    # List of strings (backward compatibility)
+                    self.cmd_on_bind_structured = [
+                        {"mode": "guest", "cmd": [str(c)]} for c in self.cmd_on_bind
+                    ]
+                    self.logger.info("Converting legacy cmd_on_bind format")
+            elif isinstance(self.cmd_on_bind, str):
+                # Single string command (backward compatibility)
+                self.cmd_on_bind_structured = [
+                    {"mode": "guest", "cmd": [str(self.cmd_on_bind)]}
+                ]
+                self.logger.info("Converting single string cmd_on_bind")
+            else:
+                self.cmd_on_bind_structured = []
+
+            # Guest-cmd must be enabled if any guest commands exist
+            has_guest_cmds = any(
+                entry.get("mode") == "guest" for entry in self.cmd_on_bind_structured
+            )
+            if has_guest_cmds and not self.get_arg("conf")["core"]["guest_cmd"]:
+                self.logger.error(
+                    "cmd_on_bind with guest mode requires guest_cmd: true in config.yaml"
+                )
+                raise ValueError("guest_cmd must be enabled for guest mode commands")
+        else:
+            self.cmd_on_bind_structured = []
+
+        if delay := self.get_arg("fetch_delay"):
             self.fetch_delay = int(delay)
             self.logger.info(f"Fetch delay set to {self.fetch_delay} seconds")
         else:
@@ -92,7 +169,15 @@ class FetchWeb(Plugin):
         self.worker_thread.start()
         self.start_time = time.time()
 
-    def fetchweb_on_bind(self, proto: str, guest_ip: str, guest_port: int, host_port: int, host_ip: str, procname: str) -> None:
+    def fetchweb_on_bind(
+        self,
+        proto: str,
+        guest_ip: str,
+        guest_port: int,
+        host_port: int,
+        host_ip: str,
+        procname: str,
+    ) -> None:
         """
         Handle a new bind event from the VPN plugin and enqueue a fetch task for web ports.
 
@@ -104,11 +189,20 @@ class FetchWeb(Plugin):
             host_ip (str): Host IP address.
             procname (str): Name of the process binding the port.
         """
-        """
-        There was a bind - if it's a web port (80, 443), enqueue the task for fetching the page.
-        """
+
         if self.shutting_down or proto != "tcp" or guest_port not in [80, 443]:
             return
+
+        # Only trigger cmd_on_bind for 0.0.0.0 to avoid running commands multiple times
+        if self.cmd_on_bind_structured and guest_ip == "0.0.0.0":
+            self.logger.info(
+                f"Bind detected on {guest_ip}:{guest_port}, spawning cmd_on_bind thread"
+            )
+            t = threading.Thread(
+                target=self._delayed_bind_workflow, args=(guest_ip, guest_port)
+            )
+            t.daemon = True
+            t.start()
 
         log_file_name = os.path.join(self.outdir, f"web_{guest_ip}_{guest_port}")
         self.task_queue.put((guest_ip, host_ip, guest_port, host_port, log_file_name))
@@ -122,8 +216,12 @@ class FetchWeb(Plugin):
         while not self.shutting_down:
             try:
                 # Wait for a task, sleeping 5s between every check
-                guest_ip, host_ip, guest_port, host_port, log_file_name = self.task_queue.get(timeout=5)
-                success = self.fetch(guest_ip, host_ip, guest_port, host_port, log_file_name)
+                guest_ip, host_ip, guest_port, host_port, log_file_name = (
+                    self.task_queue.get(timeout=5)
+                )
+                success = self.fetch(
+                    guest_ip, host_ip, guest_port, host_port, log_file_name
+                )
                 self.task_queue.task_done()
                 first = True
 
@@ -140,10 +238,149 @@ class FetchWeb(Plugin):
         if self.shutdown_after_www or self.shutdown_on_failure:
             self.shutting_down = True
             timestamp = f"{(time.time() - self.start_time):.02f}s"
-            self.logger.info(f"Shutting down after fetching {guest_ip}:{guest_port} ({timestamp} after boot)")
+            self.logger.info(
+                f"Shutting down after fetching {guest_ip}:{guest_port} ({timestamp} after boot)"
+            )
             self.panda.end_analysis()
 
-    def fetch(self, guest_ip: str, host_ip: str, guest_port: int, host_port: int, log_file_name: str) -> bool:
+    def _run_on_bind_command(self) -> bool:
+        """Execute the commands supplied via cmd_on_bind.
+
+        Returns:
+            bool: True if all commands succeeded, False otherwise.
+        """
+        overall_success = True
+
+        for entry in self.cmd_on_bind_structured:
+            mode = entry.get("mode", "guest")
+            cmds = entry.get("cmd", [])
+
+            # Normalize to list if single command
+            if isinstance(cmds, str):
+                cmds = [cmds]
+
+            for cmd in cmds:
+                if mode == "host":
+                    # Run on host directly
+                    self.logger.info(f"Running HOST command: {cmd}")
+                    try:
+                        # Split the command string into a list for subprocess
+                        cmd_list = shlex.split(cmd) if isinstance(cmd, str) else cmd
+
+                        # Determine working directory for host mode
+                        if self.outdir:
+                            cwd = os.path.abspath(os.path.join(self.outdir, "../.."))
+                            self.logger.info(f"Derived project root from outdir: {cwd}")
+                            if not os.path.isdir(cwd):
+                                self.logger.warning(
+                                    f"Project root does not exist: {cwd}"
+                                )
+                                cwd = os.getcwd()
+                        else:
+                            cwd = os.getcwd()
+
+                        self.logger.info(f"Working directory: {cwd}")
+
+                        result = subprocess.run(
+                            cmd_list,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                            cwd=cwd,
+                        )
+                        self.logger.info(f"Host command output:\n{result.stdout}")
+                        if result.stderr:
+                            self.logger.warning(
+                                f"Host command stderr:\n{result.stderr}"
+                            )
+                        if result.returncode != 0:
+                            self.logger.warning(
+                                f"Host command failed with code {result.returncode}"
+                            )
+                            overall_success = False
+                    except Exception as exc:
+                        import traceback
+
+                        self.logger.warning(f"Host command execution error: {exc}")
+                        self.logger.warning(f"Traceback:\n{traceback.format_exc()}")
+                        overall_success = False
+
+                elif mode == "guest":
+                    # Run in guest via guest_cmd.py wrapper
+                    # Pass the command as a single string to guest_cmd.py, don't split it
+                    full_cmd = [
+                        "python3",
+                        "/igloo_static/guesthopper/guest_cmd.py",
+                        cmd  # Pass as single argument
+                    ]
+                    self.logger.info(f"Running GUEST command: {cmd}")
+                    try:
+                        result = subprocess.run(
+                            full_cmd,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                        )
+                        self.logger.info(f"Guest command output:\n{result.stdout}")
+                        if result.stderr:
+                            self.logger.warning(
+                                f"Guest command stderr:\n{result.stderr}"
+                            )
+                        if result.returncode != 0:
+                            self.logger.warning(
+                                f"Guest command failed with code {result.returncode}"
+                            )
+                            overall_success = False
+                        
+                        # Append guest command output to a single file
+                        output_file = os.path.join(self.outdir, "guest_commands_output.txt")
+                        with open(output_file, 'a') as f:
+                            f.write(f"\n{'='*60}\n")
+                            f.write(f"Command: {cmd}\n")
+                            f.write(f"Return code: {result.returncode}\n")
+                            f.write(f"{'='*60}\n")
+                            f.write(f"STDOUT:\n{result.stdout}\n")
+                            if result.stderr:
+                                f.write(f"STDERR:\n{result.stderr}\n")
+                        self.logger.info(f"Guest command output appended to: {output_file}")
+                        
+                    except Exception as exc:
+                        self.logger.warning(f"Guest command execution error: {exc}")
+                        overall_success = False
+                else:
+                    self.logger.error(
+                        f"Unknown mode '{mode}' - must be 'host' or 'guest'"
+                    )
+                    overall_success = False
+
+        return overall_success
+
+    def _delayed_bind_workflow(self, guest_ip: str, guest_port: int) -> None:
+        """Execute cmd_on_bind commands after a delay"""
+        self.logger.info(f"cmd_on_bind thread started for {guest_ip}:{guest_port}")
+        self.logger.info(f"Sleeping {self.fetch_delay}s before running commands")
+
+        time.sleep(self.fetch_delay)
+
+        self.logger.info(
+            f"Woke up, executing {len(self.cmd_on_bind_structured)} command groups"
+        )
+
+        success = self._run_on_bind_command()
+
+        if success and self.shutdown_after_cmd:
+            self.logger.info("Shutting down after bind commands")
+            self.shutting_down = True
+            self.panda.end_analysis()
+
+    def fetch(
+        self,
+        guest_ip: str,
+        host_ip: str,
+        guest_port: int,
+        host_port: int,
+        log_file_name: str,
+    ) -> bool:
         """
         Fetch web content from the specified host port and log the response.
 
@@ -160,8 +397,18 @@ class FetchWeb(Plugin):
             log_file_name += ".alt"
 
         time.sleep(self.fetch_delay)  # Give service plenty of time to start
-        cmd = ["wget", "-q", f"https://{host_ip}:{host_port}" if guest_port == 443 else f"http://{host_ip}:{host_port}",
-               "--no-check-certificate", "-O", log_file_name]
+        cmd = [
+            "wget",
+            "-q",
+            (
+                f"https://{host_ip}:{host_port}"
+                if guest_port == 443
+                else f"http://{host_ip}:{host_port}"
+            ),
+            "--no-check-certificate",
+            "-O",
+            log_file_name,
+        ]
         timestamp = f"{(time.time() - self.start_time):.02f}s"
         try:
             subprocess.check_output(cmd, timeout=30)
@@ -169,11 +416,15 @@ class FetchWeb(Plugin):
             self.logger.warning(f"{timestamp}: Error running wget: {e}")
             return False
         except subprocess.TimeoutExpired:
-            self.logger.warning(f"{timestamp}: No response to wget for {host_ip}:{host_port} after 30s")
+            self.logger.warning(
+                f"{timestamp}: No response to wget for {host_ip}:{host_port} after 30s"
+            )
             return False
 
         with open(log_file_name, "rb") as f:
             buffer = f.read()
             entropy = calculate_entropy(buffer)
-            self.logger.info(f"Service on {guest_ip}:{guest_port} responds with {len(buffer)} bytes, entropy {entropy:.02f}")
+            self.logger.info(
+                f"Service on {guest_ip}:{guest_port} responds with {len(buffer)} bytes, entropy {entropy:.02f}"
+            )
         return True

--- a/pyplugins/actuation/fetch_web.py
+++ b/pyplugins/actuation/fetch_web.py
@@ -309,8 +309,7 @@ class FetchWeb(Plugin):
                         self.logger.warning(
                             f"Host command execution error: {exc}")
                         self.logger.warning(
-                            f"Traceback:\n{
-                                traceback.format_exc()}")
+                            f"Traceback:\n{traceback.format_exc()}")
                         overall_success = False
 
                 elif mode == "guest":
@@ -331,16 +330,14 @@ class FetchWeb(Plugin):
                             check=False,
                         )
                         self.logger.info(
-                            f"Guest command output:\n{
-                                result.stdout}")
+                            f"Guest command output:\n{result.stdout}")
                         if result.stderr:
                             self.logger.warning(
                                 f"Guest command stderr:\n{result.stderr}"
                             )
                         if result.returncode != 0:
                             self.logger.warning(
-                                f"Guest command failed with code {
-                                    result.returncode}")
+                                f"Guest command failed with code {result.returncode}")
                             overall_success = False
 
                         # Append guest command output to a single file
@@ -374,8 +371,7 @@ class FetchWeb(Plugin):
         self.logger.info(
             f"cmd_on_bind thread started for {guest_ip}:{guest_port}")
         self.logger.info(
-            f"Sleeping {
-                self.fetch_delay}s before running commands")
+            f"Sleeping {self.fetch_delay}s before running commands")
 
         time.sleep(self.fetch_delay)
 
@@ -441,7 +437,5 @@ class FetchWeb(Plugin):
             buffer = f.read()
             entropy = calculate_entropy(buffer)
             self.logger.info(
-                f"Service on {guest_ip}:{guest_port} responds with {
-                    len(buffer)} bytes, entropy {
-                    entropy:.02f}")
+                f"Service on {guest_ip}:{guest_port} responds with {len(buffer)} bytes, entropy {entropy:.02f}")
         return True

--- a/pyplugins/actuation/fetch_web.py
+++ b/pyplugins/actuation/fetch_web.py
@@ -18,33 +18,6 @@ Arguments
 - outdir (str): Output directory for storing fetched web content.
 - shutdown_after_www (bool, optional): If True, shut down emulation after a successful fetch.
 - shutdown_on_failure (bool, optional): If True, shut down emulation if no responsive servers are found.
-- shutdown_after_cmd (bool, optional): If True, shut down emulation after cmd_on_bind commands complete.
-- fetch_delay (int, optional): Delay in seconds before fetching/running commands after bind. Default: 20.
-- cmd_on_bind (str, list, or dict, optional): Command(s) to run after bind-triggered fetch.
-    Supports three formats:
-
-    1. Single string (runs in guest mode by default):
-        cmd_on_bind: python3 example.py
-
-    2. List of strings (runs in guest mode by default):
-        cmd_on_bind:
-            - python3 analyze.py
-            - python3 report.py
-
-    3. Structured format with explicit mode specification:
-        cmd_on_bind:
-            - mode: host
-              cmd:
-                  - python3 ./exploit.py
-            - mode: guest
-              cmd:
-                  - echo "test" > /tmp/test.txt
-
-    Mode options:
-        - host: Run command on the host system (inside container, working directory is project root)
-        - guest: Run command inside the emulated guest system via guest_cmd.py (DEFAULT)
-
-    Note: If mode is not specified, defaults to 'guest'. Guest mode requires guest_cmd: true in config.yaml core settings.
 
 Plugin Interface
 ----------------
@@ -66,10 +39,9 @@ import queue
 from collections import Counter
 import math
 import time
-from typing import Optional, Any
+from typing import Optional
 from pydantic import Field
 from penguin import plugins, Plugin, PluginArgs
-import shlex
 
 
 def calculate_entropy(buffer: bytes) -> float:
@@ -83,30 +55,21 @@ def calculate_entropy(buffer: bytes) -> float:
     """
     byte_counts = Counter(buffer)
     total_bytes = len(buffer)
-    entropy = -sum(
-        (count / total_bytes) * math.log2(count / total_bytes)
-        for count in byte_counts.values()
-    )
+    entropy = -sum((count / total_bytes) * math.log2(count / total_bytes) for count in byte_counts.values())
     return entropy
 
 
 class FetchWeb(Plugin):
     class Args(PluginArgs):
         fetch_delay: Optional[int] = Field(
-            default=None,
-            description="Seconds to wait before fetching a newly bound web service. Defaults to 20 when unset.")
+            default=None, description="Seconds to wait before fetching a newly bound web service. Defaults to 20 when unset."
+        )
         shutdown_after_www: bool = Field(
-            default=False,
-            description="If true, shut down emulation after a successful web fetch.")
+            default=False, description="If true, shut down emulation after a successful web fetch."
+        )
         shutdown_on_failure: bool = Field(
-            default=False,
-            description="If true, shut down emulation if no responsive servers are found.")
-        shutdown_after_cmd: bool = Field(
-            default=False,
-            description="If true, shut down emulation after cmd_on_bind commands complete.")
-        cmd_on_bind: Optional[Any] = Field(
-            default=None,
-            description="Command(s) to run after bind. Supports string, list, or structured format with mode (host/guest).")
+            default=False, description="If true, shut down emulation if no responsive servers are found."
+        )
 
     def __init__(self) -> None:
         """
@@ -115,50 +78,7 @@ class FetchWeb(Plugin):
         self.outdir = self.get_arg("outdir")
         self.shutdown_after_www = self.get_arg_bool("shutdown_after_www")
         self.shutdown_on_failure = self.get_arg_bool("shutdown_on_failure")
-        self.shutdown_after_cmd = self.get_arg_bool("shutdown_after_cmd")
-
-        # Parse cmd_on_bind properly
-        self.cmd_on_bind = self.get_arg("cmd_on_bind")
-
-        if self.cmd_on_bind is not None:
-            # Check if it's list of dicts with mode/cmd
-            if isinstance(
-                    self.cmd_on_bind, list) and len(
-                    self.cmd_on_bind) > 0:
-                if isinstance(self.cmd_on_bind[0], dict):
-                    self.cmd_on_bind_structured = self.cmd_on_bind
-                    self.logger.info(
-                        "Using structured cmd_on_bind with mode specification"
-                    )
-                else:
-                    # List of strings (backward compatibility)
-                    self.cmd_on_bind_structured = [
-                        {"mode": "guest", "cmd": [str(c)]} for c in self.cmd_on_bind
-                    ]
-                    self.logger.info("Converting legacy cmd_on_bind format")
-            elif isinstance(self.cmd_on_bind, str):
-                # Single string command (backward compatibility)
-                self.cmd_on_bind_structured = [
-                    {"mode": "guest", "cmd": [str(self.cmd_on_bind)]}
-                ]
-                self.logger.info("Converting single string cmd_on_bind")
-            else:
-                self.cmd_on_bind_structured = []
-
-            # Guest-cmd must be enabled if any guest commands exist
-            has_guest_cmds = any(
-                entry.get("mode") == "guest" for entry in self.cmd_on_bind_structured)
-            if has_guest_cmds and not self.get_arg(
-                    "conf")["core"]["guest_cmd"]:
-                self.logger.error(
-                    "cmd_on_bind with guest mode requires guest_cmd: true in config.yaml"
-                )
-                raise ValueError(
-                    "guest_cmd must be enabled for guest mode commands")
-        else:
-            self.cmd_on_bind_structured = []
-
-        if delay := self.get_arg("fetch_delay"):
+        if (delay := self.get_arg("fetch_delay")):
             self.fetch_delay = int(delay)
             self.logger.info(f"Fetch delay set to {self.fetch_delay} seconds")
         else:
@@ -172,15 +92,7 @@ class FetchWeb(Plugin):
         self.worker_thread.start()
         self.start_time = time.time()
 
-    def fetchweb_on_bind(
-        self,
-        proto: str,
-        guest_ip: str,
-        guest_port: int,
-        host_port: int,
-        host_ip: str,
-        procname: str,
-    ) -> None:
+    def fetchweb_on_bind(self, proto: str, guest_ip: str, guest_port: int, host_port: int, host_ip: str, procname: str) -> None:
         """
         Handle a new bind event from the VPN plugin and enqueue a fetch task for web ports.
 
@@ -192,25 +104,14 @@ class FetchWeb(Plugin):
             host_ip (str): Host IP address.
             procname (str): Name of the process binding the port.
         """
-
+        """
+        There was a bind - if it's a web port (80, 443), enqueue the task for fetching the page.
+        """
         if self.shutting_down or proto != "tcp" or guest_port not in [80, 443]:
             return
 
-        # Only trigger cmd_on_bind for 0.0.0.0 to avoid running commands
-        # multiple times
-        if self.cmd_on_bind_structured and guest_ip == "0.0.0.0":
-            self.logger.info(
-                f"Bind detected on {guest_ip}:{guest_port}, spawning cmd_on_bind thread")
-            t = threading.Thread(
-                target=self._delayed_bind_workflow, args=(guest_ip, guest_port)
-            )
-            t.daemon = True
-            t.start()
-
-        log_file_name = os.path.join(
-            self.outdir, f"web_{guest_ip}_{guest_port}")
-        self.task_queue.put(
-            (guest_ip, host_ip, guest_port, host_port, log_file_name))
+        log_file_name = os.path.join(self.outdir, f"web_{guest_ip}_{guest_port}")
+        self.task_queue.put((guest_ip, host_ip, guest_port, host_port, log_file_name))
 
     def worker(self) -> None:
         """
@@ -221,12 +122,8 @@ class FetchWeb(Plugin):
         while not self.shutting_down:
             try:
                 # Wait for a task, sleeping 5s between every check
-                guest_ip, host_ip, guest_port, host_port, log_file_name = (
-                    self.task_queue.get(timeout=5)
-                )
-                success = self.fetch(
-                    guest_ip, host_ip, guest_port, host_port, log_file_name
-                )
+                guest_ip, host_ip, guest_port, host_port, log_file_name = self.task_queue.get(timeout=5)
+                success = self.fetch(guest_ip, host_ip, guest_port, host_port, log_file_name)
                 self.task_queue.task_done()
                 first = True
 
@@ -243,157 +140,10 @@ class FetchWeb(Plugin):
         if self.shutdown_after_www or self.shutdown_on_failure:
             self.shutting_down = True
             timestamp = f"{(time.time() - self.start_time):.02f}s"
-            self.logger.info(
-                f"Shutting down after fetching {guest_ip}:{guest_port} ({timestamp} after boot)")
+            self.logger.info(f"Shutting down after fetching {guest_ip}:{guest_port} ({timestamp} after boot)")
             self.panda.end_analysis()
 
-    def _run_on_bind_command(self) -> bool:
-        """Execute the commands supplied via cmd_on_bind.
-
-        Returns:
-            bool: True if all commands succeeded, False otherwise.
-        """
-        overall_success = True
-
-        for entry in self.cmd_on_bind_structured:
-            mode = entry.get("mode", "guest")
-            cmds = entry.get("cmd", [])
-
-            # Normalize to list if single command
-            if isinstance(cmds, str):
-                cmds = [cmds]
-
-            for cmd in cmds:
-                if mode == "host":
-                    # Run on host directly
-                    self.logger.info(f"Running HOST command: {cmd}")
-                    try:
-                        # Split the command string into a list for subprocess
-                        cmd_list = shlex.split(
-                            cmd) if isinstance(cmd, str) else cmd
-
-                        # Determine working directory for host mode
-                        if self.outdir:
-                            cwd = os.path.abspath(
-                                os.path.join(self.outdir, "../.."))
-                            self.logger.info(
-                                f"Derived project root from outdir: {cwd}")
-                            if not os.path.isdir(cwd):
-                                self.logger.warning(
-                                    f"Project root does not exist: {cwd}"
-                                )
-                                cwd = os.getcwd()
-                        else:
-                            cwd = os.getcwd()
-
-                        self.logger.info(f"Working directory: {cwd}")
-
-                        result = subprocess.run(
-                            cmd_list,
-                            capture_output=True,
-                            text=True,
-                            check=False,
-                            cwd=cwd,
-                        )
-                        self.logger.info(f"Host command output:\n{result.stdout}")
-                        if result.stderr:
-                            self.logger.warning(
-                                f"Host command stderr:\n{result.stderr}"
-                            )
-                        if result.returncode != 0:
-                            self.logger.warning(f"Host command failed with code {result.returncode}")
-                            overall_success = False
-                    except Exception as exc:
-                        import traceback
-
-                        self.logger.warning(
-                            f"Host command execution error: {exc}")
-                        self.logger.warning(
-                            f"Traceback:\n{traceback.format_exc()}")
-                        overall_success = False
-
-                elif mode == "guest":
-                    # Run in guest via guest_cmd.py wrapper
-                    # Pass the command as a single string to guest_cmd.py,
-                    # don't split it
-                    full_cmd = [
-                        "python3",
-                        "/igloo_static/guesthopper/guest_cmd.py",
-                        cmd  # Pass as single argument
-                    ]
-                    self.logger.info(f"Running GUEST command: {cmd}")
-                    try:
-                        result = subprocess.run(
-                            full_cmd,
-                            capture_output=True,
-                            text=True,
-                            check=False,
-                        )
-                        self.logger.info(
-                            f"Guest command output:\n{result.stdout}")
-                        if result.stderr:
-                            self.logger.warning(
-                                f"Guest command stderr:\n{result.stderr}"
-                            )
-                        if result.returncode != 0:
-                            self.logger.warning(
-                                f"Guest command failed with code {result.returncode}")
-                            overall_success = False
-
-                        # Append guest command output to a single file
-                        output_file = os.path.join(
-                            self.outdir, "guest_commands_output.txt")
-                        with open(output_file, 'a') as f:
-                            f.write(f"\n{'=' * 60}\n")
-                            f.write(f"Command: {cmd}\n")
-                            f.write(f"Return code: {result.returncode}\n")
-                            f.write(f"{'=' * 60}\n")
-                            f.write(f"STDOUT:\n{result.stdout}\n")
-                            if result.stderr:
-                                f.write(f"STDERR:\n{result.stderr}\n")
-                        self.logger.info(
-                            f"Guest command output appended to: {output_file}")
-
-                    except Exception as exc:
-                        self.logger.warning(
-                            f"Guest command execution error: {exc}")
-                        overall_success = False
-                else:
-                    self.logger.error(
-                        f"Unknown mode '{mode}' - must be 'host' or 'guest'"
-                    )
-                    overall_success = False
-
-        return overall_success
-
-    def _delayed_bind_workflow(self, guest_ip: str, guest_port: int) -> None:
-        """Execute cmd_on_bind commands after a delay"""
-        self.logger.info(
-            f"cmd_on_bind thread started for {guest_ip}:{guest_port}")
-        self.logger.info(
-            f"Sleeping {self.fetch_delay}s before running commands")
-
-        time.sleep(self.fetch_delay)
-
-        self.logger.info(
-            f"Woke up, executing {len(self.cmd_on_bind_structured)} command groups"
-        )
-
-        success = self._run_on_bind_command()
-
-        if success and self.shutdown_after_cmd:
-            self.logger.info("Shutting down after bind commands")
-            self.shutting_down = True
-            self.panda.end_analysis()
-
-    def fetch(
-        self,
-        guest_ip: str,
-        host_ip: str,
-        guest_port: int,
-        host_port: int,
-        log_file_name: str,
-    ) -> bool:
+    def fetch(self, guest_ip: str, host_ip: str, guest_port: int, host_port: int, log_file_name: str) -> bool:
         """
         Fetch web content from the specified host port and log the response.
 
@@ -410,18 +160,8 @@ class FetchWeb(Plugin):
             log_file_name += ".alt"
 
         time.sleep(self.fetch_delay)  # Give service plenty of time to start
-        cmd = [
-            "wget",
-            "-q",
-            (
-                f"https://{host_ip}:{host_port}"
-                if guest_port == 443
-                else f"http://{host_ip}:{host_port}"
-            ),
-            "--no-check-certificate",
-            "-O",
-            log_file_name,
-        ]
+        cmd = ["wget", "-q", f"https://{host_ip}:{host_port}" if guest_port == 443 else f"http://{host_ip}:{host_port}",
+               "--no-check-certificate", "-O", log_file_name]
         timestamp = f"{(time.time() - self.start_time):.02f}s"
         try:
             subprocess.check_output(cmd, timeout=30)
@@ -429,13 +169,11 @@ class FetchWeb(Plugin):
             self.logger.warning(f"{timestamp}: Error running wget: {e}")
             return False
         except subprocess.TimeoutExpired:
-            self.logger.warning(
-                f"{timestamp}: No response to wget for {host_ip}:{host_port} after 30s")
+            self.logger.warning(f"{timestamp}: No response to wget for {host_ip}:{host_port} after 30s")
             return False
 
         with open(log_file_name, "rb") as f:
             buffer = f.read()
             entropy = calculate_entropy(buffer)
-            self.logger.info(
-                f"Service on {guest_ip}:{guest_port} responds with {len(buffer)} bytes, entropy {entropy:.02f}")
+            self.logger.info(f"Service on {guest_ip}:{guest_port} responds with {len(buffer)} bytes, entropy {entropy:.02f}")
         return True

--- a/pyplugins/actuation/run_on_bind.py
+++ b/pyplugins/actuation/run_on_bind.py
@@ -125,7 +125,7 @@ def normalize_commands(spec: Any) -> List[Dict[str, Any]]:
         spec = [spec]
 
     if not isinstance(spec, list):
-        raise ValueError( f"commands must be a string, list, or structured list, but received: {type(spec).__name__}")
+        raise ValueError(f"commands must be a string, list, or structured list, but received: {type(spec).__name__}")
 
     if not spec:
         return []
@@ -134,7 +134,7 @@ def normalize_commands(spec: Any) -> List[Dict[str, Any]]:
         return [{"mode": "guest", "cmd": [entry]} for entry in spec]
 
     if not all(isinstance(entry, dict) for entry in spec):
-        raise ValueError( "commands must be either a list of strings or a list of structured command dictionaries. Mixing formats is not supported.")
+        raise ValueError("commands must be either a list of strings or a list of structured command dictionaries. Mixing formats is not supported.")
 
     normalized: List[Dict[str, Any]] = []
     for entry in spec:

--- a/pyplugins/actuation/run_on_bind.py
+++ b/pyplugins/actuation/run_on_bind.py
@@ -1,0 +1,560 @@
+"""
+RunOnBind Plugin (run_on_bind.py) for Penguin
+=============================================
+
+Executes user-defined host or guest commands when a guest service binds a port that is exposed
+to the host by the VPN plugin.
+
+Execution model
+---------------
+
+Bind events are filtered, de-duplicated per endpoint, and queued. A single worker thread drains
+that queue, so command runs are serialized, two endpoints binding at once can never produce
+concurrent `guest_cmd.py` invocations.
+
+An attempt runs every configured command and succeeds if ANY of them does, since configurations
+routinely include commands that only apply to some targets. The first successful attempt is the
+last: the plugin stops accepting endpoints and, if `shutdown_after_cmd` is set, ends the
+analysis. A failed attempt is not terminal -- the next endpoint to bind gets its own try,
+uncapped, which keeps a run from wedging when the first endpoint to appear (often a loopback
+bind) isn't the one that works.
+
+Every command has a hard timeout, and every command's outcome is recorded whether it passed or failed.
+
+Arguments
+---------
+
+- outdir (str): Output directory for command-output artifacts.
+- commands (str, list, or dict, REQUIRED): Command(s) to run after a matching bind event.
+    Loading the plugin without commands raises at init.
+
+    Supports three formats:
+
+    1. Single string (runs in guest mode by default):
+        commands: python3 example.py
+
+    2. List of strings (runs in guest mode by default):
+        commands:
+            - python3 analyze.py
+            - python3 report.py
+
+    3. Structured format with explicit mode specification:
+        commands:
+            - mode: host
+              run:
+                  - python3 ./test.py
+            - mode: guest
+              run:
+                  - echo "test" > /tmp/test.txt
+
+    Mixed lists of strings and dictionaries are not supported.
+
+    Mode options:
+        - host: Run commands on the host system (inside the container), using the project
+          directory penguin supplies as the working directory.
+        - guest: Run commands inside the emulated guest via the `guest_cmd.py` wrapper
+          (default). Requires `guest_cmd: true` under `core` in config.yaml.
+
+- endpoints (list[str], optional): Guest endpoints that may trigger the commands,
+    formatted as `guest_ip:guest_port`. Either component may be `*` to match anything.
+    If omitted, any bind event passing the protocol/port filters may trigger.
+
+        Example:
+            endpoints:
+                - "0.0.0.0:80"
+                - "*:8080"
+
+    Prefer a wildcard over an exact IP: an allowlist that never matches means the commands
+    never run and nothing ever ends the run.
+
+- ports (list[int], optional): Restrict triggering to these guest ports. Default: any.
+- proto (str, optional): Protocol to match. Default: 'tcp'. Use '*' for any.
+- delay (int, optional): Delay in seconds after a bind before running commands. Default: 20.
+- timeout (int, optional): Per-command timeout in seconds. Default: 120. A command that
+    exceeds it is killed and counted as a failure.
+- shutdown_after_cmd (bool, optional): If True, end emulation after the first successful run.
+
+Plugin Interface
+----------------
+
+- Subscribes to the VPN plugin's 'on_bind' event.
+- Writes command output to `<outdir>/run_on_bind_output.txt`, one block per command per attempt, each carrying a `Status:` of SUCCESS or FAILED.
+- Exposes `succeeded` (bool) and `attempts` (int) for other plugins or tests to inspect.
+"""
+
+import os
+import queue
+import shlex
+import subprocess
+import threading
+import time
+import traceback
+from typing import Any, Dict, List, Optional
+
+from pydantic import Field
+from penguin import plugins, Plugin, PluginArgs
+
+
+DEFAULT_DELAY = 20
+DEFAULT_TIMEOUT = 120
+GUEST_CMD_WRAPPER = "/igloo_static/guesthopper/guest_cmd.py"
+VALID_MODES = ("host", "guest")
+OUTPUT_FILENAME = "run_on_bind_output.txt"
+
+
+def normalize_commands(spec: Any) -> List[Dict[str, Any]]:
+    """
+    Normalize the three supported `commands` formats into a single structured form.
+
+    Args:
+        spec: A string, a list of strings, a list of {mode, cmd} dicts, or None.
+    Returns:
+        list[dict]: Entries of the form {"mode": "host"|"guest", "cmd": [str, ...]}.
+        None and empty input map to an empty list; the plugin, not this function, decides
+        whether that is an error.
+    Raises:
+        ValueError: If the spec is malformed or mixes formats.
+    """
+    if spec is None:
+        return []
+
+    if isinstance(spec, str):
+        return [{"mode": "guest", "cmd": [spec]}]
+
+    if isinstance(spec, dict):
+        spec = [spec]
+
+    if not isinstance(spec, list):
+        raise ValueError( f"commands must be a string, list, or structured list, but received: {type(spec).__name__}")
+
+    if not spec:
+        return []
+
+    if all(isinstance(entry, str) for entry in spec):
+        return [{"mode": "guest", "cmd": [entry]} for entry in spec]
+
+    if not all(isinstance(entry, dict) for entry in spec):
+        raise ValueError( "commands must be either a list of strings or a list of structured command dictionaries. Mixing formats is not supported.")
+
+    normalized: List[Dict[str, Any]] = []
+    for entry in spec:
+        mode = entry.get("mode", "guest")
+        if mode not in VALID_MODES:
+            raise ValueError(f"commands mode must be one of {VALID_MODES}, but received: {mode!r}")
+
+        cmds = entry.get("run")
+        if cmds is None:
+            raise ValueError(f"commands entry is missing a 'run' key: {entry!r}")
+        if isinstance(cmds, str):
+            cmds = [cmds]
+        if not isinstance(cmds, list) or not all(isinstance(c, str) for c in cmds):
+            raise ValueError(f"commands 'run' must be a string or list of strings, but received: {cmds!r}")
+
+        normalized.append({"mode": mode, "cmd": list(cmds)})
+
+    return normalized
+
+
+def parse_endpoints(entries: Optional[List[str]]) -> List[str]:
+    """
+    Validate and normalize the `endpoints` allowlist.
+
+    Args:
+        entries: List of 'guest_ip:guest_port' strings, where either side may be '*'.
+    Returns:
+        list[str]: The validated entries.
+    Raises:
+        ValueError: If any entry is malformed.
+    """
+    validated: List[str] = []
+
+    for endpoint in entries or []:
+        try:
+            guest_ip, guest_port = endpoint.rsplit(":", 1)
+
+            if not guest_ip:
+                raise ValueError
+
+            if guest_port != "*":
+                port = int(guest_port)
+                if not 1 <= port <= 65535:
+                    raise ValueError
+
+        except (AttributeError, ValueError):
+            raise ValueError(f"Each endpoints entry must use 'guest_ip:guest_port' format with a valid port, but received: {endpoint!r}")
+
+        validated.append(endpoint)
+
+    return validated
+
+
+def endpoint_matches(guest_ip: str, guest_port: int, allowlist: List[str]) -> bool:
+    """
+    Check a bind event against the endpoint allowlist.
+
+    An empty allowlist matches everything. Either component of an allowlist entry may be '*'.
+    """
+    if not allowlist:
+        return True
+
+    for entry in allowlist:
+        allowed_ip, allowed_port = entry.rsplit(":", 1)
+        if allowed_ip not in ("*", guest_ip):
+            continue
+        if allowed_port != "*" and int(allowed_port) != int(guest_port):
+            continue
+        return True
+
+    return False
+
+
+class RunOnBind(Plugin):
+    class Args(PluginArgs):
+        commands: Any = Field(
+            ...,
+            description="Required. Command(s) to run after bind. Supports string, list, or structured format with mode (host/guest).")
+        endpoints: Optional[List[str]] = Field(
+            default=None,
+            description="Optional list of guest endpoints that may trigger commands, formatted as guest_ip:guest_port ('*' allowed for either side). If unset, any matching bind may trigger.")
+        ports: Optional[List[int]] = Field(
+            default=None,
+            description="Optional list of guest ports that may trigger commands. If unset, any port may trigger.")
+        proto: str = Field(
+            default="tcp",
+            description="Protocol to match on bind events. Use '*' to match any protocol.")
+        delay: Optional[int] = Field(
+            default=None,
+            description="Seconds to wait after a bind before running commands. Defaults to 20 when unset.")
+        timeout: Optional[int] = Field(
+            default=None,
+            description="Per-command timeout in seconds. Defaults to 120 when unset. Prevents an unresponsive guest from hanging the run.")
+        shutdown_after_cmd: bool = Field(
+            default=False,
+            description="If true, end emulation after the first successful command run.")
+
+    def __init__(self) -> None:
+        """
+        Initialize the RunOnBind plugin, validate configuration, and subscribe to VPN binds.
+        """
+        self.outdir = self.get_arg("outdir")
+        self.shutdown_after_cmd = self.get_arg_bool("shutdown_after_cmd")
+        self.proto_filter = self.get_arg("proto") or "tcp"
+        self.port_filter = [int(p) for p in (self.get_arg("ports") or [])]
+        self.endpoints = parse_endpoints(self.get_arg("endpoints"))
+        self.commands = normalize_commands(self.get_arg("commands"))
+
+        self._flat_commands = [
+            (entry["mode"], cmd) for entry in self.commands for cmd in entry["cmd"]
+        ]
+
+        delay = self.get_arg("delay")
+        self.delay = DEFAULT_DELAY if delay is None else int(delay)
+
+        timeout = self.get_arg("timeout")
+        self.timeout = DEFAULT_TIMEOUT if timeout is None else int(timeout)
+
+        if not self.commands:
+            self.logger.error("RunOnBind requires at least one command; got an empty commands.")
+            raise ValueError("commands is required and must contain at least one command")
+
+        # Guest mode requires the guest_cmd wrapper to be enabled.
+        if any(entry["mode"] == "guest" for entry in self.commands):
+            if not self.get_arg("conf")["core"]["guest_cmd"]:
+                self.logger.error("commands with guest mode requires guest_cmd: true in config.yaml")
+                raise ValueError("guest_cmd must be enabled for guest mode commands")
+
+        self.host_cwd = self._resolve_host_cwd()
+
+        if self.host_cwd == os.sep and any(e["mode"] == "host" for e in self.commands):
+            self.logger.error("Host commands are configured but the host working directory resolved to '/'. Relative paths will not resolve; use absolute paths in your host commands.")
+
+        self._seen_endpoints = set()
+        self._lock = threading.Lock()
+        self.task_queue = queue.Queue()
+        self.shutting_down = False
+        self.succeeded = False
+        self.attempts = 0
+        self.start_time = time.time()
+
+        self.logger.info(
+            f"RunOnBind armed with {len(self.commands)} command group(s), "
+            f"delay {self.delay}s, timeout {self.timeout}s, "
+            f"endpoints={self.endpoints or 'any'}, "
+            f"ports={self.port_filter or 'any'}, proto={self.proto_filter}")
+
+        plugins.subscribe(plugins.VPN, "on_bind", self.on_bind_handler)
+
+        self.worker_thread = threading.Thread(target=self.worker, daemon=True)
+        self.worker_thread.start()
+
+    def on_bind_handler(
+        self,
+        proto: str,
+        guest_ip: str,
+        guest_port: int,
+        host_port: int,
+        host_ip: str,
+        procname: str,
+    ) -> None:
+        """
+        Handle a bind event from the VPN plugin and, if it matches, queue an attempt.
+
+        Args:
+            proto (str): Protocol (e.g., 'tcp').
+            guest_ip (str): Guest IP address.
+            guest_port (int): Guest port.
+            host_port (int): Host port mapped to the guest service.
+            host_ip (str): Host IP address.
+            procname (str): Name of the process binding the port.
+        """
+        if self.shutting_down or self.succeeded:
+            return
+
+        if self.proto_filter != "*" and proto != self.proto_filter:
+            return
+
+        if self.port_filter and int(guest_port) not in self.port_filter:
+            return
+
+        if not endpoint_matches(guest_ip, guest_port, self.endpoints):
+            self.logger.debug(f"Bind on {guest_ip}:{guest_port} does not match endpoints {self.endpoints}; skipping")
+            return
+
+        guest_endpoint = f"{guest_ip}:{guest_port}"
+
+        with self._lock:
+            if guest_endpoint in self._seen_endpoints:
+                self.logger.debug(f"commands already queued for {guest_endpoint}; skipping")
+                return
+            self._seen_endpoints.add(guest_endpoint)
+
+        self.logger.info(f"Bind detected on {guest_endpoint} ({procname}); queueing commands attempt")
+        self.task_queue.put((guest_endpoint, host_ip, host_port, time.time()))
+
+    def worker(self) -> None:
+        """
+        Drain queued endpoints one at a time, stopping at the first successful run.
+
+        Serializing here is deliberate: concurrent guest_cmd.py invocations against the same
+        guest are a reliable way to wedge the emulation.
+        """
+        while not self.shutting_down and not self.succeeded:
+            try:
+                guest_endpoint, host_ip, host_port, queued_at = self.task_queue.get(timeout=5)
+            except queue.Empty:
+                continue
+
+            try:
+                self._run_attempt(guest_endpoint, host_ip, host_port, queued_at)
+            except Exception as exc:  # never let the worker die silently
+                self.logger.warning(f"commands attempt raised: {exc}")
+                self.logger.warning(f"Traceback:\n{traceback.format_exc()}")
+            finally:
+                self.task_queue.task_done()
+
+    def _run_attempt(
+        self,
+        guest_endpoint: str,
+        host_ip: str,
+        host_port: int,
+        queued_at: float,
+    ) -> None:
+        """
+        Wait out the remaining delay for one endpoint, run the commands, and decide what next.
+        """
+        remaining = self.delay - (time.time() - queued_at)
+        if remaining > 0:
+            self.logger.info(
+                f"Sleeping {remaining:.01f}s before running commands for {guest_endpoint}")
+            time.sleep(remaining)
+
+        if self.shutting_down or self.succeeded:
+            self.logger.info(
+                f"Run already resolved; skipping commands for {guest_endpoint}")
+            return
+
+        self.attempts += 1
+        self.logger.info(f"Attempt {self.attempts}: executing {len(self.commands)} command group(s) for {guest_endpoint} (host {host_ip}:{host_port})")
+
+        success = self.run_commands(guest_endpoint)
+
+        if success:
+            self.succeeded = True
+            timestamp = f"{(time.time() - self.start_time):.02f}s"
+            self.logger.info(f"commands succeeded for {guest_endpoint} ({timestamp} after boot)")
+            if self.shutdown_after_cmd:
+                self.logger.info("Shutting down after successful bind commands")
+                self.shutting_down = True
+                self.panda.end_analysis()
+            return
+
+        self.logger.warning(f"commands failed for {guest_endpoint}; waiting for another endpoint to try")
+
+    def run_commands(self, guest_endpoint: str = "") -> bool:
+        """
+        Execute every configured command once and report whether any of them succeeded.
+
+        A single success resolves the run. Configurations routinely include commands that
+        only apply to some targets, so requiring every one to pass would keep retrying
+        endpoints on account of commands that were never going to work.
+
+        Args:
+            guest_endpoint (str): Endpoint that triggered this run, for the output artifact.
+        Returns:
+            bool: True if at least one command succeeded.
+        """
+        succeeded, failed = [], []
+
+        for mode, cmd in self._flat_commands:
+            if mode == "host":
+                ok = self._run_host_command(cmd, guest_endpoint)
+            else:
+                ok = self._run_guest_command(cmd, guest_endpoint)
+            (succeeded if ok else failed).append(cmd)
+
+        self.logger.info(
+            f"{len(succeeded)}/{len(self._flat_commands)} command(s) succeeded for {guest_endpoint}")
+        if failed:
+            self.logger.info(f"Command(s) that did not succeed: {failed}")
+
+        return bool(succeeded)
+
+    def _resolve_host_cwd(self) -> str:
+        """
+        Pick the working directory for host-mode commands.
+
+        Returns:
+            str: penguin's `proj_dir` arg, or the process cwd if it is missing or not a
+            directory -- in which case relative paths in host commands will not resolve.
+        """
+        proj_dir = self.get_arg("proj_dir")
+
+        if proj_dir:
+            resolved = os.path.abspath(proj_dir)
+            if os.path.isdir(resolved):
+                self.logger.info(f"Host working directory from proj_dir: {resolved}")
+                return resolved
+            self.logger.warning(f"proj_dir is set but is not a directory: {resolved}")
+        else:
+            self.logger.warning("penguin did not supply proj_dir; cannot locate the project root")
+
+        fallback = os.getcwd()
+        self.logger.warning(
+            "Falling back to the penguin process cwd for host commands: "
+            f"{fallback}. Use absolute paths in host commands if they cannot find their files.")
+        return fallback
+
+    def _run_host_command(self, cmd: str, guest_endpoint: str = "") -> bool:
+        """
+        Run a single command on the host, rooted at the resolved project directory.
+        """
+        self.logger.info(f"Running HOST command: {cmd}")
+        try:
+            cmd_list = shlex.split(cmd) if isinstance(cmd, str) else cmd
+
+            cwd = self.host_cwd
+            if not os.path.isdir(cwd):
+                self.logger.warning(f"Host working directory disappeared since startup: {cwd}; re-resolving")
+                cwd = self.host_cwd = self._resolve_host_cwd()
+            self.logger.info(f"Working directory: {cwd}")
+
+            result = subprocess.run(
+                cmd_list,
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=cwd,
+                timeout=self.timeout,
+            )
+        except subprocess.TimeoutExpired:
+            self.logger.warning(f"Host command exceeded {self.timeout}s and was killed: {cmd}")
+            self._record_output("host", cmd, None, "", f"timed out after {self.timeout}s", guest_endpoint)
+            return False
+        except FileNotFoundError as exc:
+            self.logger.warning(f"Host command executable not found: {exc}. Working directory was {self.host_cwd}")
+            self._record_output("host", cmd, None, "", str(exc), guest_endpoint)
+            return False
+        except Exception as exc:
+            self.logger.warning(f"Host command execution error: {exc}")
+            self.logger.warning(f"Traceback:\n{traceback.format_exc()}")
+            self._record_output("host", cmd, None, "", str(exc), guest_endpoint)
+            return False
+
+        self.logger.info(f"Host command output:\n{result.stdout}")
+        if result.stderr:
+            self.logger.warning(f"Host command stderr:\n{result.stderr}")
+        if result.returncode != 0:
+            self.logger.warning(
+                f"Host command failed with code {result.returncode}")
+
+        self._record_output(
+            "host", cmd, result.returncode, result.stdout, result.stderr, guest_endpoint)
+        return result.returncode == 0
+
+    def _run_guest_command(self, cmd: str, guest_endpoint: str = "") -> bool:
+        """
+        Run a single command inside the guest via the guest_cmd.py wrapper.
+
+        The command is passed as one argument so the guest shell, not the host, splits it.
+        """
+        full_cmd = ["python3", GUEST_CMD_WRAPPER, cmd]
+        self.logger.info(f"Running GUEST command: {cmd}")
+        try:
+            result = subprocess.run(
+                full_cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=self.timeout,
+            )
+        except subprocess.TimeoutExpired:
+            self.logger.warning(f"Guest command exceeded {self.timeout}s and was killed: {cmd}")
+            self._record_output("guest", cmd, None, "", f"timed out after {self.timeout}s", guest_endpoint)
+            return False
+        except Exception as exc:
+            self.logger.warning(f"Guest command execution error: {exc}")
+            self.logger.warning(f"Traceback:\n{traceback.format_exc()}")
+            self._record_output("guest", cmd, None, "", str(exc), guest_endpoint)
+            return False
+
+        self.logger.info(f"Guest command output:\n{result.stdout}")
+        if result.stderr:
+            self.logger.warning(f"Guest command stderr:\n{result.stderr}")
+        if result.returncode != 0:
+            self.logger.warning(
+                f"Guest command failed with code {result.returncode}")
+
+        self._record_output("guest", cmd, result.returncode, result.stdout, result.stderr, guest_endpoint)
+        return result.returncode == 0
+
+    def _record_output(
+        self,
+        mode: str,
+        cmd: str,
+        returncode: Optional[int],
+        stdout: str,
+        stderr: str,
+        guest_endpoint: str = "",
+    ) -> None:
+        """
+        Append a command's result to the shared output artifact for the Verifier to inspect.
+        """
+        output_file = os.path.join(self.outdir, OUTPUT_FILENAME)
+        try:
+            with open(output_file, "a") as f:
+                f.write(f"\n{'=' * 60}\n")
+                f.write(f"Endpoint: {guest_endpoint or 'unknown'}\n")
+                f.write(f"Attempt: {self.attempts}\n")
+                f.write(f"Mode: {mode}\n")
+                f.write(f"Command: {cmd}\n")
+                f.write(f"Status: {'SUCCESS' if returncode == 0 else 'FAILED'}\n")
+                f.write(f"Return code: {returncode}\n")
+                f.write(f"{'=' * 60}\n")
+                f.write(f"STDOUT:\n{stdout}\n")
+                if stderr:
+                    f.write(f"STDERR:\n{stderr}\n")
+        except OSError as exc:
+            self.logger.warning(f"Could not write command output artifact: {exc}")
+            return
+
+        self.logger.info(f"Command output appended to: {output_file}")

--- a/pyplugins/actuation/run_on_bind.py
+++ b/pyplugins/actuation/run_on_bind.py
@@ -438,15 +438,18 @@ class RunOnBind(Plugin):
 
         for mode, cmd in self._flat_commands:
             if mode == "host":
+                cmd = self._apply_host_port(cmd, host_port)
                 ok = self._run_host_command(cmd, guest_endpoint, host_port)
             else:
                 ok = self._run_guest_command(cmd, guest_endpoint)
-            (succeeded if ok else failed).append(cmd)
+            (succeeded if ok else failed).append((mode, cmd))
 
         self.logger.info(
             f"{len(succeeded)}/{len(self._flat_commands)} command(s) succeeded for {guest_endpoint}")
         if failed:
-            self.logger.info(f"Command(s) that did not succeed: {failed}")
+            self.logger.info(f"{len(failed)} command(s) did not succeed:")
+            for failed_mode, failed_cmd in failed:
+                self.logger.info(f"  [mode: {failed_mode}] {failed_cmd}")
 
         return bool(succeeded)
 
@@ -479,12 +482,12 @@ class RunOnBind(Plugin):
         """
         Run a single command on the host, rooted at the resolved project directory.
 
-        The mapped host port is substituted for `{host_port}` and exported as
-        `PENGUIN_HOST_PORT`, since the VPN plugin picks it at bind time and the user has no
-        way to write it into their config.
+        Args:
+            cmd (str): Command with `{host_port}` already resolved by the caller.
+            guest_endpoint (str): Endpoint that triggered this run, for the artifact.
+            host_port (int): Mapped port, exported as `PENGUIN_HOST_PORT` for commands
+                that would rather read the environment than interpolate the placeholder.
         """
-        cmd = self._apply_host_port(cmd, host_port)
-
         env = dict(os.environ)
         env[HOST_PORT_ENV_VAR] = str(host_port)
 
@@ -535,6 +538,10 @@ class RunOnBind(Plugin):
     def _apply_host_port(self, cmd: str, host_port: int) -> str:
         """
         Replace the `{host_port}` placeholder in a host command with the mapped port.
+
+        Called once per command before dispatch, so every mention of the command
+        downstream -- logs, the success/failure summary, the output artifact -- shows the
+        port it really used rather than the placeholder.
 
         A literal replace rather than `str.format`, so shell and awk braces in a
         command pass through untouched.

--- a/pyplugins/actuation/run_on_bind.py
+++ b/pyplugins/actuation/run_on_bind.py
@@ -55,6 +55,25 @@ Arguments
         - guest: Run commands inside the emulated guest via the `guest_cmd.py` wrapper
           (default). Requires `guest_cmd: true` under `core` in config.yaml.
 
+    Host commands also receive the host port that the VPN plugin mapped the binding guest
+    service to. That port cannot be hardcoded in config: the VPN plugin remaps it whenever
+    the guest port is privileged or already taken. It is supplied two ways:
+
+        - `{host_port}` anywhere in the command string is replaced with the port before
+          the command is split and run.
+        - `PENGUIN_HOST_PORT` is set in the command's environment.
+
+    The bridge listens on 0.0.0.0 inside the container, so `127.0.0.1:<host_port>` always
+    reaches the service. Guest commands run inside the guest and talk to the guest port
+    directly, so they are left verbatim.
+
+        Example:
+            commands:
+                - mode: host
+                  run:
+                      - curl -sf http://127.0.0.1:{host_port}/
+                      - python3 ./probe.py --port {host_port}
+
 - endpoints (list[str], optional): Guest endpoints that may trigger the commands,
     formatted as `guest_ip:guest_port`. Either component may be `*` to match anything.
     If omitted, any bind event passing the protocol/port filters may trigger.
@@ -67,7 +86,12 @@ Arguments
     Prefer a wildcard over an exact IP: an allowlist that never matches means the commands
     never run and nothing ever ends the run.
 
-- ports (list[int], optional): Restrict triggering to these guest ports. Default: any.
+- ports (list[int], optional): Guest ports that may trigger the commands.
+    Default: `[80, 443]`, the common web-UI ports, so an unfiltered config does not
+    fire on the first unrelated bind -- a target whose httpd serves UPnP on 1900 well
+    before it binds 80 would otherwise trigger on the wrong service. Set an explicit
+    list for other services, or `[]` to accept any port: an empty list disables the
+    filter rather than matching nothing.
 - proto (str, optional): Protocol to match. Default: 'tcp'. Use '*' for any.
 - delay (int, optional): Delay in seconds after a bind before running commands. Default: 20.
 - timeout (int, optional): Per-command timeout in seconds. Default: 120. A command that
@@ -99,6 +123,8 @@ DEFAULT_DELAY = 20
 DEFAULT_TIMEOUT = 120
 GUEST_CMD_WRAPPER = "/igloo_static/guesthopper/guest_cmd.py"
 VALID_MODES = ("host", "guest")
+HOST_PORT_PLACEHOLDER = "{host_port}"
+HOST_PORT_ENV_VAR = "PENGUIN_HOST_PORT"
 OUTPUT_FILENAME = "run_on_bind_output.txt"
 
 
@@ -216,9 +242,12 @@ class RunOnBind(Plugin):
         endpoints: Optional[List[str]] = Field(
             default=None,
             description="Optional list of guest endpoints that may trigger commands, formatted as guest_ip:guest_port ('*' allowed for either side). If unset, any matching bind may trigger.")
+        # A literal default (not default_factory) so the generated arg docs show
+        # [80, 443] rather than the factory's source text. Pydantic copies mutable
+        # defaults per instance, so the list cannot be shared between plugins.
         ports: Optional[List[int]] = Field(
-            default=None,
-            description="Optional list of guest ports that may trigger commands. If unset, any port may trigger.")
+            default=[80, 443],
+            description="Guest ports that may trigger commands. Defaults to [80, 443], the common web-UI ports. Set an explicit list for other services, or [] to accept any port.")
         proto: str = Field(
             default="tcp",
             description="Protocol to match on bind events. Use '*' to match any protocol.")
@@ -376,7 +405,7 @@ class RunOnBind(Plugin):
         self.attempts += 1
         self.logger.info(f"Attempt {self.attempts}: executing {len(self.commands)} command group(s) for {guest_endpoint} (host {host_ip}:{host_port})")
 
-        success = self.run_commands(guest_endpoint)
+        success = self.run_commands(guest_endpoint, host_port)
 
         if success:
             self.succeeded = True
@@ -390,7 +419,7 @@ class RunOnBind(Plugin):
 
         self.logger.warning(f"commands failed for {guest_endpoint}; waiting for another endpoint to try")
 
-    def run_commands(self, guest_endpoint: str = "") -> bool:
+    def run_commands(self, guest_endpoint: str, host_port: int) -> bool:
         """
         Execute every configured command once and report whether any of them succeeded.
 
@@ -400,6 +429,8 @@ class RunOnBind(Plugin):
 
         Args:
             guest_endpoint (str): Endpoint that triggered this run, for the output artifact.
+            host_port (int): Host port mapped to the triggering guest service,
+                handed to host commands via `{host_port}` and `PENGUIN_HOST_PORT`.
         Returns:
             bool: True if at least one command succeeded.
         """
@@ -407,7 +438,7 @@ class RunOnBind(Plugin):
 
         for mode, cmd in self._flat_commands:
             if mode == "host":
-                ok = self._run_host_command(cmd, guest_endpoint)
+                ok = self._run_host_command(cmd, guest_endpoint, host_port)
             else:
                 ok = self._run_guest_command(cmd, guest_endpoint)
             (succeeded if ok else failed).append(cmd)
@@ -444,10 +475,19 @@ class RunOnBind(Plugin):
             f"{fallback}. Use absolute paths in host commands if they cannot find their files.")
         return fallback
 
-    def _run_host_command(self, cmd: str, guest_endpoint: str = "") -> bool:
+    def _run_host_command(self, cmd: str, guest_endpoint: str, host_port: int) -> bool:
         """
         Run a single command on the host, rooted at the resolved project directory.
+
+        The mapped host port is substituted for `{host_port}` and exported as
+        `PENGUIN_HOST_PORT`, since the VPN plugin picks it at bind time and the user has no
+        way to write it into their config.
         """
+        cmd = self._apply_host_port(cmd, host_port)
+
+        env = dict(os.environ)
+        env[HOST_PORT_ENV_VAR] = str(host_port)
+
         self.logger.info(f"Running HOST command: {cmd}")
         try:
             cmd_list = shlex.split(cmd) if isinstance(cmd, str) else cmd
@@ -464,6 +504,7 @@ class RunOnBind(Plugin):
                 text=True,
                 check=False,
                 cwd=cwd,
+                env=env,
                 timeout=self.timeout,
             )
         except subprocess.TimeoutExpired:
@@ -490,6 +531,21 @@ class RunOnBind(Plugin):
         self._record_output(
             "host", cmd, result.returncode, result.stdout, result.stderr, guest_endpoint)
         return result.returncode == 0
+
+    def _apply_host_port(self, cmd: str, host_port: int) -> str:
+        """
+        Replace the `{host_port}` placeholder in a host command with the mapped port.
+
+        A literal replace rather than `str.format`, so shell and awk braces in a
+        command pass through untouched.
+
+        Args:
+            cmd (str): Command as configured.
+            host_port (int): Port the VPN plugin mapped this bind to.
+        Returns:
+            str: The command with the placeholder resolved, unchanged if it has none.
+        """
+        return cmd.replace(HOST_PORT_PLACEHOLDER, str(host_port))
 
     def _run_guest_command(self, cmd: str, guest_endpoint: str = "") -> bool:
         """

--- a/pyplugins/testing/fetch_web_testing.py
+++ b/pyplugins/testing/fetch_web_testing.py
@@ -2,8 +2,8 @@
 FetchWeb integration test plugin.
 
 Subscribes to the same VPN on_bind events as fetch_web and verifies that:
-    - fetch_web creates an output file for each web service 
-    - Each output file has non-zero content 
+    - fetch_web creates an output file for each web service
+    - Each output file has non-zero content
 
 Arguments:
     - outdir (str): Output directory shared with fetch_web.
@@ -12,42 +12,53 @@ Arguments:
                                            Supports three path formats:
                                            1. Relative to project root: 'hello.txt' or 'scripts/output.txt'
                                            2. Relative to results dir: 'results/marker.txt'
-                                           3. Absolute path: '/host_PROJECT/file.txt' 
+                                           3. Absolute path: '/host_PROJECT/file.txt'
     - cmd_on_bind_guest_output_contains (list, optional): List of strings that should appear in
                                                            guest_commands_output.txt file.
-                                                           Example: ['root', 'uid=0'] 
+                                                           Example: ['root', 'uid=0']
     - cmd_wait_timeout (int, optional): Seconds to wait for cmd_on_bind commands to complete
-                                        before checking results. Default: 30 
+                                        before checking results. Default: 30
 
 """
 
-from penguin import plugins, Plugin 
+from penguin import plugins, Plugin
 from os.path import join, exists
-import threading 
-import time 
+import threading
+import time
+
 
 class FetchWebTest(Plugin):
     def __init__(self):
         self.outdir = self.get_arg("outdir")
         self.cmd_on_bind_marker = self.get_arg("cmd_on_bind_marker")
-        self.cmd_on_bind_guest_output_contains = self.get_arg("cmd_on_bind_guest_output_contains")
+        self.cmd_on_bind_guest_output_contains = self.get_arg(
+            "cmd_on_bind_guest_output_contains")
         self.cmd_wait_timeout = int(self.get_arg("cmd_wait_timeout") or 30)
         self.results = {}
         self.lock = threading.Lock()
         self._threads = []
         plugins.subscribe(plugins.VPN, "on_bind", self.on_bind)
 
-    def on_bind(self, proto, guest_ip, guest_port, host_port, host_ip, procname):
+    def on_bind(
+            self,
+            proto,
+            guest_ip,
+            guest_port,
+            host_port,
+            host_ip,
+            procname):
         if proto != "tcp" or guest_port not in [80, 443]:
-            return 
+            return
         log_file = join(self.outdir, f"web_{guest_ip}_{guest_port}")
-        t = threading.Thread(target=self._check_output, args=(guest_ip, guest_port, log_file))
-        t.daemon = True 
+        t = threading.Thread(
+            target=self._check_output, args=(
+                guest_ip, guest_port, log_file))
+        t.daemon = True
         t.start()
         with self.lock:
             self._threads.append(t)
 
-    def _check_output(self, guest_ip, guest_port, log_file, timeout = 90):
+    def _check_output(self, guest_ip, guest_port, log_file, timeout=90):
         """Wait for fetch_web to create the output file, then verify if it has content."""
         key = f"web_{guest_ip}_{guest_port}"
         deadline = time.time() + timeout
@@ -60,16 +71,18 @@ class FetchWebTest(Plugin):
         actual = log_file if exists(log_file) else log_file + ".alt"
 
         if not exists(actual):
-            self.logger.error(f"FetchWebTest: {key} - no output file after {timeout}s")
+            self.logger.error(
+                f"FetchWebTest: {key} - no output file after {timeout}s")
             with self.lock:
                 self.results[key] = False
-            return 
-        
+            return
+
         with open(actual, "rb") as f:
             content = f.read()
 
         if len(content) > 0:
-            self.logger.info(f"FetchWebTest: {key} - passed ({len(content)} bytes)")
+            self.logger.info(
+                f"FetchWebTest: {key} - passed ({len(content)} bytes)")
             with self.lock:
                 self.results[key] = True
         else:
@@ -80,13 +93,16 @@ class FetchWebTest(Plugin):
     def uninit(self):
         for t in self._threads:
             t.join(timeout=10)
-        
-        # If checking guest output or host marker, wait for commands to complete
+
+        # If checking guest output or host marker, wait for commands to
+        # complete
         if self.cmd_on_bind_guest_output_contains or self.cmd_on_bind_marker:
             import time
-            self.logger.info(f"Waiting {self.cmd_wait_timeout} seconds for cmd_on_bind commands to complete...")
+            self.logger.info(
+                f"Waiting {
+                    self.cmd_wait_timeout} seconds for cmd_on_bind commands to complete...")
             time.sleep(self.cmd_wait_timeout)
-        
+
         with open(join(self.outdir, "fetch_web_test.txt"), 'w') as f:
             if not self.results:
                 self.logger.warning("FetchWebTest: no web services detected")
@@ -101,46 +117,57 @@ class FetchWebTest(Plugin):
             if self.cmd_on_bind_marker:
                 import os
                 marker = self.cmd_on_bind_marker
-                
+
                 # Determine marker file path
                 if os.path.isabs(marker):
                     marker_path = marker
                 elif marker.startswith('results/'):
-                    marker_path = os.path.join(self.outdir, marker.replace('results/', '', 1))
+                    marker_path = os.path.join(
+                        self.outdir, marker.replace(
+                            'results/', '', 1))
                 else:
-                    project_root = os.path.abspath(os.path.join(self.outdir, "../.."))
+                    project_root = os.path.abspath(
+                        os.path.join(self.outdir, "../.."))
                     marker_path = os.path.join(project_root, marker)
-                
-                self.logger.info(f'FetchWebTest: Checking for host marker at {marker_path}')
-                
+
+                self.logger.info(
+                    f'FetchWebTest: Checking for host marker at {marker_path}')
+
                 if exists(marker_path):
                     self.logger.info('FetchWebTest: cmd_on_bind (host) passed')
                     f.write("cmd_on_bind_host: passed\n")
-                else: 
-                    self.logger.error(f'FetchWebTest: cmd_on_bind (host) failed - marker not found at {marker_path}')
+                else:
+                    self.logger.error(
+                        f'FetchWebTest: cmd_on_bind (host) failed - marker not found at {marker_path}')
                     f.write("cmd_on_bind_host: failed\n")
-            
+
             # Check guest command output contains expected strings
             if self.cmd_on_bind_guest_output_contains:
-                guest_output_file = join(self.outdir, "guest_commands_output.txt")
-                self.logger.info(f'FetchWebTest: Checking guest output at {guest_output_file}')
-                
+                guest_output_file = join(
+                    self.outdir, "guest_commands_output.txt")
+                self.logger.info(
+                    f'FetchWebTest: Checking guest output at {guest_output_file}')
+
                 if exists(guest_output_file):
                     with open(guest_output_file, 'r') as gf:
                         content = gf.read()
-                    
+
                     missing_strings = []
                     for expected_str in self.cmd_on_bind_guest_output_contains:
                         if expected_str not in content:
                             missing_strings.append(expected_str)
-                    
+
                     if not missing_strings:
-                        self.logger.info('FetchWebTest: cmd_on_bind (guest) passed - all expected strings found')
+                        self.logger.info(
+                            'FetchWebTest: cmd_on_bind (guest) passed - all expected strings found')
                         f.write("cmd_on_bind_guest: passed\n")
                     else:
-                        self.logger.error(f'FetchWebTest: cmd_on_bind (guest) failed - missing strings: {missing_strings}')
-                        f.write(f"cmd_on_bind_guest: failed (missing: {', '.join(missing_strings)})\n")
+                        self.logger.error(
+                            f'FetchWebTest: cmd_on_bind (guest) failed - missing strings: {missing_strings}')
+                        f.write(
+                            f"cmd_on_bind_guest: failed (missing: {
+                                ', '.join(missing_strings)})\n")
                 else:
-                    self.logger.error('FetchWebTest: cmd_on_bind (guest) failed - guest_commands_output.txt not found')
+                    self.logger.error(
+                        'FetchWebTest: cmd_on_bind (guest) failed - guest_commands_output.txt not found')
                     f.write("cmd_on_bind_guest: failed (output file not found)\n")
-        

--- a/pyplugins/testing/fetch_web_testing.py
+++ b/pyplugins/testing/fetch_web_testing.py
@@ -97,10 +97,8 @@ class FetchWebTest(Plugin):
         # If checking guest output or host marker, wait for commands to
         # complete
         if self.cmd_on_bind_guest_output_contains or self.cmd_on_bind_marker:
-            import time
             self.logger.info(
-                f"Waiting {
-                    self.cmd_wait_timeout} seconds for cmd_on_bind commands to complete...")
+                f"Waiting {self.cmd_wait_timeout} seconds for cmd_on_bind commands to complete...")
             time.sleep(self.cmd_wait_timeout)
 
         with open(join(self.outdir, "fetch_web_test.txt"), 'w') as f:

--- a/pyplugins/testing/fetch_web_testing.py
+++ b/pyplugins/testing/fetch_web_testing.py
@@ -163,8 +163,7 @@ class FetchWebTest(Plugin):
                         self.logger.error(
                             f'FetchWebTest: cmd_on_bind (guest) failed - missing strings: {missing_strings}')
                         f.write(
-                            f"cmd_on_bind_guest: failed (missing: {
-                                ', '.join(missing_strings)})\n")
+                            f"cmd_on_bind_guest: failed (missing: {', '.join(missing_strings)})\n")
                 else:
                     self.logger.error(
                         'FetchWebTest: cmd_on_bind (guest) failed - guest_commands_output.txt not found')

--- a/pyplugins/testing/fetch_web_testing.py
+++ b/pyplugins/testing/fetch_web_testing.py
@@ -1,0 +1,146 @@
+"""
+FetchWeb integration test plugin.
+
+Subscribes to the same VPN on_bind events as fetch_web and verifies that:
+    - fetch_web creates an output file for each web service 
+    - Each output file has non-zero content 
+
+Arguments:
+    - outdir (str): Output directory shared with fetch_web.
+    - cmd_on_bind_marker (str, optional): Path to a marker file that cmd_on_bind (host mode)
+                                           is expected to create on the host filesystem.
+                                           Supports three path formats:
+                                           1. Relative to project root: 'hello.txt' or 'scripts/output.txt'
+                                           2. Relative to results dir: 'results/marker.txt'
+                                           3. Absolute path: '/host_PROJECT/file.txt' 
+    - cmd_on_bind_guest_output_contains (list, optional): List of strings that should appear in
+                                                           guest_commands_output.txt file.
+                                                           Example: ['root', 'uid=0'] 
+    - cmd_wait_timeout (int, optional): Seconds to wait for cmd_on_bind commands to complete
+                                        before checking results. Default: 30 
+
+"""
+
+from penguin import plugins, Plugin 
+from os.path import join, exists
+import threading 
+import time 
+
+class FetchWebTest(Plugin):
+    def __init__(self):
+        self.outdir = self.get_arg("outdir")
+        self.cmd_on_bind_marker = self.get_arg("cmd_on_bind_marker")
+        self.cmd_on_bind_guest_output_contains = self.get_arg("cmd_on_bind_guest_output_contains")
+        self.cmd_wait_timeout = int(self.get_arg("cmd_wait_timeout") or 30)
+        self.results = {}
+        self.lock = threading.Lock()
+        self._threads = []
+        plugins.subscribe(plugins.VPN, "on_bind", self.on_bind)
+
+    def on_bind(self, proto, guest_ip, guest_port, host_port, host_ip, procname):
+        if proto != "tcp" or guest_port not in [80, 443]:
+            return 
+        log_file = join(self.outdir, f"web_{guest_ip}_{guest_port}")
+        t = threading.Thread(target=self._check_output, args=(guest_ip, guest_port, log_file))
+        t.daemon = True 
+        t.start()
+        with self.lock:
+            self._threads.append(t)
+
+    def _check_output(self, guest_ip, guest_port, log_file, timeout = 90):
+        """Wait for fetch_web to create the output file, then verify if it has content."""
+        key = f"web_{guest_ip}_{guest_port}"
+        deadline = time.time() + timeout
+
+        while time.time() < deadline:
+            if exists(log_file) or exists(log_file + ".alt"):
+                break
+            time.sleep(2)
+
+        actual = log_file if exists(log_file) else log_file + ".alt"
+
+        if not exists(actual):
+            self.logger.error(f"FetchWebTest: {key} - no output file after {timeout}s")
+            with self.lock:
+                self.results[key] = False
+            return 
+        
+        with open(actual, "rb") as f:
+            content = f.read()
+
+        if len(content) > 0:
+            self.logger.info(f"FetchWebTest: {key} - passed ({len(content)} bytes)")
+            with self.lock:
+                self.results[key] = True
+        else:
+            self.logger.error(f"FetchWebTest: {key} - output file is empty")
+            with self.lock:
+                self.results[key] = False
+
+    def uninit(self):
+        for t in self._threads:
+            t.join(timeout=10)
+        
+        # If checking guest output or host marker, wait for commands to complete
+        if self.cmd_on_bind_guest_output_contains or self.cmd_on_bind_marker:
+            import time
+            self.logger.info(f"Waiting {self.cmd_wait_timeout} seconds for cmd_on_bind commands to complete...")
+            time.sleep(self.cmd_wait_timeout)
+        
+        with open(join(self.outdir, "fetch_web_test.txt"), 'w') as f:
+            if not self.results:
+                self.logger.warning("FetchWebTest: no web services detected")
+                f.write("FetchWebTest: no web services detected\n")
+
+            for key, passed in self.results.items():
+                result = "passed" if passed else "failed"
+                self.logger.info(f"FetchWebTest: {key}: {result}")
+                f.write(f"{key}: {result}\n")
+
+            # Check host mode marker file
+            if self.cmd_on_bind_marker:
+                import os
+                marker = self.cmd_on_bind_marker
+                
+                # Determine marker file path
+                if os.path.isabs(marker):
+                    marker_path = marker
+                elif marker.startswith('results/'):
+                    marker_path = os.path.join(self.outdir, marker.replace('results/', '', 1))
+                else:
+                    project_root = os.path.abspath(os.path.join(self.outdir, "../.."))
+                    marker_path = os.path.join(project_root, marker)
+                
+                self.logger.info(f'FetchWebTest: Checking for host marker at {marker_path}')
+                
+                if exists(marker_path):
+                    self.logger.info('FetchWebTest: cmd_on_bind (host) passed')
+                    f.write("cmd_on_bind_host: passed\n")
+                else: 
+                    self.logger.error(f'FetchWebTest: cmd_on_bind (host) failed - marker not found at {marker_path}')
+                    f.write("cmd_on_bind_host: failed\n")
+            
+            # Check guest command output contains expected strings
+            if self.cmd_on_bind_guest_output_contains:
+                guest_output_file = join(self.outdir, "guest_commands_output.txt")
+                self.logger.info(f'FetchWebTest: Checking guest output at {guest_output_file}')
+                
+                if exists(guest_output_file):
+                    with open(guest_output_file, 'r') as gf:
+                        content = gf.read()
+                    
+                    missing_strings = []
+                    for expected_str in self.cmd_on_bind_guest_output_contains:
+                        if expected_str not in content:
+                            missing_strings.append(expected_str)
+                    
+                    if not missing_strings:
+                        self.logger.info('FetchWebTest: cmd_on_bind (guest) passed - all expected strings found')
+                        f.write("cmd_on_bind_guest: passed\n")
+                    else:
+                        self.logger.error(f'FetchWebTest: cmd_on_bind (guest) failed - missing strings: {missing_strings}')
+                        f.write(f"cmd_on_bind_guest: failed (missing: {', '.join(missing_strings)})\n")
+                else:
+                    self.logger.error('FetchWebTest: cmd_on_bind (guest) failed - guest_commands_output.txt not found')
+                    f.write("cmd_on_bind_guest: failed (output file not found)\n")
+        

--- a/pyplugins/testing/fetch_web_testing.py
+++ b/pyplugins/testing/fetch_web_testing.py
@@ -5,20 +5,11 @@ Subscribes to the same VPN on_bind events as fetch_web and verifies that:
     - fetch_web creates an output file for each web service
     - Each output file has non-zero content
 
+Bind-triggered command execution moved to the run_on_bind plugin; see run_on_bind_testing
+for the checks that cover it.
+
 Arguments:
     - outdir (str): Output directory shared with fetch_web.
-    - cmd_on_bind_marker (str, optional): Path to a marker file that cmd_on_bind (host mode)
-                                           is expected to create on the host filesystem.
-                                           Supports three path formats:
-                                           1. Relative to project root: 'hello.txt' or 'scripts/output.txt'
-                                           2. Relative to results dir: 'results/marker.txt'
-                                           3. Absolute path: '/host_PROJECT/file.txt'
-    - cmd_on_bind_guest_output_contains (list, optional): List of strings that should appear in
-                                                           guest_commands_output.txt file.
-                                                           Example: ['root', 'uid=0']
-    - cmd_wait_timeout (int, optional): Seconds to wait for cmd_on_bind commands to complete
-                                        before checking results. Default: 30
-
 """
 
 from penguin import plugins, Plugin
@@ -30,10 +21,6 @@ import time
 class FetchWebTest(Plugin):
     def __init__(self):
         self.outdir = self.get_arg("outdir")
-        self.cmd_on_bind_marker = self.get_arg("cmd_on_bind_marker")
-        self.cmd_on_bind_guest_output_contains = self.get_arg(
-            "cmd_on_bind_guest_output_contains")
-        self.cmd_wait_timeout = int(self.get_arg("cmd_wait_timeout") or 30)
         self.results = {}
         self.lock = threading.Lock()
         self._threads = []
@@ -94,13 +81,6 @@ class FetchWebTest(Plugin):
         for t in self._threads:
             t.join(timeout=10)
 
-        # If checking guest output or host marker, wait for commands to
-        # complete
-        if self.cmd_on_bind_guest_output_contains or self.cmd_on_bind_marker:
-            self.logger.info(
-                f"Waiting {self.cmd_wait_timeout} seconds for cmd_on_bind commands to complete...")
-            time.sleep(self.cmd_wait_timeout)
-
         with open(join(self.outdir, "fetch_web_test.txt"), 'w') as f:
             if not self.results:
                 self.logger.warning("FetchWebTest: no web services detected")
@@ -110,61 +90,3 @@ class FetchWebTest(Plugin):
                 result = "passed" if passed else "failed"
                 self.logger.info(f"FetchWebTest: {key}: {result}")
                 f.write(f"{key}: {result}\n")
-
-            # Check host mode marker file
-            if self.cmd_on_bind_marker:
-                import os
-                marker = self.cmd_on_bind_marker
-
-                # Determine marker file path
-                if os.path.isabs(marker):
-                    marker_path = marker
-                elif marker.startswith('results/'):
-                    marker_path = os.path.join(
-                        self.outdir, marker.replace(
-                            'results/', '', 1))
-                else:
-                    project_root = os.path.abspath(
-                        os.path.join(self.outdir, "../.."))
-                    marker_path = os.path.join(project_root, marker)
-
-                self.logger.info(
-                    f'FetchWebTest: Checking for host marker at {marker_path}')
-
-                if exists(marker_path):
-                    self.logger.info('FetchWebTest: cmd_on_bind (host) passed')
-                    f.write("cmd_on_bind_host: passed\n")
-                else:
-                    self.logger.error(
-                        f'FetchWebTest: cmd_on_bind (host) failed - marker not found at {marker_path}')
-                    f.write("cmd_on_bind_host: failed\n")
-
-            # Check guest command output contains expected strings
-            if self.cmd_on_bind_guest_output_contains:
-                guest_output_file = join(
-                    self.outdir, "guest_commands_output.txt")
-                self.logger.info(
-                    f'FetchWebTest: Checking guest output at {guest_output_file}')
-
-                if exists(guest_output_file):
-                    with open(guest_output_file, 'r') as gf:
-                        content = gf.read()
-
-                    missing_strings = []
-                    for expected_str in self.cmd_on_bind_guest_output_contains:
-                        if expected_str not in content:
-                            missing_strings.append(expected_str)
-
-                    if not missing_strings:
-                        self.logger.info(
-                            'FetchWebTest: cmd_on_bind (guest) passed - all expected strings found')
-                        f.write("cmd_on_bind_guest: passed\n")
-                    else:
-                        self.logger.error(
-                            f'FetchWebTest: cmd_on_bind (guest) failed - missing strings: {missing_strings}')
-                        f.write(
-                            f"cmd_on_bind_guest: failed (missing: {', '.join(missing_strings)})\n")
-                else:
-                    self.logger.error(
-                        'FetchWebTest: cmd_on_bind (guest) failed - guest_commands_output.txt not found')
-                    f.write("cmd_on_bind_guest: failed (output file not found)\n")

--- a/pyplugins/testing/run_on_bind_testing.py
+++ b/pyplugins/testing/run_on_bind_testing.py
@@ -1,0 +1,128 @@
+"""
+RunOnBind integration test plugin.
+
+Verifies that run_on_bind actually executed its configured commands, by checking the
+side effects those commands were supposed to produce:
+
+    - A marker file created on the host filesystem by a host-mode command.
+    - Expected strings appearing in run_on_bind's output artifact.
+
+Both checks are optional; configure whichever the commands under test produce.
+
+Arguments:
+    - outdir (str): Output directory shared with run_on_bind.
+    - host_marker (str, optional): Path to a file a host-mode command is expected to
+        create. Three formats:
+            1. Relative to the project root: 'hello.txt' or 'scripts/output.txt'
+            2. Relative to the results dir:  'results/marker.txt'
+            3. Absolute:                     '/host_PROJECT/file.txt'
+        Relative paths resolve against penguin's `proj_dir`, which is the working
+        directory run_on_bind gives host commands, so a command writing 'hello.txt'
+        lands where this plugin looks for it.
+    - output_contains (list[str], optional): Strings expected in run_on_bind_output.txt.
+        Example: ['root', 'uid=0']
+    - wait_timeout (int, optional): Seconds to wait for each expected file to appear
+        before declaring it missing. Default: 30.
+
+Writes results to `<outdir>/run_on_bind_test.txt`.
+"""
+
+import os
+import time
+from os.path import join, exists
+
+from penguin import Plugin
+
+
+OUTPUT_FILENAME = "run_on_bind_output.txt"
+RESULTS_FILENAME = "run_on_bind_test.txt"
+DEFAULT_WAIT_TIMEOUT = 30
+
+
+class RunOnBindTest(Plugin):
+    def __init__(self):
+        self.outdir = self.get_arg("outdir")
+        self.host_marker = self.get_arg("host_marker")
+        self.output_contains = self.get_arg("output_contains") or []
+
+        if not isinstance(self.output_contains, list):
+            raise ValueError("output_contains must be a list of strings.")
+
+        if not all(isinstance(entry, str) for entry in self.output_contains):
+            raise ValueError("output_contains must contain only strings.")
+
+        self.wait_timeout = int(self.get_arg("wait_timeout") or DEFAULT_WAIT_TIMEOUT)
+
+    def _resolve_marker_path(self):
+        """
+        Resolve the configured marker into an absolute path.
+
+        Relative paths resolve against `proj_dir` -- the same directory run_on_bind runs
+        host commands in -- so that a command writing a relative path and this check agree
+        on where the file lands.
+        """
+        marker = self.host_marker
+
+        if os.path.isabs(marker):
+            return marker
+
+        if marker.startswith("results/"):
+            return join(self.outdir, marker.replace("results/", "", 1))
+
+        return join(self.get_arg("proj_dir") or os.getcwd(), marker)
+
+    def _wait_for(self, path):
+        """Poll for a path until it exists or wait_timeout elapses."""
+        deadline = time.time() + self.wait_timeout
+        while time.time() < deadline:
+            if exists(path):
+                return True
+            time.sleep(1)
+        return exists(path)
+
+    def _check_marker(self, f):
+        marker_path = self._resolve_marker_path()
+        self.logger.info(f"RunOnBindTest: checking for host marker at {marker_path}")
+
+        if self._wait_for(marker_path):
+            self.logger.info("RunOnBindTest: host marker passed")
+            f.write("host_marker: passed\n")
+        else:
+            self.logger.error(
+                f"RunOnBindTest: host marker failed - not found at {marker_path} "
+                f"after {self.wait_timeout}s")
+            f.write("host_marker: failed\n")
+
+    def _check_output_contains(self, f):
+        output_file = join(self.outdir, OUTPUT_FILENAME)
+        self.logger.info(f"RunOnBindTest: checking command output at {output_file}")
+
+        if not self._wait_for(output_file):
+            self.logger.error(
+                f"RunOnBindTest: output check failed - {OUTPUT_FILENAME} not found")
+            f.write("output_contains: failed (output file not found)\n")
+            return
+
+        with open(output_file, "r") as of:
+            content = of.read()
+
+        missing = [s for s in self.output_contains if s not in content]
+
+        if missing:
+            self.logger.error(
+                f"RunOnBindTest: output check failed - missing strings: {missing}")
+            f.write(f"output_contains: failed (missing: {', '.join(missing)})\n")
+        else:
+            self.logger.info("RunOnBindTest: output check passed")
+            f.write("output_contains: passed\n")
+
+    def uninit(self):
+        if not self.host_marker and not self.output_contains:
+            self.logger.warning("RunOnBindTest: nothing configured to check")
+
+        with open(join(self.outdir, RESULTS_FILENAME), "w") as f:
+            if self.host_marker:
+                self._check_marker(f)
+
+            if self.output_contains:
+                self._check_output_contains(f)

--- a/pyplugins/testing/run_on_bind_testing.py
+++ b/pyplugins/testing/run_on_bind_testing.py
@@ -19,6 +19,11 @@ Arguments:
         Relative paths resolve against penguin's `proj_dir`, which is the working
         directory run_on_bind gives host commands, so a command writing 'hello.txt'
         lands where this plugin looks for it.
+    - host_marker_min_size (int, optional): Bytes `host_marker` must hold to count as
+        passing. Defaults to 1, so a truncated marker fails -- a command like
+        `wget -q -O out.txt <url>` leaves a 0-byte file behind when it errors out, and an
+        existence-only check would call that a pass. Set to 0 when the marker is a
+        `touch`-style success flag with no content.
     - output_contains (list[str], optional): Strings expected in run_on_bind_output.txt.
         Example: ['root', 'uid=0']
     - wait_timeout (int, optional): Seconds to wait for each expected file to appear
@@ -37,6 +42,7 @@ from penguin import Plugin
 OUTPUT_FILENAME = "run_on_bind_output.txt"
 RESULTS_FILENAME = "run_on_bind_test.txt"
 DEFAULT_WAIT_TIMEOUT = 30
+DEFAULT_MARKER_MIN_SIZE = 1
 
 
 class RunOnBindTest(Plugin):
@@ -50,6 +56,13 @@ class RunOnBindTest(Plugin):
 
         if not all(isinstance(entry, str) for entry in self.output_contains):
             raise ValueError("output_contains must contain only strings.")
+
+        min_size = self.get_arg("host_marker_min_size")
+        self.host_marker_min_size = (
+            DEFAULT_MARKER_MIN_SIZE if min_size is None else int(min_size))
+
+        if self.host_marker_min_size < 0:
+            raise ValueError("host_marker_min_size must not be negative.")
 
         self.wait_timeout = int(self.get_arg("wait_timeout") or DEFAULT_WAIT_TIMEOUT)
 
@@ -71,27 +84,51 @@ class RunOnBindTest(Plugin):
 
         return join(self.get_arg("proj_dir") or os.getcwd(), marker)
 
-    def _wait_for(self, path):
-        """Poll for a path until it exists or wait_timeout elapses."""
+    def _wait_for(self, path, min_size=0):
+        """
+        Poll for a path until it holds at least `min_size` bytes or wait_timeout elapses.
+
+        A file can appear before the command writing it is finished, so size is polled
+        alongside existence rather than sampled once the path shows up.
+        """
         deadline = time.time() + self.wait_timeout
-        while time.time() < deadline:
-            if exists(path):
+        while True:
+            if self._satisfies(path, min_size):
                 return True
+            if time.time() >= deadline:
+                return False
             time.sleep(1)
-        return exists(path)
+
+    @staticmethod
+    def _satisfies(path, min_size):
+        try:
+            return os.path.getsize(path) >= min_size
+        except OSError:
+            return False
 
     def _check_marker(self, f):
         marker_path = self._resolve_marker_path()
-        self.logger.info(f"RunOnBindTest: checking for host marker at {marker_path}")
+        min_size = self.host_marker_min_size
+        self.logger.info(
+            f"RunOnBindTest: checking for host marker at {marker_path} "
+            f"(min size {min_size} bytes)")
 
-        if self._wait_for(marker_path):
+        if self._wait_for(marker_path, min_size):
             self.logger.info("RunOnBindTest: host marker passed")
             f.write("host_marker: passed\n")
-        else:
+        elif not exists(marker_path):
             self.logger.error(
                 f"RunOnBindTest: host marker failed - not found at {marker_path} "
                 f"after {self.wait_timeout}s")
-            f.write("host_marker: failed\n")
+            f.write("host_marker: failed (not found)\n")
+        else:
+            size = os.path.getsize(marker_path)
+            self.logger.error(
+                f"RunOnBindTest: host marker failed - {marker_path} holds {size} bytes, "
+                f"expected at least {min_size} after {self.wait_timeout}s")
+            f.write(
+                f"host_marker: failed (too small: {size} bytes, "
+                f"expected >= {min_size})\n")
 
     def _check_output_contains(self, f):
         output_file = join(self.outdir, OUTPUT_FILENAME)

--- a/tests/unit/test_run_on_bind_testing.py
+++ b/tests/unit/test_run_on_bind_testing.py
@@ -1,0 +1,86 @@
+"""Host-side coverage for the RunOnBind test plugin
+(pyplugins/testing/run_on_bind_testing.py), driven with no PANDA/guest.
+
+The plugin's whole job is grading side effects, so the interesting logic is the
+grading itself: a marker that never appears, one that appears empty (a failed
+`wget -q -O file` leaves a 0-byte file behind), and one with real content.
+`wait_timeout` is 1s throughout so the failing paths don't stall the suite.
+"""
+from pathlib import Path
+
+import pytest
+
+from penguin.testing import load_pyplugin
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN = REPO_ROOT / "pyplugins" / "testing" / "run_on_bind_testing.py"
+RESULTS = "run_on_bind_test.txt"
+
+
+def grade(tmp_path, **args):
+    """Run the plugin's uninit-time checks and return its results artifact."""
+    lp = load_pyplugin(str(PLUGIN), outdir=tmp_path, args={"wait_timeout": 1, **args})
+    lp.finalize()
+    return (tmp_path / RESULTS).read_text()
+
+
+def test_marker_with_content_passes(tmp_path):
+    marker = tmp_path / "marker.txt"
+    marker.write_text("hello")
+    assert "host_marker: passed" in grade(tmp_path, host_marker=str(marker))
+
+
+def test_empty_marker_fails(tmp_path):
+    marker = tmp_path / "marker.txt"
+    marker.touch()  # what a failed `wget -q -O marker.txt <url>` leaves behind
+    results = grade(tmp_path, host_marker=str(marker))
+    assert "host_marker: failed (too small: 0 bytes, expected >= 1)" in results
+
+
+def test_empty_marker_passes_when_min_size_is_zero(tmp_path):
+    marker = tmp_path / "flag"
+    marker.touch()  # a touch-style success flag, opted into explicitly
+    results = grade(tmp_path, host_marker=str(marker), host_marker_min_size=0)
+    assert "host_marker: passed" in results
+
+
+def test_missing_marker_fails_as_not_found(tmp_path):
+    results = grade(tmp_path, host_marker=str(tmp_path / "nope.txt"))
+    assert "host_marker: failed (not found)" in results
+
+
+def test_missing_marker_fails_even_with_min_size_zero(tmp_path):
+    results = grade(
+        tmp_path, host_marker=str(tmp_path / "nope.txt"), host_marker_min_size=0)
+    assert "host_marker: failed (not found)" in results
+
+
+def test_short_marker_fails_against_larger_min_size(tmp_path):
+    marker = tmp_path / "marker.txt"
+    marker.write_text("hi")
+    results = grade(tmp_path, host_marker=str(marker), host_marker_min_size=64)
+    assert "host_marker: failed (too small: 2 bytes, expected >= 64)" in results
+
+
+def test_results_relative_marker_resolves_into_outdir(tmp_path):
+    (tmp_path / "marker.txt").write_text("hello")
+    results = grade(tmp_path, host_marker="results/marker.txt")
+    assert "host_marker: passed" in results
+
+
+def test_negative_min_size_rejected(tmp_path):
+    with pytest.raises(ValueError, match="host_marker_min_size"):
+        load_pyplugin(str(PLUGIN), outdir=tmp_path,
+                      args={"host_marker": "x", "host_marker_min_size": -1})
+
+
+def test_output_contains_still_uses_existence_only(tmp_path):
+    (tmp_path / "run_on_bind_output.txt").write_text("uid=0(root)\n")
+    results = grade(tmp_path, output_contains=["root", "uid=0"])
+    assert "output_contains: passed" in results
+
+
+def test_output_contains_reports_missing_strings(tmp_path):
+    (tmp_path / "run_on_bind_output.txt").write_text("uid=1000(user)\n")
+    results = grade(tmp_path, output_contains=["root"])
+    assert "output_contains: failed (missing: root)" in results


### PR DESCRIPTION
## Summary

Adds `run_on_bind`, a standalone plugin that executes host or guest commands when a guest
service binds a port exposed to the host by the VPN plugin.

This started as an extension to `fetch_web`. It is split into its own plugin so that:

- `fetch_web` remains responsible only for detecting web services and retrieving content.
- Bind-triggered execution works for any service, not just HTTP/HTTPS.
- Command execution can be tested independently of web fetching.

## Changes

### New: `run_on_bind`

* Subscribes to the VPN `on_bind` event and filters by `proto`, `ports`, and an optional
  `endpoints` allowlist. Ports are not hardcoded to HTTP/HTTPS: `ports` accepts any list,
  and `[]` accepts any port. By default, `ports` is `[80, 443]` so an unfiltered
  configuration does not trigger on the first unrelated bind (for example, a target that
  binds UPnP on port 1900 before its web service binds port 80).
* De-duplicates per endpoint, and drains a queue from a single worker thread so two
  simultaneous binds can never produce concurrent `guest_cmd.py` invocations.
* **Host mode**: runs on the host (inside the container), with the working directory set to
  penguin's `proj_dir` argument. Host commands receive the host port to which the VPN plugin
  mapped the guest service. Because this port may be remapped when the guest port is
  privileged or already in use, it cannot be reliably hardcoded in the configuration. The
  mapped port is exposed in two ways:
  * `{host_port}` anywhere in the command string is replaced with the mapped port before
    the command is executed.
  * `PENGUIN_HOST_PORT` is set in the command's environment.
  The VPN bridge listens on `0.0.0.0` inside the container, so a host command such as
  `curl -sf http://127.0.0.1:{host_port}/` can reach the mapped service.
* **Guest mode** (default): runs inside the emulated guest via `guest_cmd.py`. Requires
  `core.guest_cmd: true`. Guest commands execute inside the guest and access the guest port
  directly, so they are left unchanged and do not receive the mapped host port.
* `delay` (default 20s) before running, and a per-command `timeout` (default 120s) so an
  unresponsive guest cannot hang the run.
* An attempt succeeds if **any** configured command succeeds. Configurations routinely
  include commands that only apply to some targets, so requiring all of them to pass would
  keep retrying endpoints on account of commands that were never going to work.
* A failed attempt is not terminal: the next endpoint to bind gets its own try, uncapped.
  This keeps a run from wedging when the first endpoint to appear (often a loopback bind)
  isn't the one that works. The first successful attempt is the last.
* `shutdown_after_cmd` ends the emulation after the first successful attempt.
* Writes `run_on_bind_output.txt` one block per command per attempt, recording endpoint,
  attempt, mode, command, `Status: SUCCESS|FAILED`, return code, stdout, and stderr. Every
  command is recorded regardless of outcome, including timeouts and missing executables.


### New: `run_on_bind_testing` 

- `host_marker`: a file a host-mode command is expected to create. Relative paths resolve
  against `proj_dir` — the same working directory host commands run in — so a command
  writing a relative path and this check agree on where the file lands. `results/…` resolves
  against the output directory; absolute paths are used as-is.
- `output_contains`: strings expected in `run_on_bind_output.txt`.
- `wait_timeout` (default 30): polls for each expected file rather than sleeping a fixed
  interval, so a passing run finishes as soon as the files appear.
- Writes results to `run_on_bind_test.txt`.

### `fetch_web_testing` scoped back to fetch_web only

Removed `cmd_on_bind_marker`, `cmd_on_bind_guest_output_contains`, and `cmd_wait_timeout`;
those checks now live in `run_on_bind_testing`. Web-service verification (the
`web_<ip>_<port>` output files) is unchanged.


## Example

```yaml
core:
  guest_cmd: true
  timeout: 600

plugins:
  run_on_bind:
    ports: [80]
    commands:
      - mode: host
        run:
          - touch hello.txt
      - mode: guest
        run:
          - echo "im here" > /tmp/temp.txt && cat /tmp/temp.txt
    shutdown_after_cmd: true

  run_on_bind_testing:
    host_marker: hello.txt
    output_contains:
      - here
    wait_timeout: 30
```

This verifies that host-mode commands create the expected marker file and that guest-mode
commands execute and produce the expected output.

`commands` also accepts a bare string or a list of strings, both of which default to guest
mode:

```yaml
  run_on_bind:
    commands: python3 example.py
```

## Running alongside `fetch_web`

The two plugins share no state, separate subscriptions, queues, worker threads and output
files, but either can end the emulation. When both are loaded, enable at most one shutdown
flag (`shutdown_after_cmd`, `shutdown_after_www`, `shutdown_on_failure`); otherwise whichever
finishes first calls `end_analysis()` and truncates the other's in-flight work. To let both
complete, leave all three unset and bound the run with `core.timeout`, which is otherwise
unbounded.