### PR TITLE
Syscalls method detection fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 .*.sw*
 pyplugins/__pycache__
+**/__pycache__
+**/.pytest_cache
 unittest
 tests
 src/penguin.egg-info

--- a/pyplugins/apis/kprobes.py
+++ b/pyplugins/apis/kprobes.py
@@ -68,7 +68,9 @@ class Kprobes(Plugin):
         self._kprobe_event = self.plugins.portal.wrap(self._kprobe_event)
 
     def _resolve_callback(self, f, is_method, hook_ptr):
-        if is_method and hasattr(f, '__qualname__') and '.' in f.__qualname__:
+        if (is_method and hasattr(f, '__qualname__')
+                and '.' in f.__qualname__
+                and '<locals>' not in f.__qualname__):
             class_name = f.__qualname__.split('.')[0]
             method_name = f.__qualname__.split('.')[-1]
             try:
@@ -430,7 +432,9 @@ class Kprobes(Plugin):
                 wrapper._original_func = func
 
                 is_method = hasattr(func, '__self__') or (
-                    hasattr(func, '__qualname__') and '.' in func.__qualname__)
+                    hasattr(func, '__qualname__')
+                    and '.' in func.__qualname__
+                    and '<locals>' not in func.__qualname__)
 
                 for kprobe_config in kprobe_configs:
                     kprobe_config["callback"] = func

--- a/pyplugins/apis/syscalls.py
+++ b/pyplugins/apis/syscalls.py
@@ -722,7 +722,9 @@ class Syscalls(Plugin):
         callable or None
             The resolved callable.
         """
-        if is_method and hasattr(f, '__qualname__') and '.' in f.__qualname__:
+        if (is_method and hasattr(f, '__qualname__')
+                and '.' in f.__qualname__
+                and '<locals>' not in f.__qualname__):
             class_name = f.__qualname__.split('.')[0]
             method_name = f.__qualname__.split('.')[-1]
             try:
@@ -1087,9 +1089,14 @@ class Syscalls(Plugin):
 
             # Detect if this is a method by checking if it has __self__ (bound method)
             # or if it's being called on a class (unbound method during class
-            # definition)
+            # definition). A nested closure (e.g. a handler defined inside another
+            # method) also has a dotted __qualname__, but it carries '<locals>' and
+            # is NOT resolvable via getattr(plugins, ClassName) -- exclude it so it
+            # is used directly rather than dropped at resolution time.
             is_method = hasattr(func, '__self__') or (
-                hasattr(func, '__qualname__') and '.' in func.__qualname__)
+                hasattr(func, '__qualname__')
+                and '.' in func.__qualname__
+                and '<locals>' not in func.__qualname__)
 
             # Create hook configuration
             hook_config = {

--- a/pyplugins/apis/uprobes.py
+++ b/pyplugins/apis/uprobes.py
@@ -54,7 +54,9 @@ class Uprobes(Plugin):
         self._uprobe_event = self.plugins.portal.wrap(self._uprobe_event)
 
     def _resolve_callback(self, f, is_method, hook_ptr):
-        if is_method and hasattr(f, '__qualname__') and '.' in f.__qualname__:
+        if (is_method and hasattr(f, '__qualname__')
+                and '.' in f.__qualname__
+                and '<locals>' not in f.__qualname__):
             class_name = f.__qualname__.split('.')[0]
             method_name = f.__qualname__.split('.')[-1]
             try:
@@ -423,7 +425,9 @@ class Uprobes(Plugin):
                 wrapper._original_func = func
 
                 is_method = hasattr(func, '__self__') or (
-                    hasattr(func, '__qualname__') and '.' in func.__qualname__)
+                    hasattr(func, '__qualname__')
+                    and '.' in func.__qualname__
+                    and '<locals>' not in func.__qualname__)
 
                 for uprobe_config in uprobe_configs:
                     uprobe_config["callback"] = func

--- a/tests/unit/test_syscalls_method_detection.py
+++ b/tests/unit/test_syscalls_method_detection.py
@@ -1,26 +1,33 @@
-"""Regression coverage for syscall-hook callback classification in
-``pyplugins/apis/syscalls.py``.
+"""Regression coverage for hook-callback classification in the three probe APIs
+(``pyplugins/apis/{syscalls,uprobes,kprobes}.py``).
 
-The ``Syscalls.syscall`` decorator has to tell three kinds of callable apart:
+Each decorator has to tell three kinds of callable apart:
 
 * a **bound method** (``func.__self__`` set),
 * an **unbound plugin method** captured at class-definition time (qualname
-  ``Plugin.method``) — which must be re-resolved to the bound method on the live
-  plugin instance at event time, and
-* a **nested closure** (qualname ``Outer.method.<locals>.handler``) — which is a
-  plain function and must be used *as-is*.
+  ``Plugin.method``) — re-resolved to the bound method on the live plugin
+  instance at event time, and
+* a **nested closure** (qualname ``Outer.method.<locals>.handler``) — a plain
+  function that must be used *as-is*.
 
 The original heuristic classified anything with a dotted ``__qualname__`` as a
 method. A closure's qualname always contains ``<locals>`` and dots, so it was
-misclassified; ``_resolve_syscall_callback`` then tried
-``getattr(plugins, "Outer")`` / ``hasattr(instance, "handler")``, failed, logged
-``"Could not find method handler on instance"`` and returned ``None`` — silently
-dropping the hook. This is exactly the path the ``breakpoint syscall`` CLI takes,
-because ``HookLogger.register_syscall`` wraps every action in a nested ``handler``
-closure.
+misclassified, and ``_resolve_callback`` then split the qualname and tried
+``getattr(plugins, "Outer")`` / ``hasattr(instance, "handler")``. The
+consequences differed by API:
 
-These tests drive the *real* module (behind the ``hyper.consts`` FFI-enum
-boundary, so they need the real ISF fixture) with a null ``plugins`` bound.
+* **syscalls** logged ``"Could not find method handler on instance"`` and
+  returned ``None`` — silently dropping the hook (the ``breakpoint syscall`` CLI
+  bug, since ``HookLogger.register_syscall`` wraps every action in a nested
+  ``handler`` closure);
+* **uprobes/kprobes** fell through to ``return f`` (hook still fired) *unless* a
+  plugin was registered under the closure's outer name and exposed a matching
+  attribute — then they bound to the **wrong** callable.
+
+The fix, in all three, is to also require ``<locals>`` be absent from the
+qualname, so a nested closure is never mistaken for a method. These tests drive
+the real modules (behind the ``hyper.consts`` FFI-enum boundary, so they need the
+real ISF fixture) with a null ``plugins`` bound.
 """
 from pathlib import Path
 
