### PR TITLE
docs: also publish rendered HTML to a `docs` branch

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -162,6 +162,10 @@ jobs:
   deploy_static:
     needs: build_docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # force-push the rendered HTML to the `docs` branch
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -176,6 +180,20 @@ jobs:
         run: |
           mkdir html_content
           tar -xvf docs.tar.gz -C html_content
+
+      # Also publish the rendered site to a `docs` branch so it can be cloned
+      # and served directly (git clone --branch docs --depth 1 …), independent
+      # of the GitHub Pages artifact deploy below and the release tarball.
+      # force_orphan keeps `docs` as a single-commit, generated-only branch with
+      # no shared history — never hand-edit it. peaceiris disables Jekyll (drops
+      # a .nojekyll) by default, which Sphinx's `_static/` dirs require.
+      - name: Publish HTML to the docs branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./html_content
+          publish_branch: docs
+          force_orphan: true
       # A re-run (workflow or just this job) does NOT clear artifacts uploaded by
       # a prior attempt. upload-pages-artifact always names its artifact
       # "github-pages", so a re-run leaves 2+ identically-named artifacts in the


### PR DESCRIPTION
## What

Adds a step to the `deploy_static` job in `.github/workflows/docs.yaml` that force-pushes the built Sphinx HTML to an orphan `docs` branch, using `peaceiris/actions-gh-pages@v4`.

## Why

Today the rendered docs are only reachable via GitHub Pages or by downloading + untarring the `docs.tar.gz` release asset. Neither is a plain `git clone`. Publishing the site to a branch lets us clone and serve the static HTML directly:

```sh
git clone --branch docs --depth 1 <repo> penguin-docs
cd penguin-docs && python3 -m http.server
```

## How

- Reuses the same `./html_content` that `deploy_static` already untars for the Pages artifact — this is purely an additional publish target.
- `force_orphan: true` keeps `docs` as a single-commit, generated-only branch (no `main` history, no repo bloat).
- peaceiris disables Jekyll by default (drops a `.nojekyll`), which Sphinx's `_static/` dirs require.
- Added `contents: write` to the `deploy_static` job (job-level `permissions` blocks reset token scope, so `pages`/`id-token` are re-declared too).

The existing Pages artifact deploy and release-asset attach are untouched.

## Notes

- **First run bootstraps the branch** — `docs` is created on the first successful `deploy_static` after merge.
- **`docs` is machine-owned** — force-pushed every release; do not hand-edit.