### PR TITLE
Add statedir for persistent storage across boots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ results/
 projects/
 compose_projects/
 tests/integration/test_target/config.yaml
-tests/integration/test_target/nvram_state.yaml
+tests/integration/test_target/state/
 penguin.sif
 fw
 # Generated during the container build; absent in source checkouts (penguin

--- a/pyplugins/interventions/nvram2.py
+++ b/pyplugins/interventions/nvram2.py
@@ -40,6 +40,7 @@ import os
 import hashlib
 import glob
 import re
+import shutil
 import yaml
 from pathlib import Path
 
@@ -327,6 +328,7 @@ class Nvram2(Plugin):
 
         config = self.get_arg("conf")
         proj_dir = self.get_arg("proj_dir")
+        state_dir = self.get_arg("statedir")
         self.logging_enabled = self.get_arg_bool("logging", default=True)
         self.persist = self.get_arg_bool("persist", default=False)
         self.logger.info(f"logging nvram accesses: {self.logging_enabled}")
@@ -337,7 +339,18 @@ class Nvram2(Plugin):
         if self.persist:
             self.log_mask |= NVRAM_LOG_SET
 
-        self.persist_path = os.path.join(proj_dir, persisted_file) if proj_dir else None
+        self.persist_path = os.path.join(state_dir, persisted_file) if state_dir else None
+
+        # Migrate legacy nvram_state.yaml from proj_dir root to statedir if present.
+        if self.persist and self.persist_path and proj_dir:
+            legacy_path = os.path.join(proj_dir, persisted_file)
+            if os.path.exists(legacy_path) and not os.path.exists(self.persist_path):
+                try:
+                    shutil.move(legacy_path, self.persist_path)
+                    self.logger.info(f"migrated nvram state from {legacy_path} to {self.persist_path}")
+                except Exception as e:
+                    self.logger.warning(f"failed to migrate nvram state from {legacy_path}: {e}")
+
         self.state = self._load_persisted()
         if self.persist and self.state:
             config_nvram = config["nvram"] if "nvram" in config else {}

--- a/src/penguin/init_runner.py
+++ b/src/penguin/init_runner.py
@@ -170,6 +170,10 @@ class InitPluginRunner:
         # patch_name -> plugin name, filled as patches are collected
         self._patch_owner: Dict[str, str] = {}
 
+        # Ensure statedir exists before plugins use it (mirrors penguin_run.py).
+        state_dir = self.ctx.proj_dir / "state"
+        state_dir.mkdir(exist_ok=True, parents=True)
+
     # ----- loading ----------------------------------------------------------
 
     def load_plugins(self, extra_args: Optional[Dict[str, Any]] = None) -> List[InitPlugin]:
@@ -180,6 +184,7 @@ class InitPluginRunner:
             "conf": {},
             "proj_dir": str(self.ctx.proj_dir),
             "outdir": str(self.ctx.proj_dir),
+            "statedir": str(self.ctx.proj_dir / "state"),
             "plugin_path": self.ctx.options.get("plugin_path", ""),
             "verbose": self.ctx.options.get("verbose", False),
         }

--- a/src/penguin/penguin_run.py
+++ b/src/penguin/penguin_run.py
@@ -314,6 +314,10 @@ def run_config(
     if not os.path.isdir(qcow_dir):
         os.makedirs(qcow_dir, exist_ok=True)
 
+    state_dir = os.path.join(proj_dir, "state")
+    if not os.path.isdir(state_dir):
+        os.makedirs(state_dir, exist_ok=True)
+
     if out_dir is None:
         out_dir = os.path.join(proj_dir, "output")
     if not os.path.isdir(out_dir):
@@ -868,6 +872,7 @@ def run_config(
         "fs": config_fs,
         "fw": config_image,
         "outdir": out_dir,
+        "statedir": state_dir,
         "verbose": verbose,
         "telnet_port": telnet_port,
     }

--- a/src/penguin/plugin_manager.py
+++ b/src/penguin/plugin_manager.py
@@ -253,7 +253,7 @@ class Plugin:
         A snapshot does not capture host-side plugin state; plugins that hold
         in-memory state needed for continuity after a cross-process restore
         should return it here. File-backed state (e.g. NVRAM's nvram_state.yaml)
-        can self-heal via the output dir and need not be returned. The returned
+        can self-heal via the statedir and need not be returned. The returned
         value is stored in the snapshot's host sidecar and handed back to
         :meth:`load_state` on restore.
         """

--- a/tests/integration/test_target/test.py
+++ b/tests/integration/test_target/test.py
@@ -170,7 +170,9 @@ def run_test(kernel, arch, image, test_file=None, docs_only=False, execution_mod
 
     # Start from a clean nvram_state.yaml; a test may ship a preset
     # (patches/tests/<test>.state.yaml) to exercise the persistence reload path.
-    state_dest = Path(TEST_DIR, "nvram_state.yaml")
+    state_dir = Path(TEST_DIR, "state")
+    state_dir.mkdir(exist_ok=True)
+    state_dest = state_dir / "nvram_state.yaml"
     if state_dest.exists():
         state_dest.unlink()
     if test_file:


### PR DESCRIPTION
- Create <proj_dir>/state directory for persistent runtime state
- Add statedir to plugin args in penguin_run.py and init_runner.py
- Update nvram2 plugin to use statedir instead of proj_dir for nvram_state.yaml
- Update integration test to place nvram state files in state/ directory
- Update .gitignore to ignore test_target/state/ instead of specific nvram_state.yaml

The statedir provides a dedicated location for persistent state that survives across guest reboots, separate from per-run output (outdir) and project configuration (proj_dir). Currently used by nvram2 persistence feature.