@@ -29,7 +36,7 @@ import pytest
 from penguin.testing import load_module
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SYSCALLS = str(REPO_ROOT / "pyplugins" / "apis" / "syscalls.py")
+APIS = REPO_ROOT / "pyplugins" / "apis"
 
 
 # --- module-level stand-ins ------------------------------------------------- #
@@ -41,19 +48,29 @@ SYSCALLS = str(REPO_ROOT / "pyplugins" / "apis" / "syscalls.py")
 
 class _ClosureMaker:
     """Stands in for ``HookLogger``: a method that returns a nested closure,
-    just like ``register_syscall`` does with its ``handler``."""
+    just like ``register_syscall``/``register_uprobe`` do with their ``handler``.
+    The closure's qualname is ``_ClosureMaker.register.<locals>.handler``."""
 
     def register(self):
-        def handler(regs, proto, sc, *args):   # nested closure -> "<locals>"
+        def handler(*args, **kwargs):
             yield from ()
         return handler
 
 
-class _MethodPlugin:
-    """Stands in for a normal plugin whose class-body method is registered
-    directly as a syscall callback."""
+class _Decoy:
+    """A plugin registered under the name ``_ClosureMaker`` (the closure's outer
+    class name) that *does* expose a ``handler`` attribute. A resolver that
+    misreads the closure as the method ``_ClosureMaker.handler`` would wrongly
+    bind to this instead of returning the closure."""
 
-    def on_syscall(self, regs, proto, sc, *args):
+    def handler(self, *args, **kwargs):
+        yield from ()
+
+
+class _MethodPlugin:
+    """A normal plugin whose class-body method is registered directly."""
+
+    def on_event(self, *args, **kwargs):
         yield from ()
 
 
@@ -68,62 +85,78 @@ class _RecordingLogger:
         pass
 
 
