### PR TITLE
wrapper: rewrite host paths in --extra_docker_args for the shared daemon

### DIFF
--- a/penguin
+++ b/penguin
@@ -1025,8 +1025,20 @@ penguin_run() {
         docker_cmd+=("-w" "/workspace")
     fi
 
-    # Add extra args, if set
+    # Add extra args, if set. Under a shared daemon, host bind paths passed via
+    # --extra_docker_args must be expressed in the daemon's view just like the
+    # wrapper's own mounts above (e.g. CI's
+    # `--extra_docker_args "-v <_work>/results:/workspace/results"`) -- otherwise
+    # the raw host path resolves in the daemon's namespace, not this runner's
+    # per-pod workspace, and penguin fails writing into the bind (e.g. creating
+    # results/latest -> EPERM). The invariant is just "a path under FROM becomes
+    # TO", so a plain string substitution over the whole arg string covers every
+    # mount syntax (-v, --volume, --mount) without parsing docker's grammar.
+    # No-op when PENGUIN_HOST_MOUNT_* are unset (every local / non-shared run).
     if [ -n "$extra_docker_args" ]; then
+        if [ -n "${PENGUIN_HOST_MOUNT_FROM:-}" ] && [ -n "${PENGUIN_HOST_MOUNT_TO:-}" ]; then
+            extra_docker_args="${extra_docker_args//$PENGUIN_HOST_MOUNT_FROM/$PENGUIN_HOST_MOUNT_TO}"
+        fi
         docker_cmd+=($extra_docker_args)
     fi
 


### PR DESCRIPTION
## Problem — rehostings nightly is fully red

Every `build_images (<device>)` job in the rehostings nightly fails at the `repro` step:

```
+ penguin --extra_docker_args '-v /home/runner/_work/rehostings/rehostings/docker/results:/workspace/results' repro …
penguin v3.0.66
PermissionError: [Errno 13] Permission denied: './0' -> '/workspace/./results/latest'
```

## Root cause

The shared-daemon mount rewrite (`rewrite_host_mount()`) is applied to the wrapper's own `-v` maps and the workspace mount, **but `--extra_docker_args` was appended to the docker command verbatim** (`docker_cmd+=($extra_docker_args)`). On the shared per-node CI daemon a bind passed that way keeps its raw `/home/runner/_work/…` host path, which the daemon resolves in **its own** namespace instead of this runner's per-pod checkout. So `-v <_work>/results:/workspace/results` lands on a wrong, root-owned dir, and penguin dies creating the `results/latest -> 0` symlink with EPERM — failing every device build.

## Fix

The invariant is just *"a host path under `PENGUIN_HOST_MOUNT_FROM` must be expressed as `PENGUIN_HOST_MOUNT_TO`"* — the same thing the wrapper already does for its own mounts. That needs no understanding of docker's argument grammar, so it's a plain prefix substitution over the whole `--extra_docker_args` string:

```bash
if [ -n "$extra_docker_args" ]; then
    if [ -n "${PENGUIN_HOST_MOUNT_FROM:-}" ] && [ -n "${PENGUIN_HOST_MOUNT_TO:-}" ]; then
        extra_docker_args="${extra_docker_args//$PENGUIN_HOST_MOUNT_FROM/$PENGUIN_HOST_MOUNT_TO}"
    fi
    docker_cmd+=($extra_docker_args)
fi
```

Covers every mount syntax (`-v`, `--volume`, `--mount type=bind,source=…`) for free, since it doesn't parse args.

> An earlier revision of this PR tokenized the arg string and rewrote `-v`/`--volume` host sides explicitly. Replaced with the one-line substitution above — simpler, and it also covers `--mount`, which the tokenizer missed.

## Safety

The container side of a bind (e.g. `/workspace/results`) never contains the `_work` prefix, so only the host side is rewritten. And it's a **no-op** unless both `PENGUIN_HOST_MOUNT_FROM`/`TO` are set — i.e. every local and non-shared run is byte-identical to before. Verified in isolation across all four mount syntaxes; env-unset leaves the arg string unchanged.
