### PR TITLE
Declarative lib_inject.stubs: force symbols to a constant / patch asm

### DIFF
--- a/docs/lib_inject.md
+++ b/docs/lib_inject.md
@@ -1,0 +1,124 @@
+# Library injection (`lib_inject`)
+
+Penguin can replace library functions in the guest at runtime by preloading a
+small shared object (`/igloo/lib_inject_<abi>.so`, wired in via
+`/etc/ld.so.preload`). This is how NVRAM shims work, and it is the mechanism
+behind three user-facing config knobs, all under `lib_inject:`.
+
+Because injection is a real `LD_PRELOAD`, it only affects **dynamically linked**
+guest binaries; statically linked programs are unaffected.
+
+## `lib_inject.aliases` — point a symbol at an existing shim
+
+```yaml
+lib_inject:
+  aliases:
+    nvram_load: nvram_init      # call nvram_load -> run the nvram_init shim
+    fputs: "false"              # fputs always "fails"
+```
+
+Maps a symbol name to the name of a function already defined in the injected
+library (the NVRAM shims, or the generic `libinject_ret_0` / `libinject_ret_1`
+constant returns). Wired with the linker's `--defsym`.
+
+## `lib_inject.extra` — inline custom C
+
+```yaml
+lib_inject:
+  extra: |
+    int my_check(void) { return 1; }
+```
+
+Raw C compiled straight into the injected library. Pair with `aliases` to route
+a real symbol at your function.
+
+## `lib_inject.d/` — hand-authored shim files
+
+Any `.c`/`.h` file dropped in `<project>/lib_inject.d/` is compiled into the
+injected library and the directory is added to the include path. This is the
+file-based counterpart to `extra:` — better when you have more than a snippet.
+Dotfiles and subdirectories are ignored, so `.generated/` (below) is never
+double-compiled.
+
+## `lib_inject.stubs` — declarative "just return a constant"
+
+Forcing a function to "just return 0/1" is a constant rehosting move. `stubs:`
+makes it declarative: it **compiles down to the machinery above** — one generated
+C shim per stub, plus an `aliases` entry — rather than making you hand-write both.
+
+```yaml
+lib_inject:
+  stubs:
+    libX.so:                       # library key: a label + the glob target
+      get_flag: { return: 0 }      # get_flag() -> 0
+      set_mode: { return: 1, type: int }
+      "nvram_*": { return: 0 }     # glob: every exported nvram_* symbol -> 0
+    /lib/libc.so:                  # absolute guest path also accepted
+      memcpy: { guard_null_args: [0, 1], return: 0 }
+```
+
+A stub takes one of two mutually exclusive forms.
+
+**Symbol return** — replace a symbol globally (LD_PRELOAD), touching no binary on
+disk:
+
+- **`return`** — the constant to return. Also the value returned on the NULL path
+  of a guarded stub (defaults to `0` if omitted).
+- **`type`** — the C return type of the generated shim. Defaults to `long`
+  (register width), which is right for most integer/pointer returns; override
+  for e.g. `int` or `void *`.
+- **`guard_null_args`** — zero-based argument positions to NULL-check. If any
+  listed argument is NULL the shim returns `return`; otherwise it **calls through
+  to the real function** (via `dlsym(RTLD_NEXT, ...)`).
+
+**Assembly body** — overwrite the instructions at one specific location in one
+specific binary:
+
+- **`body`** — assembly assembled with keystone and written over the symbol's
+  code. The stub key is `symbol` (patch at the symbol's start) or
+  `symbol@offset` (`offset` is hex `0x..` or decimal, added to the symbol
+  address). This form compiles down to a `static_files` `binary_patch` action —
+  `binary_patch` stays the single owner of on-disk patching.
+- **`mode`** — assembly mode passed to `binary_patch` (e.g. `arm`/`thumb`);
+  defaults to the target arch's natural mode.
+- **`expect`** — optional hex of the bytes expected at the patch site, checked
+  before the overwrite.
+
+```yaml
+lib_inject:
+  stubs:
+    libvendor.so:
+      hw_probe:        { body: "movs r0, #0\nbx lr", mode: thumb }  # return 0 in Thumb
+      init_dsp@0x10:   { body: "nop" }                              # patch 16 bytes in
+```
+
+Unlike the symbol-return forms, an assembly-body stub edits exactly one binary
+(the library key), not every importer of the symbol.
+
+### Notes and limits
+
+- **Library key.** It is an organizational label *and* the target for glob
+  expansion. Aliasing itself is global (a stubbed symbol is replaced everywhere
+  it is imported), matching how `lib_inject` works. An absolute path
+  (`/lib/libc.so`) is matched exactly; a bare basename (`libX.so`) is searched
+  for in the rootfs and must be unambiguous.
+- **Globs** are expanded against the library's exported (`.dynsym`) symbols at
+  build time. A glob that resolves to no library, an ambiguous basename, a
+  stripped object, or zero matching symbols is a hard error — a silently-empty
+  stub is worse than a loud failure.
+- **`guard_null_args` call-through** preserves the first 8 integer/pointer
+  register arguments only; floating-point, struct-by-value, and stack arguments
+  are not carried through. It also imports `dlsym`, so use it only where a real
+  dynamic linker is present (the normal LD_PRELOAD case).
+- **Precedence.** A symbol may not appear in both `stubs` and `aliases`; doing so
+  is a hard error, so there is exactly one owner per symbol.
+- **Generated files.** The symbol-return shims are written to
+  `<project>/lib_inject.d/.generated/` (regenerated on every build) so you can
+  inspect the exact C that was compiled. They live under a dotfile subdir so the
+  `lib_inject.d/` scanner ignores them.
+- **Assembly bodies delegate to `binary_patch`.** The `body`/`symbol@offset`
+  form does not invent a new patching mechanism — it resolves the symbol to a
+  file offset (statically, from the rootfs) and emits a `static_files`
+  `binary_patch`, which applies the edit at boot. Multiple body stubs on the same
+  binary are coalesced into one action. Symbol resolution needs a non-stripped
+  symbol table in the target object.

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -280,6 +280,28 @@ pseudofiles:
                 val: 0
 ```
 
+## Stubbing library functions
+
+When a program calls a library function that misbehaves under emulation (a
+hardware probe, a licensing check, a NVRAM accessor), forcing that function to
+return a constant is often enough to get past it. Declare it under
+`lib_inject.stubs`:
+
+```yaml
+lib_inject:
+  stubs:
+    libvendor.so:
+      hw_present: { return: 1 }
+      "check_*":  { return: 0 }        # glob over exported symbols
+    /lib/libc.so:
+      memcpy: { guard_null_args: [0, 1], return: 0 }  # skip on NULL, else real
+```
+
+This compiles down to the injected library (a generated shim + a `--defsym`
+alias), so it reuses the same build path as `lib_inject.aliases`/`extra`. See
+[lib_inject.md](lib_inject.md) for the full reference, including globs,
+return-type overrides, the `guard_null_args` call-through, and its limits.
+
 ## Advanced debugging
 If you've tried selecting the correct init program, modeling psueodfiles, and
 adding environment variables but things are still failing, you'll need to

--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -2647,6 +2647,188 @@ nvram_init
 
 Custom source code for library functions to intercept and model
 
+### `lib_inject.stubs` Declarative symbol stubs
+
+|||
+|-|-|
+|__Default__|`null`|
+
+Declarative symbol stubs, grouped by library/object.
+
+    Each key is a library/object (an absolute guest path like ``/lib/libc.so``
+    or a bare basename like ``libX.so`` searched for in the rootfs). Each value
+    maps a symbol key to a stub action. A symbol key is either a symbol name, a
+    glob such as ``nvram_*`` (expanded against the library's exported symbols at
+    build time; symbol-return stubs only), or ``symbol@offset`` (assembly-body
+    stubs only, where ``offset`` is added to the symbol address).
+
+```yaml
+{}
+```
+
+```yaml
+/lib/libc.so:
+  memcpy:
+    guard_null_args:
+    - 0
+    - 1
+    return: 0
+libX.so:
+  get_flag:
+    return: 0
+  hw_probe:
+    body: 'movs r0, #0
+
+      bx lr'
+    mode: thumb
+  nvram_*:
+    return: 0
+```
+
+#### `lib_inject.stubs.<string>` Per-library symbol stubs
+
+Symbols (or globs) to stub within one library/object. The library key is
+    an organizational label and the glob-resolution target; aliasing itself is
+    global (``--defsym``).
+
+##### `lib_inject.stubs.<string>.<string>` Symbol stub
+
+A single declarative symbol stub.
+
+    Two mutually exclusive forms:
+
+    * **Symbol return** (``return`` / ``type`` / ``guard_null_args``): force a
+      symbol to return a constant, optionally guarding NULL arguments. Compiles
+      to a generated C shim plus a ``lib_inject`` alias (``--defsym``) -- a
+      global, LD_PRELOAD-based replacement that touches no binary on disk.
+
+    * **Assembly body** (``body`` / ``mode`` / ``expect``): overwrite the
+      instructions at a specific symbol location with assembled machine code.
+      Used when the stub key is ``symbol`` or ``symbol@offset``. Compiles down to
+      a ``static_files`` ``binary_patch`` action (the single owner of on-disk
+      patching); it edits one specific binary rather than replacing a symbol
+      everywhere.
+
+###### `lib_inject.stubs.<string>.<string>.return_` Constant value to return
+
+|||
+|-|-|
+|__Type__|integer or null|
+|__Default__|`null`|
+
+Value the stubbed symbol returns. For a plain stub this is the return value; for a 'guard_null_args' stub it is the value returned on the NULL path (defaults to 0 if omitted).
+
+```yaml
+0
+```
+
+```yaml
+1
+```
+
+```yaml
+42
+```
+
+###### `lib_inject.stubs.<string>.<string>.type` Return C type
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`long`|
+
+C return type of the generated shim. Defaults to register-width 'long', which is correct for most integer/pointer returns.
+
+```yaml
+long
+```
+
+```yaml
+int
+```
+
+```yaml
+unsigned int
+```
+
+```yaml
+void *
+```
+
+###### `lib_inject.stubs.<string>.<string>.guard_null_args` NULL-guarded argument positions
+
+|||
+|-|-|
+|__Type__|list of integer or null|
+|__Default__|`null`|
+
+Zero-based argument positions to NULL-check. If any listed argument is NULL the shim returns the 'return' constant; otherwise it calls through to the real symbol. Limited to the first 8 integer/pointer register arguments (indices 0-7); floating-point, struct-by-value, and stack arguments are not preserved on the call-through path.
+
+```yaml
+- 0
+```
+
+```yaml
+- 0
+- 1
+```
+
+###### `lib_inject.stubs.<string>.<string>.body` Assembly body to write at the symbol
+
+|||
+|-|-|
+|__Type__|string|
+|__Patch merge behavior__|Concatenate strings separated by `'\n'`|
+|__Default__|`null`|
+
+Assembly to assemble (via keystone) and write over the instructions at the stub's symbol/offset. Use with a 'symbol' or 'symbol@offset' key. Compiles down to a static_files 'binary_patch'. Mutually exclusive with 'return'/'guard_null_args'.
+
+```yaml
+'mov v0, $zero
+
+  jr $ra'
+```
+
+```yaml
+'movs r0, #0
+
+  bx lr'
+```
+
+###### `lib_inject.stubs.<string>.<string>.mode` Assembly mode for 'body'
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Assembly mode passed through to binary_patch (e.g. 'arm' or 'thumb' on ARM). Defaults to the target arch's natural mode.
+
+```yaml
+arm
+```
+
+```yaml
+thumb
+```
+
+###### `lib_inject.stubs.<string>.<string>.expect` Expected original bytes
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Optional hex string of the bytes expected at the patch site; passed through to binary_patch as a safety check before the 'body' overwrite.
+
+```yaml
+'00000000'
+```
+
+```yaml
+1eff2fe1
+```
+
 ## `static_files` Static files
 
 Files to create in the guest filesystem

--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -2693,30 +2693,16 @@ Symbols (or globs) to stub within one library/object. The library key is
 
 ##### `lib_inject.stubs.<string>.<string>` Symbol stub
 
-A single declarative symbol stub.
+A single declarative symbol stub. Two mutually exclusive forms: symbol-return ('return'/'type'/'guard_null_args'), which compiles to a generated C shim plus a lib_inject '--defsym' alias; and assembly-body ('body'/'mode'/'expect') at a 'symbol' or 'symbol@offset' key, which compiles to a static_files 'binary_patch'.
 
-    Two mutually exclusive forms:
-
-    * **Symbol return** (``return`` / ``type`` / ``guard_null_args``): force a
-      symbol to return a constant, optionally guarding NULL arguments. Compiles
-      to a generated C shim plus a ``lib_inject`` alias (``--defsym``) -- a
-      global, LD_PRELOAD-based replacement that touches no binary on disk.
-
-    * **Assembly body** (``body`` / ``mode`` / ``expect``): overwrite the
-      instructions at a specific symbol location with assembled machine code.
-      Used when the stub key is ``symbol`` or ``symbol@offset``. Compiles down to
-      a ``static_files`` ``binary_patch`` action (the single owner of on-disk
-      patching); it edits one specific binary rather than replacing a symbol
-      everywhere.
-
-###### `lib_inject.stubs.<string>.<string>.return_` Constant value to return
+###### `lib_inject.stubs.<string>.<string>.return` Constant value to return
 
 |||
 |-|-|
 |__Type__|integer or null|
 |__Default__|`null`|
 
-Value the stubbed symbol returns. For a plain stub this is the return value; for a 'guard_null_args' stub it is the value returned on the NULL path (defaults to 0 if omitted).
+Value the stubbed symbol returns. For a plain stub this is the return value; for a 'guard_null_args' stub it is the value returned on the NULL path (defaults to 0).
 
 ```yaml
 0
@@ -2737,7 +2723,7 @@ Value the stubbed symbol returns. For a plain stub this is the return value; for
 |__Type__|string or null|
 |__Default__|`long`|
 
-C return type of the generated shim. Defaults to register-width 'long', which is correct for most integer/pointer returns.
+C return type of the generated shim. Defaults to register-width 'long', correct for most integer/pointer returns.
 
 ```yaml
 long

--- a/pyplugins/interventions/nvram2.py
+++ b/pyplugins/interventions/nvram2.py
@@ -91,7 +91,11 @@ def add_lib_inject_for_abi(config, abi, cache_dir, proj_dir=None, build_log_path
     headers_dir = f"/igloo_static/musl-headers/{abi_info['musl_arch_name']}/include"
     libnvram_arch_name = abi_info.get(
         'libnvram_arch_name', None) or arch_info['libnvram_arch_name']
-    aliases = lib_inject.get("aliases", dict())
+    # Local copy: the declarative `stubs` section is compiled into extra
+    # aliases below, and this function is called once per ABI. Mutating the
+    # shared config dict would leak stub aliases into later ABIs (and make the
+    # precedence check misfire), so never touch lib_inject["aliases"] in place.
+    aliases = dict(lib_inject.get("aliases", dict()))
 
     cache_dir = Path(cache_dir)
     os.makedirs(cache_dir, exist_ok=True)
@@ -100,6 +104,42 @@ def add_lib_inject_for_abi(config, abi, cache_dir, proj_dir=None, build_log_path
     dropin_include = []
     if dropin_c or dropin_h:
         dropin_include = ["-I", str(Path(proj_dir) / "lib_inject.d")]
+
+    # Declarative `lib_inject.stubs` -> generated C shims + --defsym aliases.
+    # The generated .c files live under a dotted subdir of lib_inject.d/ so the
+    # hand-authored dropin scanner (which skips dotfiles) never double-compiles
+    # them; we wire them into the build explicitly here and hash their bytes.
+    stub_c_paths = []
+    stub_include = []
+    stub_signature = []
+    stubs_cfg = lib_inject.get("stubs", dict())
+    if stubs_cfg and proj_dir:
+        from penguin import stubs as stubs_mod
+        resolver = None
+        fs_rel = config.get("core", dict()).get("fs")
+        if fs_rel:
+            resolver = stubs_mod.make_fs_resolver(os.path.join(proj_dir, fs_rel))
+        try:
+            files, stub_aliases = stubs_mod.generate(
+                stubs_cfg, resolver=resolver, existing_aliases=aliases
+            )
+        except stubs_mod.StubError as e:
+            print(f"FATAL: {e}")
+            raise
+        gen_dir = Path(proj_dir) / "lib_inject.d" / ".generated"
+        stub_c_paths = stubs_mod.write_files(gen_dir, files)
+        stub_include = ["-I", str(gen_dir)]
+        aliases.update(stub_aliases)
+        for p in stub_c_paths:
+            try:
+                stub_signature.append((Path(p).name, Path(p).read_bytes()))
+            except Exception:
+                pass
+        _append_build_log(
+            build_log_path,
+            f"[{arch}/{abi}] stubs: {len(stub_aliases)} symbol(s) -> "
+            f"{sorted(stub_aliases)}",
+        )
 
     hash_options = "-Wl,--hash-style=both" if "mips" not in arch else ""
 
@@ -119,11 +159,13 @@ def add_lib_inject_for_abi(config, abi, cache_dir, proj_dir=None, build_log_path
             f"-DCONFIG_{libnvram_arch_name.upper()}=1",
         ]
         + dropin_include
+        + stub_include
         + [
             "/igloo_static/libnvram/nvram.c",
             "/igloo_static/guest-utils/ltrace/inject_ltrace.c",
         ]
         + [str(p) for p in dropin_c]
+        + [str(p) for p in stub_c_paths]
         + [
             "--language",
             "c",
@@ -164,10 +206,12 @@ def add_lib_inject_for_abi(config, abi, cache_dir, proj_dir=None, build_log_path
         except Exception:
             pass
 
-    hash_input = str((arch, abi, aliases, lib_inject.get("extra", ""), args, [n for n, _ in dropin_signature])).encode()
+    hash_input = str((arch, abi, aliases, lib_inject.get("extra", ""), args, [n for n, _ in dropin_signature], [n for n, _ in stub_signature])).encode()
     for content in source_files_content:
         hash_input += content
     for _, content in dropin_signature:
+        hash_input += content
+    for _, content in stub_signature:
         hash_input += content
     cache_key = hashlib.sha256(hash_input).hexdigest()
     cache_path = cache_dir / f"lib_inject_{arch}_{abi}_{cache_key}.so"
@@ -283,6 +327,30 @@ def prep_config(conf, cache_dir, proj_dir=None, build_log_path=None):
 
     _append_build_log(build_log_path, "lib_inject build log start")
     add_lib_inject_all_abis(conf, cache_dir, proj_dir=proj_dir, build_log_path=build_log_path)
+
+    # Assembly-body stubs (lib_inject.stubs with a `body:`) compile down to a
+    # static_files binary_patch. This is arch-independent, so emit it once here
+    # rather than per-ABI in add_lib_inject_for_abi.
+    lib_inject = conf.get("lib_inject", dict())
+    stubs_cfg = lib_inject.get("stubs", dict())
+    if stubs_cfg and proj_dir:
+        from penguin import stubs as stubs_mod
+
+        fs_rel = conf.get("core", dict()).get("fs")
+        if fs_rel:
+            resolver = stubs_mod.make_fs_offset_resolver(os.path.join(proj_dir, fs_rel))
+            try:
+                patches = stubs_mod.generate_patches(stubs_cfg, resolver)
+                if patches:
+                    conf.setdefault("static_files", dict())
+                    stubs_mod.merge_patches_into_static_files(conf["static_files"], patches)
+                    _append_build_log(
+                        build_log_path,
+                        f"stubs: emitted binary_patch for {sorted(patches)}",
+                    )
+            except stubs_mod.StubError as e:
+                print(f"FATAL: {e}")
+                raise
 
 
 class Nvram2(Plugin):

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -1327,143 +1327,141 @@ LibInjectAliases = _newtype(
 )
 
 
-class StubAction(PartialModelMixin, BaseModel):
-    """A single declarative symbol stub.
-
-    Two mutually exclusive forms:
-
-    * **Symbol return** (``return`` / ``type`` / ``guard_null_args``): force a
-      symbol to return a constant, optionally guarding NULL arguments. Compiles
-      to a generated C shim plus a ``lib_inject`` alias (``--defsym``) -- a
-      global, LD_PRELOAD-based replacement that touches no binary on disk.
-
-    * **Assembly body** (``body`` / ``mode`` / ``expect``): overwrite the
-      instructions at a specific symbol location with assembled machine code.
-      Used when the stub key is ``symbol`` or ``symbol@offset``. Compiles down to
-      a ``static_files`` ``binary_patch`` action (the single owner of on-disk
-      patching); it edits one specific binary rather than replacing a symbol
-      everywhere."""
-
-    model_config = ConfigDict(
-        title="Symbol stub", extra="forbid", populate_by_name=True
-    )
-
-    return_: Annotated[
-        Optional[int],
-        Field(
-            None,
-            alias="return",
-            title="Constant value to return",
-            description=(
-                "Value the stubbed symbol returns. For a plain stub this is the "
-                "return value; for a 'guard_null_args' stub it is the value "
-                "returned on the NULL path (defaults to 0 if omitted)."
-            ),
-            examples=[0, 1, 42],
-        ),
-    ]
-
-    type: Annotated[
-        Optional[str],
-        Field(
-            "long",
-            title="Return C type",
-            description=(
-                "C return type of the generated shim. Defaults to register-width "
-                "'long', which is correct for most integer/pointer returns."
-            ),
-            examples=["long", "int", "unsigned int", "void *"],
-        ),
-    ]
-
-    guard_null_args: Annotated[
-        Optional[list[int]],
-        Field(
-            None,
-            title="NULL-guarded argument positions",
-            description=(
-                "Zero-based argument positions to NULL-check. If any listed "
-                "argument is NULL the shim returns the 'return' constant; "
-                "otherwise it calls through to the real symbol. Limited to the "
-                "first 8 integer/pointer register arguments (indices 0-7); "
-                "floating-point, struct-by-value, and stack arguments are not "
-                "preserved on the call-through path."
-            ),
-            examples=[[0], [0, 1]],
-        ),
-    ]
-
-    body: Annotated[
-        Optional[StrLines],
-        Field(
-            None,
-            title="Assembly body to write at the symbol",
-            description=(
-                "Assembly to assemble (via keystone) and write over the "
-                "instructions at the stub's symbol/offset. Use with a "
-                "'symbol' or 'symbol@offset' key. Compiles down to a "
-                "static_files 'binary_patch'. Mutually exclusive with "
-                "'return'/'guard_null_args'."
-            ),
-            examples=["mov v0, $zero\njr $ra", "movs r0, #0\nbx lr"],
-        ),
-    ]
-
-    mode: Annotated[
-        Optional[str],
-        Field(
-            None,
-            title="Assembly mode for 'body'",
-            description=(
-                "Assembly mode passed through to binary_patch (e.g. 'arm' or "
-                "'thumb' on ARM). Defaults to the target arch's natural mode."
-            ),
-            examples=["arm", "thumb"],
-        ),
-    ]
-
-    expect: Annotated[
-        Optional[str],
-        Field(
-            None,
-            title="Expected original bytes",
-            description=(
-                "Optional hex string of the bytes expected at the patch site; "
-                "passed through to binary_patch as a safety check before the "
-                "'body' overwrite."
-            ),
-            examples=["00000000", "1eff2fe1"],
-        ),
-    ]
-
-    @model_validator(mode="after")
-    def _require_action(self):
-        is_body = self.body is not None
-        is_return = self.return_ is not None or bool(self.guard_null_args)
-        if is_body and is_return:
+def _stub_action_check(self):
+    # `return` is a Python keyword, so read it dynamically (see StubAction).
+    ret = getattr(self, "return", None)
+    body = self.body
+    guard = self.guard_null_args
+    is_body = body is not None
+    is_return = ret is not None or bool(guard)
+    if is_body and is_return:
+        raise ValueError(
+            "a stub uses either 'body' (assembly patch) or "
+            "'return'/'guard_null_args' (symbol return), not both"
+        )
+    if not is_body and not is_return:
+        raise ValueError(
+            "a stub must set 'body', 'return', and/or 'guard_null_args'"
+        )
+    if not is_body and (self.mode is not None or self.expect is not None):
+        raise ValueError("'mode'/'expect' are only valid with a 'body' stub")
+    for i in guard or []:
+        if i < 0 or i > 7:
             raise ValueError(
-                "a stub uses either 'body' (assembly patch) or "
-                "'return'/'guard_null_args' (symbol return), not both"
+                "guard_null_args indices must be between 0 and 7 "
+                "(only the first 8 register arguments can be guarded)"
             )
-        if not is_body and not is_return:
-            raise ValueError(
-                "a stub must set 'body', 'return', and/or 'guard_null_args'"
-            )
-        if is_body and (self.guard_null_args or self.return_ is not None):
-            raise ValueError(
-                "'return'/'guard_null_args' are not valid with a 'body' stub"
-            )
-        if not is_body and (self.mode is not None or self.expect is not None):
-            raise ValueError(
-                "'mode'/'expect' are only valid with a 'body' stub"
-            )
-        for i in self.guard_null_args or []:
-            if i < 0 or i > 7:
-                raise ValueError(
-                    "guard_null_args indices must be between 0 and 7 "
-                    "(only the first 8 register arguments can be guarded)"
-                )
-        return self
+    return self
+
+
+# Built dynamically (rather than a normal class) so the field can be named
+# literally `return` -- a Python keyword. This mirrors how the `move` action
+# defines its `from` field. Using an alias instead would round-trip badly:
+# config load does model_dump(exclude_none=True) WITHOUT by_alias and then
+# jsonschema-validates against the (aliased) schema, so an aliased `return_`
+# field would dump as `return_` and fail the schema's `return`.
+StubAction = type(
+    "StubAction",
+    (PartialModelMixin, BaseModel),
+    {
+        "model_config": ConfigDict(title="Symbol stub", extra="forbid"),
+        "__doc__": (
+            "A single declarative symbol stub. Two mutually exclusive forms: "
+            "symbol-return ('return'/'type'/'guard_null_args'), which compiles "
+            "to a generated C shim plus a lib_inject '--defsym' alias; and "
+            "assembly-body ('body'/'mode'/'expect') at a 'symbol' or "
+            "'symbol@offset' key, which compiles to a static_files "
+            "'binary_patch'."
+        ),
+        "__annotations__": {
+            "return": Annotated[
+                Optional[int],
+                Field(
+                    None,
+                    title="Constant value to return",
+                    description=(
+                        "Value the stubbed symbol returns. For a plain stub this "
+                        "is the return value; for a 'guard_null_args' stub it is "
+                        "the value returned on the NULL path (defaults to 0)."
+                    ),
+                    examples=[0, 1, 42],
+                ),
+            ],
+            "type": Annotated[
+                Optional[str],
+                Field(
+                    "long",
+                    title="Return C type",
+                    description=(
+                        "C return type of the generated shim. Defaults to "
+                        "register-width 'long', correct for most integer/pointer "
+                        "returns."
+                    ),
+                    examples=["long", "int", "unsigned int", "void *"],
+                ),
+            ],
+            "guard_null_args": Annotated[
+                Optional[list[int]],
+                Field(
+                    None,
+                    title="NULL-guarded argument positions",
+                    description=(
+                        "Zero-based argument positions to NULL-check. If any "
+                        "listed argument is NULL the shim returns the 'return' "
+                        "constant; otherwise it calls through to the real symbol. "
+                        "Limited to the first 8 integer/pointer register "
+                        "arguments (indices 0-7); floating-point, struct-by-value, "
+                        "and stack arguments are not preserved on the call-through "
+                        "path."
+                    ),
+                    examples=[[0], [0, 1]],
+                ),
+            ],
+            "body": Annotated[
+                Optional[StrLines],
+                Field(
+                    None,
+                    title="Assembly body to write at the symbol",
+                    description=(
+                        "Assembly to assemble (via keystone) and write over the "
+                        "instructions at the stub's symbol/offset. Use with a "
+                        "'symbol' or 'symbol@offset' key. Compiles down to a "
+                        "static_files 'binary_patch'. Mutually exclusive with "
+                        "'return'/'guard_null_args'."
+                    ),
+                    examples=["mov v0, $zero\njr $ra", "movs r0, #0\nbx lr"],
+                ),
+            ],
+            "mode": Annotated[
+                Optional[str],
+                Field(
+                    None,
+                    title="Assembly mode for 'body'",
+                    description=(
+                        "Assembly mode passed through to binary_patch (e.g. 'arm' "
+                        "or 'thumb' on ARM). Defaults to the target arch's natural "
+                        "mode."
+                    ),
+                    examples=["arm", "thumb"],
+                ),
+            ],
+            "expect": Annotated[
+                Optional[str],
+                Field(
+                    None,
+                    title="Expected original bytes",
+                    description=(
+                        "Optional hex string of the bytes expected at the patch "
+                        "site; passed through to binary_patch as a safety check "
+                        "before the 'body' overwrite."
+                    ),
+                    examples=["00000000", "1eff2fe1"],
+                ),
+            ],
+        },
+        "_require_action": model_validator(mode="after")(_stub_action_check),
+    },
+)
 
 
 class StubLibrary(RootModel):

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -1327,6 +1327,185 @@ LibInjectAliases = _newtype(
 )
 
 
+class StubAction(PartialModelMixin, BaseModel):
+    """A single declarative symbol stub.
+
+    Two mutually exclusive forms:
+
+    * **Symbol return** (``return`` / ``type`` / ``guard_null_args``): force a
+      symbol to return a constant, optionally guarding NULL arguments. Compiles
+      to a generated C shim plus a ``lib_inject`` alias (``--defsym``) -- a
+      global, LD_PRELOAD-based replacement that touches no binary on disk.
+
+    * **Assembly body** (``body`` / ``mode`` / ``expect``): overwrite the
+      instructions at a specific symbol location with assembled machine code.
+      Used when the stub key is ``symbol`` or ``symbol@offset``. Compiles down to
+      a ``static_files`` ``binary_patch`` action (the single owner of on-disk
+      patching); it edits one specific binary rather than replacing a symbol
+      everywhere."""
+
+    model_config = ConfigDict(
+        title="Symbol stub", extra="forbid", populate_by_name=True
+    )
+
+    return_: Annotated[
+        Optional[int],
+        Field(
+            None,
+            alias="return",
+            title="Constant value to return",
+            description=(
+                "Value the stubbed symbol returns. For a plain stub this is the "
+                "return value; for a 'guard_null_args' stub it is the value "
+                "returned on the NULL path (defaults to 0 if omitted)."
+            ),
+            examples=[0, 1, 42],
+        ),
+    ]
+
+    type: Annotated[
+        Optional[str],
+        Field(
+            "long",
+            title="Return C type",
+            description=(
+                "C return type of the generated shim. Defaults to register-width "
+                "'long', which is correct for most integer/pointer returns."
+            ),
+            examples=["long", "int", "unsigned int", "void *"],
+        ),
+    ]
+
+    guard_null_args: Annotated[
+        Optional[list[int]],
+        Field(
+            None,
+            title="NULL-guarded argument positions",
+            description=(
+                "Zero-based argument positions to NULL-check. If any listed "
+                "argument is NULL the shim returns the 'return' constant; "
+                "otherwise it calls through to the real symbol. Limited to the "
+                "first 8 integer/pointer register arguments (indices 0-7); "
+                "floating-point, struct-by-value, and stack arguments are not "
+                "preserved on the call-through path."
+            ),
+            examples=[[0], [0, 1]],
+        ),
+    ]
+
+    body: Annotated[
+        Optional[StrLines],
+        Field(
+            None,
+            title="Assembly body to write at the symbol",
+            description=(
+                "Assembly to assemble (via keystone) and write over the "
+                "instructions at the stub's symbol/offset. Use with a "
+                "'symbol' or 'symbol@offset' key. Compiles down to a "
+                "static_files 'binary_patch'. Mutually exclusive with "
+                "'return'/'guard_null_args'."
+            ),
+            examples=["mov v0, $zero\njr $ra", "movs r0, #0\nbx lr"],
+        ),
+    ]
+
+    mode: Annotated[
+        Optional[str],
+        Field(
+            None,
+            title="Assembly mode for 'body'",
+            description=(
+                "Assembly mode passed through to binary_patch (e.g. 'arm' or "
+                "'thumb' on ARM). Defaults to the target arch's natural mode."
+            ),
+            examples=["arm", "thumb"],
+        ),
+    ]
+
+    expect: Annotated[
+        Optional[str],
+        Field(
+            None,
+            title="Expected original bytes",
+            description=(
+                "Optional hex string of the bytes expected at the patch site; "
+                "passed through to binary_patch as a safety check before the "
+                "'body' overwrite."
+            ),
+            examples=["00000000", "1eff2fe1"],
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def _require_action(self):
+        is_body = self.body is not None
+        is_return = self.return_ is not None or bool(self.guard_null_args)
+        if is_body and is_return:
+            raise ValueError(
+                "a stub uses either 'body' (assembly patch) or "
+                "'return'/'guard_null_args' (symbol return), not both"
+            )
+        if not is_body and not is_return:
+            raise ValueError(
+                "a stub must set 'body', 'return', and/or 'guard_null_args'"
+            )
+        if is_body and (self.guard_null_args or self.return_ is not None):
+            raise ValueError(
+                "'return'/'guard_null_args' are not valid with a 'body' stub"
+            )
+        if not is_body and (self.mode is not None or self.expect is not None):
+            raise ValueError(
+                "'mode'/'expect' are only valid with a 'body' stub"
+            )
+        for i in self.guard_null_args or []:
+            if i < 0 or i > 7:
+                raise ValueError(
+                    "guard_null_args indices must be between 0 and 7 "
+                    "(only the first 8 register arguments can be guarded)"
+                )
+        return self
+
+
+class StubLibrary(RootModel):
+    """Symbols (or globs) to stub within one library/object. The library key is
+    an organizational label and the glob-resolution target; aliasing itself is
+    global (``--defsym``)."""
+
+    root: dict[str, StubAction]
+    model_config = ConfigDict(title="Per-library symbol stubs")
+
+
+class Stubs(RootModel):
+    """Declarative symbol stubs, grouped by library/object.
+
+    Each key is a library/object (an absolute guest path like ``/lib/libc.so``
+    or a bare basename like ``libX.so`` searched for in the rootfs). Each value
+    maps a symbol key to a stub action. A symbol key is either a symbol name, a
+    glob such as ``nvram_*`` (expanded against the library's exported symbols at
+    build time; symbol-return stubs only), or ``symbol@offset`` (assembly-body
+    stubs only, where ``offset`` is added to the symbol address)."""
+
+    root: dict[str, StubLibrary]
+    model_config = ConfigDict(
+        title="Declarative symbol stubs",
+        json_schema_extra=dict(
+            examples=[
+                {},
+                {
+                    "libX.so": {
+                        "get_flag": {"return": 0},
+                        "nvram_*": {"return": 0},
+                        "hw_probe": {"body": "movs r0, #0\nbx lr", "mode": "thumb"},
+                    },
+                    "/lib/libc.so": {
+                        "memcpy": {"guard_null_args": [0, 1], "return": 0},
+                    },
+                },
+            ]
+        ),
+    )
+
+
 class LibInject(PartialModelMixin, BaseModel):
     """Library functions to be intercepted"""
 
@@ -1347,6 +1526,19 @@ class LibInject(PartialModelMixin, BaseModel):
             None,
             title="Extra injected library code",
             description="Custom source code for library functions to intercept and model",
+        ),
+    ]
+
+    stubs: Annotated[
+        Optional[Stubs],
+        Field(
+            None,
+            title="Declarative symbol stubs",
+            description=(
+                "Force library/object symbols to return a constant. Compiles "
+                "down to generated C shims plus 'aliases' entries; a symbol may "
+                "not appear in both 'stubs' and 'aliases'."
+            ),
         ),
     ]
 

--- a/src/penguin/stubs.py
+++ b/src/penguin/stubs.py
@@ -69,8 +69,7 @@ def _action_get(action, key, default=None):
                 return action["return"]
             return action.get("return_", default)
         return action.get(key, default)
-    if key == "return":
-        return getattr(action, "return_", default)
+    # StubAction model: the field is literally named `return` (a keyword).
     return getattr(action, key, default)
 
 

--- a/src/penguin/stubs.py
+++ b/src/penguin/stubs.py
@@ -1,0 +1,448 @@
+"""
+Declarative symbol stubs -> generated C shims + ``lib_inject`` aliases.
+
+A ``lib_inject.stubs`` config section stubs out library/object symbols. It has
+two families, both of which compile down to existing machinery rather than
+inventing a new one:
+
+* **Symbol return** (``return``/``type``/``guard_null_args``) generates one tiny
+  C function per stubbed symbol plus a linker ``--defsym`` alias, fed through the
+  same clang build in ``pyplugins/interventions/nvram2.py``. This is a global,
+  LD_PRELOAD-based replacement.
+* **Assembly body** (``body`` at a ``symbol`` or ``symbol@offset`` key) resolves
+  the symbol to a file offset (statically, from the rootfs) and emits a
+  ``static_files`` ``binary_patch`` action -- delegating on-disk patching to its
+  single owner (``pyplugins/core/live_image.py``).
+
+This module is deliberately pure/host-side (no penguin runtime imports) so the
+codegen can be unit-tested directly. The library-symbol resolver used for glob
+expansion is injectable: :func:`make_fs_resolver` provides the production
+default that reads a project rootfs tarball, and tests can pass a plain callable
+returning a set of names.
+
+Config shape (already validated by ``structure.Stubs``), as a plain dict::
+
+    {
+        "libX.so":     {"get_flag": {"return": 0}, "nvram_*": {"return": 0}},
+        "/lib/libc.so": {"memcpy": {"guard_null_args": [0, 1], "return": 0}},
+    }
+"""
+
+import fnmatch
+import io
+import re
+import tarfile
+from pathlib import Path, PurePosixPath
+
+# Characters that make a symbol key a glob rather than a literal name.
+_GLOB_CHARS = ("*", "?", "[")
+
+# Max register-passed integer/pointer args we can thread through on the
+# guard_null_args call-through path (indices 0-7).
+_MAX_ARGS = 8
+
+_ARG_LIST = ", ".join(f"long a{i}" for i in range(_MAX_ARGS))
+_ARG_NAMES = ", ".join(f"a{i}" for i in range(_MAX_ARGS))
+_FN_PTR_TYPE = "(*)(" + ", ".join("long" for _ in range(_MAX_ARGS)) + ")"
+
+
+class StubError(Exception):
+    """Raised for any invalid or unsatisfiable ``stubs`` configuration."""
+
+
+def _is_glob(key):
+    return any(c in key for c in _GLOB_CHARS)
+
+
+def _c_ident(name):
+    """Sanitize a symbol name for use inside a generated C identifier."""
+    return re.sub(r"[^0-9A-Za-z_]", "_", name)
+
+
+def _action_get(action, key, default=None):
+    """Read a field from a stub action, accepting either a plain config dict
+    (``return``/``type``/``guard_null_args``) or a validated ``StubAction``
+    model (``return_``/...)."""
+    if isinstance(action, dict):
+        if key == "return":
+            if "return" in action:
+                return action["return"]
+            return action.get("return_", default)
+        return action.get(key, default)
+    if key == "return":
+        return getattr(action, "return_", default)
+    return getattr(action, key, default)
+
+
+# --------------------------------------------------------------------------- #
+# symbol resolution (glob expansion)
+# --------------------------------------------------------------------------- #
+def _exported_symbols(stream):
+    """Return the set of exported (defined, GLOBAL/WEAK FUNC/OBJECT) dynamic
+    symbols in an ELF shared object read from ``stream``. Raises :class:`StubError`
+    if the object has no dynamic symbol table (stripped / not a shared object)."""
+    from elftools.elf.elffile import ELFFile
+    from elftools.elf.sections import SymbolTableSection
+
+    elf = ELFFile(stream)
+    dynsym = elf.get_section_by_name(".dynsym")
+    if not isinstance(dynsym, SymbolTableSection):
+        raise StubError("no .dynsym section (object is stripped or not dynamic)")
+    names = set()
+    for sym in dynsym.iter_symbols():
+        if not sym.name or sym["st_shndx"] == "SHN_UNDEF":
+            continue
+        info = sym["st_info"]
+        if info["bind"] not in ("STB_GLOBAL", "STB_WEAK"):
+            continue
+        if info["type"] not in ("STT_FUNC", "STT_OBJECT", "STT_GNU_IFUNC"):
+            continue
+        names.add(sym.name)
+    if not names:
+        raise StubError("no exported symbols (object is stripped)")
+    return names
+
+
+def _norm_guest_path(member_name):
+    """Normalize a tar member name (``./usr/lib/x`` or ``usr/lib/x``) to an
+    absolute guest path (``/usr/lib/x``)."""
+    return "/" + str(PurePosixPath(member_name.lstrip("./"))).lstrip("/")
+
+
+def _find_member(tf, library_key):
+    """Locate one tar member for ``library_key`` and return ``(bytes, guest_path)``.
+    An absolute key matches the exact guest path; a bare basename is searched for
+    and must be unambiguous. Raises :class:`StubError` when missing or ambiguous."""
+    want_abs = library_key.startswith("/")
+    base = PurePosixPath(library_key).name
+    matches = []
+    for m in tf.getmembers():
+        if not m.isfile():
+            continue
+        guest_path = _norm_guest_path(m.name)
+        if want_abs:
+            if guest_path == library_key:
+                matches.append(m)
+        elif PurePosixPath(guest_path).name == base:
+            matches.append(m)
+    if not matches:
+        raise StubError(
+            f"stubs: library {library_key!r} not found in rootfs"
+        )
+    if len(matches) > 1:
+        paths = ", ".join(sorted(_norm_guest_path(m.name) for m in matches))
+        raise StubError(
+            f"stubs: {library_key!r} is ambiguous in rootfs ({paths}); "
+            f"use an absolute guest path"
+        )
+    return tf.extractfile(matches[0]).read(), _norm_guest_path(matches[0].name)
+
+
+def make_fs_resolver(fs_tar_path):
+    """Return ``resolve(library_key) -> set[str]`` reading exported symbols out
+    of a project rootfs tarball. Used for glob expansion. Raises :class:`StubError`
+    when the library is missing, ambiguous, or stripped."""
+
+    def resolve(library_key):
+        with tarfile.open(fs_tar_path) as tf:
+            data, _guest_path = _find_member(tf, library_key)
+        try:
+            return _exported_symbols(io.BytesIO(data))
+        except StubError as e:
+            raise StubError(f"stubs: {library_key}: {e}")
+
+    return resolve
+
+
+def _vaddr_to_file_offset(elf, vaddr):
+    """Map a virtual address to a file offset using PT_LOAD program headers.
+    Raises :class:`StubError` if no loadable segment contains ``vaddr``."""
+    for seg in elf.iter_segments():
+        if seg["p_type"] != "PT_LOAD":
+            continue
+        start = seg["p_vaddr"]
+        end = start + seg["p_filesz"]
+        if start <= vaddr < end:
+            return seg["p_offset"] + (vaddr - start)
+    raise StubError(f"vaddr {vaddr:#x} is not in any loadable segment")
+
+
+def _symbol_file_offset(stream, symbol):
+    """Return the file offset of ``symbol`` in an ELF read from ``stream``.
+    Reads .symtab then .dynsym. Raises :class:`StubError` if not found."""
+    from elftools.elf.elffile import ELFFile
+    from elftools.elf.sections import SymbolTableSection
+
+    elf = ELFFile(stream)
+    for sec_name in (".symtab", ".dynsym"):
+        sec = elf.get_section_by_name(sec_name)
+        if not isinstance(sec, SymbolTableSection):
+            continue
+        syms = sec.get_symbol_by_name(symbol)
+        if syms:
+            return _vaddr_to_file_offset(elf, syms[0]["st_value"])
+    raise StubError(f"symbol {symbol!r} not found (no .symtab/.dynsym entry)")
+
+
+def make_fs_offset_resolver(fs_tar_path):
+    """Return ``resolve(library_key, symbol) -> (guest_path, file_offset)`` for
+    the assembly-body form, reading the ELF out of a project rootfs tarball.
+    Raises :class:`StubError` when the library or symbol can't be resolved."""
+
+    def resolve(library_key, symbol):
+        with tarfile.open(fs_tar_path) as tf:
+            data, guest_path = _find_member(tf, library_key)
+        try:
+            off = _symbol_file_offset(io.BytesIO(data), symbol)
+        except StubError as e:
+            raise StubError(f"stubs: {library_key}: {e}")
+        return guest_path, off
+
+    return resolve
+
+
+# --------------------------------------------------------------------------- #
+# expansion + codegen
+# --------------------------------------------------------------------------- #
+def _is_body(action):
+    return _action_get(action, "body") is not None
+
+
+def _split(stubs):
+    """Partition a ``stubs`` config into ``(shim_stubs, body_entries)``.
+
+    ``shim_stubs`` keeps the ``{lib: {sym: action}}`` shape for the symbol-return
+    family; ``body_entries`` is a flat ``[(lib, symkey, action)]`` list for the
+    assembly-body family."""
+    shim = {}
+    body = []
+    for libkey, syms in (stubs or {}).items():
+        for symkey, action in (syms or {}).items():
+            if _is_body(action):
+                body.append((libkey, symkey, action))
+            else:
+                shim.setdefault(libkey, {})[symkey] = action
+    return shim, body
+
+
+def parse_symbol_key(symkey):
+    """Split a body-stub key ``symbol`` or ``symbol@offset`` into
+    ``(symbol, offset)``. ``offset`` accepts hex (``0x..``) or decimal and
+    defaults to 0. Raises :class:`StubError` on a malformed key."""
+    sym, sep, off = symkey.partition("@")
+    if not sep:
+        return symkey, 0
+    if not sym or not off:
+        raise StubError(f"stubs: malformed symbol@offset key {symkey!r}")
+    try:
+        return sym, int(off, 0)
+    except ValueError:
+        raise StubError(
+            f"stubs: bad offset in key {symkey!r} (want hex 0x.. or decimal)"
+        )
+
+
+def expand(stubs, resolver=None):
+    """Flatten the symbol-return family of a ``stubs`` config into a list of
+    ``(symbol, action, library_key)`` tuples, expanding glob keys against the
+    library's exported symbols via ``resolver``. Assembly-body stubs are ignored
+    here (see :func:`generate_patches`). Deterministically ordered. Raises
+    :class:`StubError` on a glob that matches nothing, a duplicated symbol, an
+    ``@`` in a symbol-return key, or a glob with no resolver supplied."""
+    shim, _body = _split(stubs)
+    out = []
+    seen = {}
+    for libkey, syms in sorted(shim.items()):
+        for symkey, action in sorted(syms.items()):
+            if "@" in symkey:
+                raise StubError(
+                    f"stubs: 'symbol@offset' key {symkey!r} is only valid with "
+                    f"a 'body' action"
+                )
+            if _is_glob(symkey):
+                if resolver is None:
+                    raise StubError(
+                        f"stubs: glob {symkey!r} on {libkey!r} requires a symbol "
+                        f"resolver but none is available"
+                    )
+                exported = resolver(libkey)
+                matched = sorted(fnmatch.filter(exported, symkey))
+                if not matched:
+                    raise StubError(
+                        f"stubs: glob {symkey!r} on {libkey!r} matched no "
+                        f"exported symbols"
+                    )
+                resolved = [(s, action) for s in matched]
+            else:
+                resolved = [(symkey, action)]
+            for sym, act in resolved:
+                if sym in seen:
+                    raise StubError(
+                        f"stubs: symbol {sym!r} is stubbed more than once "
+                        f"(via {seen[sym]!r} and {libkey!r}); define it once"
+                    )
+                seen[sym] = libkey
+                out.append((sym, act, libkey))
+    return out
+
+
+def check_precedence(stubs, existing_aliases, resolver=None):
+    """Raise :class:`StubError` if any stubbed symbol also appears in
+    ``lib_inject.aliases`` (a symbol must be owned by exactly one of them)."""
+    existing = set(existing_aliases or {})
+    for sym, _action, libkey in expand(stubs, resolver):
+        if sym in existing:
+            raise StubError(
+                f"stubs: symbol {sym!r} (from {libkey!r}) is also defined in "
+                f"lib_inject.aliases; define it in only one place"
+            )
+
+
+def _shim_name(sym):
+    return f"__igloo_stub_{_c_ident(sym)}"
+
+
+def _gen_plain(sym, rtype, retval):
+    shim = _shim_name(sym)
+    return (
+        f"/* generated stub: {sym} -> return {retval} */\n"
+        f"{rtype} {shim}() {{ return ({rtype}){retval}; }}\n"
+    )
+
+
+def _gen_guard(sym, rtype, retval, guard_args):
+    shim = _shim_name(sym)
+    ident = _c_ident(sym)
+    real = f"__igloo_real_{ident}"
+    guard_expr = " || ".join(f"a{i} == 0" for i in guard_args)
+    return (
+        f"/* generated stub: {sym} -> return {retval} when "
+        f"arg(s) {list(guard_args)} are NULL, else call through */\n"
+        f"extern void *dlsym(void *handle, const char *symbol);\n"
+        f"#ifndef RTLD_NEXT\n"
+        f"#define RTLD_NEXT ((void *)-1L)\n"
+        f"#endif\n"
+        f"static {rtype} {_FN_PTR_TYPE.replace('(*)', '(*' + real + ')')};\n"
+        f"{rtype} {shim}({_ARG_LIST}) {{\n"
+        f"    if ({guard_expr})\n"
+        f"        return ({rtype}){retval};\n"
+        f"    if (!{real})\n"
+        f"        {real} = ({rtype}{_FN_PTR_TYPE})dlsym(RTLD_NEXT, \"{sym}\");\n"
+        f"    return {real}({_ARG_NAMES});\n"
+        f"}}\n"
+    )
+
+
+def generate(stubs, resolver=None, existing_aliases=None):
+    """Compile a ``stubs`` config into generated C shims and ``--defsym`` aliases.
+
+    Returns ``(files, aliases)`` where ``files`` maps a filename ->
+    C source (to write into the generated shim directory) and ``aliases`` maps a
+    real symbol name -> generated shim function name. If ``existing_aliases`` is
+    provided, the precedence rule (no symbol in both ``stubs`` and ``aliases``)
+    is enforced.
+    """
+    pairs = expand(stubs, resolver)
+    if existing_aliases is not None:
+        existing = set(existing_aliases)
+        for sym, _a, libkey in pairs:
+            if sym in existing:
+                raise StubError(
+                    f"stubs: symbol {sym!r} (from {libkey!r}) is also defined in "
+                    f"lib_inject.aliases; define it in only one place"
+                )
+
+    files = {}
+    aliases = {}
+    for sym, action, _libkey in pairs:
+        rtype = (_action_get(action, "type") or "long").strip()
+        retval = _action_get(action, "return")
+        guard = _action_get(action, "guard_null_args") or []
+        if retval is None:
+            retval = 0  # guard-only stub: NULL path returns 0 by default
+        if guard:
+            src = _gen_guard(sym, rtype, int(retval), list(guard))
+        else:
+            src = _gen_plain(sym, rtype, int(retval))
+        files[f"stub_{_c_ident(sym)}.c"] = src
+        aliases[sym] = _shim_name(sym)
+    return files, aliases
+
+
+def generate_patches(stubs, offset_resolver):
+    """Compile the assembly-body family of a ``stubs`` config into ``binary_patch``
+    edits, grouped by target guest file.
+
+    Returns ``dict[guest_path, list[entry]]`` where each entry is a
+    ``BinaryPatchEntry`` dict (``file_offset`` + ``asm`` + optional ``mode`` /
+    ``expect`` + provenance). ``offset_resolver(library_key, symbol)`` must return
+    ``(guest_path, file_offset)``. Raises :class:`StubError` on a glob key, a
+    malformed key, or an unresolved symbol."""
+    _shim, body = _split(stubs)
+    patches = {}
+    for libkey, symkey, action in sorted(body, key=lambda t: (t[0], t[1])):
+        if _is_glob(symkey):
+            raise StubError(
+                f"stubs: glob key {symkey!r} on {libkey!r} is not allowed with a "
+                f"'body' action (patch one location at a time)"
+            )
+        sym, delta = parse_symbol_key(symkey)
+        guest_path, base = offset_resolver(libkey, sym)
+        entry = {
+            "file_offset": base + delta,
+            "asm": _action_get(action, "body"),
+            "why": f"stubs: {libkey} {symkey}",
+            "tag": "stubs",
+        }
+        mode = _action_get(action, "mode")
+        if mode is not None:
+            entry["mode"] = mode
+        expect = _action_get(action, "expect")
+        if expect is not None:
+            entry["expect"] = expect
+        patches.setdefault(guest_path, []).append(entry)
+    return patches
+
+
+def merge_patches_into_static_files(static_files, patches):
+    """Merge ``generate_patches`` output into a config ``static_files`` dict.
+
+    For each guest file, appends the edits to an existing ``binary_patch`` action
+    (coalescing into its ``patches`` list) or creates a new one. Raises
+    :class:`StubError` if the path already holds a non-``binary_patch`` action."""
+    for guest_path, entries in patches.items():
+        existing = static_files.get(guest_path)
+        if existing is None:
+            static_files[guest_path] = {"type": "binary_patch", "patches": list(entries)}
+            continue
+        if existing.get("type") != "binary_patch":
+            raise StubError(
+                f"stubs: cannot patch {guest_path!r}; a non-binary_patch "
+                f"static_files action already targets it"
+            )
+        merged = existing.get("patches")
+        if merged is None:
+            # normalize a single-edit action into the patches-list form
+            single = {k: v for k, v in existing.items() if k != "type"}
+            merged = [single] if single else []
+        merged = list(merged) + list(entries)
+        static_files[guest_path] = {"type": "binary_patch", "patches": merged}
+
+
+def write_files(gen_dir, files):
+    """Write generated shim files into ``gen_dir``, replacing any previous
+    contents so removed stubs don't linger. Returns the sorted list of written
+    ``.c`` paths (as strings)."""
+    import shutil
+
+    gen_dir = Path(gen_dir)
+    if gen_dir.exists():
+        shutil.rmtree(gen_dir)
+    gen_dir.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for name, src in sorted(files.items()):
+        p = gen_dir / name
+        p.write_text(src)
+        if p.suffix == ".c":
+            paths.append(str(p))
+    return sorted(paths)

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -10,7 +10,8 @@ what the run produces. They are the slow integration gate — run in CI by the
   fixtures; pass/fail is decided by a guest-side `verifier` plugin emitting
   JUnit `verifier.xml`.
 - `basic_target/` — smoke test: `init`/`refresh`/boot, C drop-in + lib_inject
-  markers (plus the `snapshot_*_test.py` save/restore/VPN tests).
+  markers, and a declarative `lib_inject.stubs` return-stub compiled through the
+  real per-arch toolchain (plus the `snapshot_*_test.py` save/restore/VPN tests).
 - `compose/` — two-guest network end-to-end test (arch-independent).
 
 These contain stand-alone configs realized without a rootfs, to test failure

--- a/tests/integration/basic_target/patch.yaml
+++ b/tests/integration/basic_target/patch.yaml
@@ -3,6 +3,15 @@ core:
   # Keep the default firmware scoping on so the default path stays covered.
   analysis_scope: firmware
 
+lib_inject:
+  # Declarative stub: exercises the full schema -> generated C shim ->
+  # clang cross-compile -> --defsym alias path on the real per-arch toolchain.
+  # A failed codegen/link would abort `penguin run` before assertions.
+  stubs:
+    libplaceholder.so:
+      igloo_stub_probe:
+        return: 43981   # 0xABCD
+
 env:
   igloo_init: /init.sh
 

--- a/tests/integration/basic_target/test.py
+++ b/tests/integration/basic_target/test.py
@@ -187,6 +187,30 @@ def assert_dropin_c_result(project_dir):
         raise AssertionError(f"C drop-in did not point at compiled cache: {host_path}")
 
 
+def assert_stubs_result(project_dir):
+    """Verify the declarative `lib_inject.stubs` return-stub compiled through the
+    real per-arch toolchain: the generated shim was written, and its symbol made
+    it into the cached lib_inject .so. (A failed codegen or --defsym link would
+    have already aborted `penguin run`.)"""
+    gen = project_dir / "lib_inject.d" / ".generated" / "stub_igloo_stub_probe.c"
+    if not gen.exists():
+        raise AssertionError(f"generated stub shim not written: {gen}")
+    src = gen.read_text()
+    if "return (long)43981;" not in src:
+        raise AssertionError(f"generated stub shim unexpected contents: {src!r}")
+
+    cache_dir = project_dir / "qcows" / "cache"
+    matches = sorted(cache_dir.glob("lib_inject_*.so"))
+    if not matches:
+        raise AssertionError(f"no cached lib_inject build found under {cache_dir}")
+    shim = b"__igloo_stub_igloo_stub_probe"
+    if not any(shim in path.read_bytes() for path in matches):
+        raise AssertionError(
+            f"stub shim symbol {shim!r} missing from cached lib_inject .so files: "
+            f"{[p.name for p in matches]}"
+        )
+
+
 def run_test(kernel, arch, image, execution_mode="qemu"):
     id = subprocess.check_output(
         f"docker create {image}", shell=True).decode().strip()
@@ -234,6 +258,8 @@ def run_test(kernel, arch, image, execution_mode="qemu"):
         assert_dropin_c_result(project_path)
 
     assert_lib_inject_dropin_result(project_path)
+
+    assert_stubs_result(project_path)
 
     logger.info("Test completed")
 

--- a/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
+++ b/tests/unit/PYPLUGIN_COVERAGE_PLAN.md
@@ -212,6 +212,27 @@ Ordered most-valuable first. Percentages are current host coverage.
     staged window is left untouched and the tag/why land in
     `binary_patches.yaml`). This replaces the file's original hand-rolled
     `sys.modules`-stub loader — the case that motivated the harness.
+11. ✅ **`src/penguin/stubs.py` — `lib_inject.stubs` codegen** — done
+    (`test_stubs.py`, draft 07). The declarative `lib_inject.stubs` section
+    (force a library/object symbol to return a constant) compiles to a generated
+    C shim + a `--defsym` alias, reusing the existing `nvram2` lib_inject build.
+    The codegen is a pure host-side module, so it is fully unit-tested here:
+    schema validation (`structure.StubAction`: require `return`/`guard_null_args`,
+    guard-index bounds, unknown-key rejection), `generate()` output (plain return,
+    `type` override, `guard_null_args` call-through via `dlsym(RTLD_NEXT,...)` with
+    no `dlsym` leaking into plain stubs), glob expansion against an injected
+    symbol resolver, the missing/ambiguous/stripped-library and no-match hard
+    errors, the duplicate-symbol and `stubs`↔`aliases` precedence conflicts, and
+    `write_files` regeneration. The assembly-**body** form (`symbol@offset:
+    {body: asm}`) is also covered: `parse_symbol_key`, `generate_patches`
+    (offset+delta, mode/expect passthrough, glob rejection), `_vaddr_to_file_offset`,
+    `merge_patches_into_static_files` (create/append/normalize/conflict), and that
+    the synthesized `binary_patch` validates against the real `StaticFiles`
+    schema. The `nvram2` glue that writes `lib_inject.d/.generated/`, runs the
+    `clang-20` cross-compile, and resolves symbol offsets from the rootfs stays
+    out of host scope (same toolchain-image boundary noted for `nvram2.py` above)
+    — covered by the generated-C `-fsyntax-only` check and a `tests/integration/`
+    boot fixture, not host unit tests.
 
     **Out of scope — stays a `tests/integration/` fixture (`live_image.yaml`):**
     the real guest round-trip (the batch hypercall's `hyp_file_op --range`

--- a/tests/unit/test_stubs.py
+++ b/tests/unit/test_stubs.py
@@ -1,0 +1,305 @@
+"""
+Unit tests for declarative ``lib_inject.stubs``: schema validation and the
+schema -> C-shim/alias codegen in ``penguin.stubs``.
+
+Everything here is pure host-side logic: no rootfs, kernel, or container. Glob
+expansion is exercised with an injected fake symbol resolver; the production
+rootfs resolver's not-found / ambiguous paths are tested with an in-memory tar.
+"""
+
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from penguin import stubs
+from penguin.penguin_config import structure
+from pydantic import ValidationError
+
+
+# --------------------------------------------------------------------------- #
+# schema validation
+# --------------------------------------------------------------------------- #
+def _validate(section):
+    """Validate a `stubs` section the way it hangs off lib_inject."""
+    return structure.LibInject.model_validate({"stubs": section})
+
+
+def test_schema_return_only():
+    _validate({"libX.so": {"foo": {"return": 0}}})
+
+
+def test_schema_return_alias_populates_field():
+    a = structure.StubAction.model_validate({"return": 42})
+    assert a.return_ == 42
+    assert a.type == "long"  # default
+
+
+def test_schema_type_override_and_guard():
+    _validate({"libc.so": {"memcpy": {"guard_null_args": [0, 1], "return": 0}}})
+    _validate({"libX.so": {"bar": {"return": 5, "type": "int"}}})
+
+
+def test_schema_requires_return_or_guard():
+    with pytest.raises(ValidationError):
+        _validate({"libX.so": {"foo": {"type": "int"}}})
+
+
+def test_schema_guard_index_bounds():
+    with pytest.raises(ValidationError):
+        _validate({"libc.so": {"memcpy": {"guard_null_args": [8]}}})
+    with pytest.raises(ValidationError):
+        _validate({"libc.so": {"memcpy": {"guard_null_args": [-1]}}})
+
+
+def test_schema_forbids_unknown_key():
+    with pytest.raises(ValidationError):
+        _validate({"libX.so": {"foo": {"return": 0, "bogus": 1}}})
+
+
+# --------------------------------------------------------------------------- #
+# codegen: plain return
+# --------------------------------------------------------------------------- #
+def test_generate_return_only():
+    files, aliases = stubs.generate({"libX.so": {"foo": {"return": 0}}})
+    assert aliases == {"foo": "__igloo_stub_foo"}
+    src = files["stub_foo.c"]
+    assert "long __igloo_stub_foo()" in src
+    assert "return (long)0;" in src
+    assert "dlsym" not in src  # no call-through machinery for a plain stub
+
+
+def test_generate_type_override():
+    files, _ = stubs.generate({"libX.so": {"bar": {"return": 5, "type": "int"}}})
+    src = files["stub_bar.c"]
+    assert "int __igloo_stub_bar()" in src
+    assert "return (int)5;" in src
+
+
+def test_generate_accepts_validated_model():
+    a = structure.StubAction.model_validate({"return": 3, "type": "int"})
+    files, _ = stubs.generate({"libX.so": {"foo": a}})
+    assert "int __igloo_stub_foo()" in files["stub_foo.c"]
+    assert "return (int)3;" in files["stub_foo.c"]
+
+
+# --------------------------------------------------------------------------- #
+# codegen: guard_null_args (call-through)
+# --------------------------------------------------------------------------- #
+def test_generate_guard_call_through():
+    files, aliases = stubs.generate(
+        {"libc.so": {"memcpy": {"guard_null_args": [0, 1], "return": 0}}}
+    )
+    assert aliases == {"memcpy": "__igloo_stub_memcpy"}
+    src = files["stub_memcpy.c"]
+    assert 'dlsym(RTLD_NEXT, "memcpy")' in src
+    assert "a0 == 0 || a1 == 0" in src
+    assert "return (long)0;" in src           # NULL path
+    assert "__igloo_real_memcpy(a0, a1" in src  # call-through path
+
+
+def test_generate_guard_defaults_return_zero():
+    files, _ = stubs.generate({"libc.so": {"strcmp": {"guard_null_args": [0]}}})
+    src = files["stub_strcmp.c"]
+    assert "a0 == 0" in src
+    assert "return (long)0;" in src
+
+
+# --------------------------------------------------------------------------- #
+# glob expansion
+# --------------------------------------------------------------------------- #
+def test_generate_glob_expands():
+    def resolver(lib):
+        return {"nvram_get", "nvram_set", "unrelated"}
+
+    files, aliases = stubs.generate(
+        {"libnvram.so": {"nvram_*": {"return": 0}}}, resolver=resolver
+    )
+    assert set(aliases) == {"nvram_get", "nvram_set"}
+    assert set(files) == {"stub_nvram_get.c", "stub_nvram_set.c"}
+
+
+def test_generate_glob_no_match_errors():
+    def resolver(lib):
+        return {"aaa"}
+
+    with pytest.raises(stubs.StubError):
+        stubs.generate({"lib.so": {"zzz_*": {"return": 0}}}, resolver=resolver)
+
+
+def test_generate_glob_without_resolver_errors():
+    with pytest.raises(stubs.StubError):
+        stubs.generate({"l.so": {"z_*": {"return": 0}}})
+
+
+# --------------------------------------------------------------------------- #
+# conflicts / precedence
+# --------------------------------------------------------------------------- #
+def test_generate_duplicate_symbol_errors():
+    with pytest.raises(stubs.StubError):
+        stubs.generate(
+            {"a.so": {"foo": {"return": 0}}, "b.so": {"foo": {"return": 1}}}
+        )
+
+
+def test_precedence_conflict_errors():
+    with pytest.raises(stubs.StubError):
+        stubs.check_precedence({"l.so": {"foo": {"return": 0}}}, {"foo": "x"})
+    with pytest.raises(stubs.StubError):
+        stubs.generate(
+            {"l.so": {"foo": {"return": 0}}}, existing_aliases={"foo": "x"}
+        )
+
+
+def test_precedence_no_conflict_ok():
+    stubs.check_precedence({"l.so": {"foo": {"return": 0}}}, {"other": "x"})
+
+
+# --------------------------------------------------------------------------- #
+# file writing
+# --------------------------------------------------------------------------- #
+def test_write_files_and_regenerates(tmp_path):
+    gen = tmp_path / "gen"
+    paths = stubs.write_files(gen, {"stub_foo.c": "a\n", "notes.txt": "x\n"})
+    assert [Path(p).name for p in paths] == ["stub_foo.c"]  # only .c returned
+    assert (gen / "stub_foo.c").read_text() == "a\n"
+    # a second build with a different stub set wipes the stale file
+    stubs.write_files(gen, {"stub_bar.c": "b\n"})
+    assert not (gen / "stub_foo.c").exists()
+    assert (gen / "stub_bar.c").read_text() == "b\n"
+
+
+# --------------------------------------------------------------------------- #
+# production rootfs resolver: not-found / ambiguous
+# --------------------------------------------------------------------------- #
+def _make_tar(tmp_path, arcnames):
+    tarp = tmp_path / "fs.tar.gz"
+    src = tmp_path / "blob"
+    src.write_bytes(b"not-an-elf")
+    with tarfile.open(tarp, "w:gz") as tf:
+        for name in arcnames:
+            tf.add(src, arcname=name)
+    return str(tarp)
+
+
+def test_resolver_missing_library_errors(tmp_path):
+    tarp = _make_tar(tmp_path, ["./bin/sh"])
+    resolve = stubs.make_fs_resolver(tarp)
+    with pytest.raises(stubs.StubError):
+        resolve("/lib/libc.so")
+    with pytest.raises(stubs.StubError):
+        resolve("libc.so")
+
+
+def test_resolver_ambiguous_basename_errors(tmp_path):
+    tarp = _make_tar(tmp_path, ["./lib/libX.so", "./usr/lib/libX.so"])
+    resolve = stubs.make_fs_resolver(tarp)
+    with pytest.raises(stubs.StubError):
+        resolve("libX.so")
+
+
+# --------------------------------------------------------------------------- #
+# assembly-body form (sym@addr: {body: ...})
+# --------------------------------------------------------------------------- #
+def test_schema_body_only():
+    _validate({"libX.so": {"hw_probe": {"body": "movs r0, #0\nbx lr", "mode": "thumb"}}})
+
+
+def test_schema_body_and_return_mutually_exclusive():
+    with pytest.raises(ValidationError):
+        _validate({"libX.so": {"foo": {"body": "nop", "return": 0}}})
+
+
+def test_schema_mode_expect_require_body():
+    with pytest.raises(ValidationError):
+        _validate({"libX.so": {"foo": {"return": 0, "mode": "thumb"}}})
+    with pytest.raises(ValidationError):
+        _validate({"libX.so": {"foo": {"return": 0, "expect": "00000000"}}})
+
+
+def test_parse_symbol_key():
+    assert stubs.parse_symbol_key("foo") == ("foo", 0)
+    assert stubs.parse_symbol_key("foo@0x10") == ("foo", 16)
+    assert stubs.parse_symbol_key("foo@16") == ("foo", 16)
+    with pytest.raises(stubs.StubError):
+        stubs.parse_symbol_key("foo@")
+    with pytest.raises(stubs.StubError):
+        stubs.parse_symbol_key("foo@nothex")
+
+
+def test_generate_patches_basic():
+    # fake resolver: symbol -> (guest_path, base_offset)
+    def resolver(lib, sym):
+        return ("/usr/lib/libX.so", 0x1000)
+
+    patches = stubs.generate_patches(
+        {"libX.so": {
+            "hw_probe": {"body": "movs r0, #0", "mode": "thumb"},
+            "check@0x8": {"body": "nop", "expect": "00000000"},
+        }},
+        resolver,
+    )
+    assert set(patches) == {"/usr/lib/libX.so"}
+    entries = {e["file_offset"]: e for e in patches["/usr/lib/libX.so"]}
+    assert entries[0x1000]["asm"] == "movs r0, #0"
+    assert entries[0x1000]["mode"] == "thumb"
+    assert entries[0x1008]["asm"] == "nop"           # base + 0x8
+    assert entries[0x1008]["expect"] == "00000000"
+    assert all(e["tag"] == "stubs" for e in patches["/usr/lib/libX.so"])
+
+
+def test_generate_patches_rejects_glob():
+    def resolver(lib, sym):
+        return ("/x", 0)
+
+    with pytest.raises(stubs.StubError):
+        stubs.generate_patches({"libX.so": {"chk_*": {"body": "nop"}}}, resolver)
+
+
+def test_generate_ignores_body_stubs():
+    # a mixed config: generate() (shim path) sees only the return stub
+    files, aliases = stubs.generate(
+        {"libX.so": {"foo": {"return": 0}, "bar": {"body": "nop"}}}
+    )
+    assert aliases == {"foo": "__igloo_stub_foo"}
+    assert set(files) == {"stub_foo.c"}
+
+
+def test_expand_rejects_at_in_return_key():
+    with pytest.raises(stubs.StubError):
+        stubs.generate({"libX.so": {"foo@0x4": {"return": 0}}})
+
+
+def test_vaddr_to_file_offset():
+    class _Elf:
+        def __init__(self, segs):
+            self._segs = segs
+
+        def iter_segments(self):
+            return self._segs
+
+    seg = {"p_type": "PT_LOAD", "p_vaddr": 0x1000, "p_filesz": 0x200, "p_offset": 0x400}
+    elf = _Elf([seg])
+    assert stubs._vaddr_to_file_offset(elf, 0x1050) == 0x450
+    with pytest.raises(stubs.StubError):
+        stubs._vaddr_to_file_offset(elf, 0x9999)
+
+
+def test_merge_patches_into_static_files():
+    sf = {}
+    stubs.merge_patches_into_static_files(sf, {"/a": [{"file_offset": 0, "asm": "nop"}]})
+    assert sf["/a"]["type"] == "binary_patch"
+    assert len(sf["/a"]["patches"]) == 1
+    # append to existing binary_patch
+    stubs.merge_patches_into_static_files(sf, {"/a": [{"file_offset": 4, "asm": "nop"}]})
+    assert len(sf["/a"]["patches"]) == 2
+    # normalize a single-edit action, then append
+    sf2 = {"/b": {"type": "binary_patch", "file_offset": 0, "hex_bytes": "90"}}
+    stubs.merge_patches_into_static_files(sf2, {"/b": [{"file_offset": 8, "asm": "nop"}]})
+    assert len(sf2["/b"]["patches"]) == 2
+    # conflict on a non-binary_patch action
+    with pytest.raises(stubs.StubError):
+        stubs.merge_patches_into_static_files(
+            {"/c": {"type": "inline_file", "contents": "x"}},
+            {"/c": [{"file_offset": 0, "asm": "nop"}]},
+        )

--- a/tests/unit/test_stubs.py
+++ b/tests/unit/test_stubs.py
@@ -29,10 +29,32 @@ def test_schema_return_only():
     _validate({"libX.so": {"foo": {"return": 0}}})
 
 
-def test_schema_return_alias_populates_field():
+def test_schema_return_field():
     a = structure.StubAction.model_validate({"return": 42})
-    assert a.return_ == 42
+    assert getattr(a, "return") == 42
     assert a.type == "long"  # default
+
+
+def test_config_roundtrip_dump_then_jsonschema():
+    """Mirror penguin_config._validate_config_schema: pydantic-validate, then
+    model_dump(exclude_none=True) WITHOUT by_alias, then jsonschema-validate
+    against the generated schema. The `return` field must survive this round
+    trip (a regression guard for the aliased-field dump mismatch)."""
+    import jsonschema
+
+    cfg = dict(
+        core=dict(version=2, arch="armel"),
+        env={}, pseudofiles={}, nvram={}, static_files={}, plugins={},
+        lib_inject={"stubs": {
+            "libX.so": {"foo": {"return": 0}, "nvram_*": {"return": 1}},
+            "libc.so": {"memcpy": {"guard_null_args": [0, 1], "return": 0}},
+        }},
+    )
+    model = structure.Main(**cfg)
+    dumped = model.model_dump(exclude_none=True)
+    # the dumped key must be `return`, not `return_`
+    assert "return" in dumped["lib_inject"]["stubs"]["libX.so"]["foo"]
+    jsonschema.validate(instance=dumped, schema=structure.Main.model_json_schema())
 
 
 def test_schema_type_override_and_guard():


### PR DESCRIPTION
## What

Adds a declarative `lib_inject.stubs` config section — a first-class way to do the constant rehosting move of forcing a library/object function to "just return 0/1" (or a specific value, or a NULL-guarded passthrough, or an inline-asm overwrite). It **compiles down to the existing `lib_inject` and `binary_patch` machinery** rather than introducing a new injection mechanism.

Implements draft 07.

## Config

```yaml
lib_inject:
  stubs:
    libX.so:                       # library key: organizational label + glob target
      get_flag: { return: 0 }
      set_mode: { return: 1, type: int }
      "nvram_*": { return: 0 }     # glob over exported symbols
      hw_probe: { body: "movs r0, #0\nbx lr", mode: thumb }   # asm overwrite
    /lib/libc.so:
      memcpy: { guard_null_args: [0, 1], return: 0 }          # NULL-guard, else call through
```

Two mutually exclusive forms per stub:

- **Symbol return** (`return` / `type` / `guard_null_args`) — generates one tiny C shim per symbol plus a `--defsym` alias, fed through the existing clang build in `nvram2`. Globs expand against the library's exported symbols at build time. `guard_null_args` early-returns the constant when a listed pointer arg is NULL, otherwise calls through to the real symbol via `dlsym(RTLD_NEXT, ...)` (sound because injection is a real `LD_PRELOAD`; limited to the first 8 integer/pointer register args — documented).
- **Assembly body** (`body` at a `symbol` or `symbol@offset` key) — resolves the symbol to a file offset statically from the rootfs and emits a `static_files` `binary_patch`, keeping `binary_patch` the single owner of on-disk patching.

### Decisions
- Nested under `lib_inject` (it compiles to lib_inject), so the precedence check vs `lib_inject.aliases` is a local sibling — a symbol in both is a **hard error**.
- Return type defaults to `long`, overridable via `type`.
- Glob library lookup accepts an absolute guest path or a bare basename; missing/ambiguous/stripped is a hard error.
- Generated shims are written to `<proj>/lib_inject.d/.generated/` for inspection. The existing (previously undocumented) hand-authored `lib_inject.d/` dropin folder is now documented.

## Where

- `src/penguin/stubs.py` — new, pure/host-side codegen (schema → C shims + aliases; symbol→offset resolution → binary_patch).
- `src/penguin/penguin_config/structure.py` — `StubAction`/`StubLibrary`/`Stubs` under `LibInject`.
- `pyplugins/interventions/nvram2.py` — wiring: return/glob/guard per ABI in `add_lib_inject_for_abi`; assembly-body once in `prep_config`.

## Testing

- `tests/unit/test_stubs.py` (30 tests): schema validation, codegen for all forms, glob expansion, precedence/duplicate errors, the rootfs resolver, and `binary_patch` synthesis (validated against the real schema). Full `tests/unit` suite: **617 passed** in a fresh venv; flake8 clean.
- `tests/integration/basic_target`: a return-stub compiled through the real per-arch toolchain, asserting the generated shim lands in the cached `lib_inject_*.so` (runs across the CI arch × kernel matrix).
- Verified the toolchain boundary directly: the generated shim cross-compiles with clang-20 for ARM and `--defsym`-links with the alias and shim exported at the **same address**.

## Docs

New `docs/lib_inject.md` (full reference incl. the `lib_inject.d/` folder), regenerated `docs/schema_doc.md`, and a `docs/playbook.md` technique section.