-def _make_syscalls(igloo_ko_isf):
-    """Import the real ``apis.syscalls`` (real consts via the ISF) and build a
-    ``Syscalls`` instance without its PANDA-heavy ``__init__``, wiring only the
-    attributes the decorator and resolver touch."""
-    mod, mgr = load_module(SYSCALLS, real_isf=igloo_ko_isf)
-    s = mod.Syscalls.__new__(mod.Syscalls)
-    s._pending_hooks = []
-    s._hooks = {}
-    s.logger = _RecordingLogger()
-    return s, mgr
+# (module filename, plugin class, resolver method, resolver takes a hook_ptr arg)
+CASES = [
+    ("syscalls.py", "Syscalls", "_resolve_syscall_callback", False),
+    ("uprobes.py", "Uprobes", "_resolve_callback", True),
+    ("kprobes.py", "Kprobes", "_resolve_callback", True),
+]
+CASE_IDS = [c[1] for c in CASES]
 
 
-# --- the regression: a closure hook must not be treated as a method --------- #
-def test_nested_closure_hook_is_not_classified_as_method(igloo_ko_isf):
-    s, _ = _make_syscalls(igloo_ko_isf)
+def _make(igloo_ko_isf, filename, clsname):
+    """Import the real API module (real consts via the ISF) and build the plugin
+    without its PANDA-heavy ``__init__``, wiring only what the resolver touches."""
+    mod, mgr = load_module(str(APIS / filename), real_isf=igloo_ko_isf)
+    cls = getattr(mod, clsname)
+    inst = cls.__new__(cls)
+    inst._hooks = {}
+    inst.logger = _RecordingLogger()
+    return inst, mgr
+
+
+def _resolve(inst, method, takes_hook_ptr, f, is_method):
+    fn = getattr(inst, method)
+    # hook_ptr 0 is absent from the empty _hooks map, so the cache-update branch
+    # is skipped and only the classification path is exercised.
+    return fn(f, is_method, 0) if takes_hook_ptr else fn(f, is_method)
+
+
+# --- the regression, across all three probe APIs ---------------------------- #
+@pytest.mark.parametrize("filename,clsname,method,hp", CASES, ids=CASE_IDS)
+def test_nested_closure_hook_is_neither_dropped_nor_misbound(
+        igloo_ko_isf, filename, clsname, method, hp):
+    inst, mgr = _make(igloo_ko_isf, filename, clsname)
     handler = _ClosureMaker().register()
     assert "<locals>" in handler.__qualname__     # sanity: this is the shape that broke
+
+    # Register a decoy under the closure's outer class name that *has* a "handler"
+    # attribute. Pre-fix: syscalls -> None (drop); uprobes/kprobes -> decoy.handler
+    # (wrong bind). Either way, not the closure. Pass is_method=True (the worst
+    # case the old heuristic produced) so the resolver's guard is what's tested.
+    mgr._ClosureMaker = _Decoy()
+
+    resolved = _resolve(inst, method, hp, handler, True)
+
+    assert resolved is handler
+    assert inst.logger.errors == []
+
+
+@pytest.mark.parametrize("filename,clsname,method,hp", CASES, ids=CASE_IDS)
+def test_real_plugin_method_still_binds(igloo_ko_isf, filename, clsname, method, hp):
+    """Guard against over-correction: a genuine class-body plugin method (qualname
+    without "<locals>") must still resolve to the bound method on the instance."""
+    inst, mgr = _make(igloo_ko_isf, filename, clsname)
+    target = _MethodPlugin()
+    mgr._MethodPlugin = target                    # getattr(plugins, "_MethodPlugin")
+
+    resolved = _resolve(inst, method, hp, _MethodPlugin.on_event, True)
+
+    assert getattr(resolved, "__self__", None) is target
+    assert getattr(resolved, "__func__", None) is _MethodPlugin.on_event
+
+
+# --- syscalls decorator: is_method is recorded at registration -------------- #
+def test_syscalls_decorator_flags_closure_as_not_a_method(igloo_ko_isf):
+    """Cover the *other* fix site: the ``@syscall`` decorator stores ``is_method``
+    in the hook config at registration time, and it must be False for a closure."""
+    mod, mgr = load_module(str(APIS / "syscalls.py"), real_isf=igloo_ko_isf)
+    s = mod.Syscalls.__new__(mod.Syscalls)
+    s._pending_hooks = []
+    handler = _ClosureMaker().register()
 
     s.syscall("ioctl")(handler)
 
     hook_config = s._pending_hooks[-1][0]
     assert hook_config["callback"] is handler
     assert hook_config["is_method"] is False
-
-    # With is_method False the resolver returns the closure unchanged (the hook
-    # fires) rather than trying — and failing — to bind it to a plugin instance.
-    assert s._resolve_syscall_callback(handler, hook_config["is_method"]) is handler
-
-
-def test_resolver_does_not_drop_closure_even_if_flagged_a_method(igloo_ko_isf):
-    """Defense in depth: even if a caller passes ``is_method=True`` for a closure,
-    the resolver must return the closure (not ``None``) and log no
-    "Could not find method" error — the exact failure the user hit."""
-    s, mgr = _make_syscalls(igloo_ko_isf)
-    handler = _ClosureMaker().register()
-    # Make the pre-fix error path deterministic: a real instance is resolvable by
-    # class name but has no "handler" attribute, so the old code logged + dropped.
-    mgr._ClosureMaker = _ClosureMaker()
-
-    resolved = s._resolve_syscall_callback(handler, True)
-
-    assert resolved is handler
-    assert s.logger.errors == []
-
-
-# --- positive control: a genuine plugin method still resolves --------------- #
-def test_plugin_method_hook_still_resolves_to_bound_method(igloo_ko_isf):
-    s, mgr = _make_syscalls(igloo_ko_isf)
-    instance = _MethodPlugin()
-    mgr._MethodPlugin = instance                  # getattr(plugins, "_MethodPlugin")
-
-    # Registered unbound (as at class-definition time): qualname "_MethodPlugin.on_syscall".
-    s.syscall("ioctl")(_MethodPlugin.on_syscall)
-    hook_config = s._pending_hooks[-1][0]
-    assert hook_config["is_method"] is True
-
-    resolved = s._resolve_syscall_callback(_MethodPlugin.on_syscall, True)
-    assert resolved.__self__ is instance
-    assert resolved.__func__ is _MethodPlugin.on_syscall

--- a/tests/unit/test_syscalls_method_detection.py
+++ b/tests/unit/test_syscalls_method_detection.py
@@ -1,0 +1,129 @@
+"""Regression coverage for syscall-hook callback classification in
+``pyplugins/apis/syscalls.py``.
+
+The ``Syscalls.syscall`` decorator has to tell three kinds of callable apart:
+
+* a **bound method** (``func.__self__`` set),
+* an **unbound plugin method** captured at class-definition time (qualname
+  ``Plugin.method``) — which must be re-resolved to the bound method on the live
+  plugin instance at event time, and
+* a **nested closure** (qualname ``Outer.method.<locals>.handler``) — which is a
+  plain function and must be used *as-is*.
+
+The original heuristic classified anything with a dotted ``__qualname__`` as a
+method. A closure's qualname always contains ``<locals>`` and dots, so it was
+misclassified; ``_resolve_syscall_callback`` then tried
+``getattr(plugins, "Outer")`` / ``hasattr(instance, "handler")``, failed, logged
+``"Could not find method handler on instance"`` and returned ``None`` — silently
+dropping the hook. This is exactly the path the ``breakpoint syscall`` CLI takes,
+because ``HookLogger.register_syscall`` wraps every action in a nested ``handler``
+closure.
+
+These tests drive the *real* module (behind the ``hyper.consts`` FFI-enum
+boundary, so they need the real ISF fixture) with a null ``plugins`` bound.
+"""
+from pathlib import Path
+
+import pytest
+
+from penguin.testing import load_module
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SYSCALLS = str(REPO_ROOT / "pyplugins" / "apis" / "syscalls.py")
+
+
+# --- module-level stand-ins ------------------------------------------------- #
+# Defined at module scope on purpose: a real Penguin plugin is a module-level
+# class, so its methods have qualname "Plugin.method" (no "<locals>"), while a
+# handler closure created *inside* one of its methods has "<locals>" in its
+# qualname. Defining these inside a test function would inject an extra
+# "<locals>" into every qualname and mask the distinction under test.
+
+class _ClosureMaker:
+    """Stands in for ``HookLogger``: a method that returns a nested closure,
+    just like ``register_syscall`` does with its ``handler``."""
+
+    def register(self):
+        def handler(regs, proto, sc, *args):   # nested closure -> "<locals>"
+            yield from ()
+        return handler
+
+
+class _MethodPlugin:
+    """Stands in for a normal plugin whose class-body method is registered
+    directly as a syscall callback."""
+
+    def on_syscall(self, regs, proto, sc, *args):
+        yield from ()
+
+
+class _RecordingLogger:
+    def __init__(self):
+        self.errors = []
+
+    def error(self, msg, *a, **k):
+        self.errors.append(msg % a if a else msg)
+
+    def info(self, *a, **k):
+        pass
+
+
+def _make_syscalls(igloo_ko_isf):
+    """Import the real ``apis.syscalls`` (real consts via the ISF) and build a
+    ``Syscalls`` instance without its PANDA-heavy ``__init__``, wiring only the
+    attributes the decorator and resolver touch."""
+    mod, mgr = load_module(SYSCALLS, real_isf=igloo_ko_isf)
+    s = mod.Syscalls.__new__(mod.Syscalls)
+    s._pending_hooks = []
+    s._hooks = {}
+    s.logger = _RecordingLogger()
+    return s, mgr
+
+
+# --- the regression: a closure hook must not be treated as a method --------- #
+def test_nested_closure_hook_is_not_classified_as_method(igloo_ko_isf):
+    s, _ = _make_syscalls(igloo_ko_isf)
+    handler = _ClosureMaker().register()
+    assert "<locals>" in handler.__qualname__     # sanity: this is the shape that broke
+
+    s.syscall("ioctl")(handler)
+
+    hook_config = s._pending_hooks[-1][0]
+    assert hook_config["callback"] is handler
+    assert hook_config["is_method"] is False
+
+    # With is_method False the resolver returns the closure unchanged (the hook
+    # fires) rather than trying — and failing — to bind it to a plugin instance.
+    assert s._resolve_syscall_callback(handler, hook_config["is_method"]) is handler
+
+
+def test_resolver_does_not_drop_closure_even_if_flagged_a_method(igloo_ko_isf):
+    """Defense in depth: even if a caller passes ``is_method=True`` for a closure,
+    the resolver must return the closure (not ``None``) and log no
+    "Could not find method" error — the exact failure the user hit."""
+    s, mgr = _make_syscalls(igloo_ko_isf)
+    handler = _ClosureMaker().register()
+    # Make the pre-fix error path deterministic: a real instance is resolvable by
+    # class name but has no "handler" attribute, so the old code logged + dropped.
+    mgr._ClosureMaker = _ClosureMaker()
+
+    resolved = s._resolve_syscall_callback(handler, True)
+
+    assert resolved is handler
+    assert s.logger.errors == []
+
+
+# --- positive control: a genuine plugin method still resolves --------------- #
+def test_plugin_method_hook_still_resolves_to_bound_method(igloo_ko_isf):
+    s, mgr = _make_syscalls(igloo_ko_isf)
+    instance = _MethodPlugin()
+    mgr._MethodPlugin = instance                  # getattr(plugins, "_MethodPlugin")
+
+    # Registered unbound (as at class-definition time): qualname "_MethodPlugin.on_syscall".
+    s.syscall("ioctl")(_MethodPlugin.on_syscall)
+    hook_config = s._pending_hooks[-1][0]
+    assert hook_config["is_method"] is True
+
+    resolved = s._resolve_syscall_callback(_MethodPlugin.on_syscall, True)
+    assert resolved.__self__ is instance
+    assert resolved.__func__ is _MethodPlugin.on_syscall


### PR DESCRIPTION
Correctly classify nested closures in the syscall/uprobe/kprobe APIs

The hook-registration decorators in apis/{syscalls,uprobes,kprobes}.py decided whether a callback was a plugin method by checking only for a dotted __qualname__, which misclassifies nested closures (e.g. the `handler` that HookLogger.register_syscall builds for every `breakpoint syscall`/`uprobe`) since their qualname is `Class.method.<locals>.handler`.

For syscalls this was user-visible: the resolver then failed to bind the "method," logged `Could not find method handler on instance`, and returned None, silently dropping the hook so no syscall trace fired. Uprobes/kprobes didn't drop hooks (their resolver falls through to `return f`), but the same misclassification risks binding to the wrong callable and forces a redundant plugin lookup on every event.

The fix adds a `'<locals>' not in __qualname__` guard at both the classification and resolution sites in all three files, so a closure is used as-is while genuine class-body methods still bind.

Adds tests/unit/test_syscalls_method_detection.py (parametrized over all three APIs), verified in-container to fail on the pre-fix code and pass after.