### PR TITLE
Guest Python (penguest) + first-class uncompiled init drop-ins

### DIFF
--- a/docs/init_dropins.md
+++ b/docs/init_dropins.md
@@ -1,0 +1,91 @@
+# Init drop-ins: `init.d/` and `source.d/`
+
+Penguin runs a stack of small scripts during guest boot. You can add your own by
+dropping files into two folders at the top level of your project directory — no
+config authoring, no build step for scripts:
+
+```
+projects/myfw/
+  init.d/       # each executable file is run at boot
+  source.d/     # each file is sourced into the boot shell before init.d runs
+```
+
+Both folders are discovered automatically at config-load time and installed into
+the guest under `/igloo/init.d/` and `/igloo/source.d/`. The listing is **flat**
+(top level only) and processed in **sorted filename order**.
+
+## `init.d/` — scripts run at boot
+
+The boot runner (`/igloo/init.sh`) execs every **executable** file in
+`/igloo/init.d/*`, in sorted order, before handing off to the firmware's real
+init. A drop-in therefore needs two things to run:
+
+1. **It is executable.** Drop-ins are installed `0755` for you.
+2. **It has a shebang pointing at an interpreter that exists in the guest.**
+   The runner execs the file directly, so the kernel resolves the `#!` line
+   itself. A minimal firmware root filesystem often has no `/bin/sh` or
+   `/usr/bin/python`, so Penguin normalizes drop-in shebangs to the interpreters
+   it ships:
+
+   | Drop-in                                   | In-guest interpreter   |
+   |-------------------------------------------|------------------------|
+   | `*.sh`                                    | `/igloo/utils/sh` (busybox) |
+   | extension-less with a shell shebang       | `/igloo/utils/sh`      |
+   | `*.py`                                    | `/igloo/utils/python3` *(requires in-guest Python)* |
+
+   > **Python note:** `.py` drop-ins require the in-guest Python interpreter to
+   > be staged for the target architecture. When it is, `.py` drop-ins get their
+   > shebang resolved to `/igloo/utils/python3` and the [`penguest`](penguest.md)
+   > guest module on their path; when no interpreter is available for the target, the build
+   > fails with a clear message rather than installing a script that dies at
+   > boot. The shell half (`.sh`) has no such dependency and works everywhere.
+
+Shebang handling for `init.d/` scripts:
+
+- **Missing shebang** → the correct `#!` line is prepended (with a warning).
+- **Foreign shebang** (e.g. `#!/bin/sh`, `#!/usr/bin/env python3`) → rewritten to
+  the in-guest interpreter (with a warning).
+- **Already correct** (`#!/igloo/utils/sh`) → installed verbatim, untouched.
+
+Your source file on the host is never modified; normalization happens on the
+copy installed into the guest image.
+
+Files that are **not** recognized as scripts are installed verbatim, exactly as
+before:
+
+- `*.c` → compiled with the drop-in musl toolchain and installed as a native
+  binary (see [`dropin_compile.py`](../src/penguin/dropin_compile.py)). This is
+  the "compileables" path.
+- `*.h` → skipped (headers for the `.c` compileables).
+- prebuilt binaries, `*.conf`, `*.txt`, etc. → copied unchanged. (A prebuilt
+  binary you drop in extension-less still runs, since the kernel execs ELF
+  directly — Penguin does not touch it.)
+
+### Ordering
+
+`init.d/` runs in **sorted filename order**. To force a script to run last, name
+it so it sorts after the rest — the `zz_` prefix convention is used internally
+(e.g. `core.startup_script` installs as `/igloo/init.d/zz_startup_script`).
+
+## `source.d/` — shell fragments sourced before init
+
+Every file in `source.d/*` is **sourced** into the boot shell (not executed)
+before any `init.d/` script runs, so it is shell-only and needs no shebang. Use
+it for environment setup that later `init.d/` scripts rely on.
+
+## Relation to `core.startup_script`
+
+`core.startup_script` is the single-inline-shell-body case: its body is installed
+as `/igloo/init.d/zz_startup_script` with `#!/igloo/utils/sh` prepended. The
+`init.d/` folder is the many-files-in-a-folder case; both coexist.
+
+## Example
+
+```sh
+# projects/myfw/init.d/10_net.sh
+ip link set eth0 up
+udhcpc -i eth0
+```
+
+No shebang needed — Penguin prepends `#!/igloo/utils/sh`. Drop the file in, run
+the project, and it executes at boot.

--- a/docs/penguest.md
+++ b/docs/penguest.md
@@ -1,0 +1,175 @@
+# `penguest` — the in-guest Python binding
+
+`penguest` is a small Python module shipped **into the emulated guest** so that
+Python scripts running inside the target can talk back to the Penguin host. It
+is the guest-side complement to the host's portalcall dispatcher
+(`pyplugins/apis/portalcall.py`) and reuses the exact ABI the C helpers already
+use (`guest-utils/native/portal_call.h`) — it does not invent a new mechanism.
+
+## What's in the guest
+
+Penguin ships a **full CPython** interpreter into the guest as a pristine
+nixpkgs glibc runtime closure (via `penguin-tools`), reachable through the
+wrapper `/igloo/utils/python3`. Because it is a real CPython, the **entire
+standard library is available** — this is not a cut-down or static build.
+
+Guidance for scripts (and for anything the AI-rehosting loop authors):
+
+- **Rely on the pure-Python stdlib + `ctypes`.** `os`, `sys`, `struct`, `json`,
+  `socket`, `ctypes`, etc. are always present and portable across the target
+  architectures. `penguest` itself uses only `ctypes`/`os` (portal) and
+  `socket`/`json`/`struct` (vsock).
+- Avoid pinning behaviour to CPython internals or optional C extensions that may
+  vary; keep probe scripts to the batteries above so they run identically on
+  every arch.
+
+## `penguest.portal_call`
+
+```python
+import penguest
+
+# Lands at the host handler registered with @plugins.portalcall.portalcall(M).
+result = penguest.portal_call(M, arg0, arg1, ...)   # up to 10 integer args
+```
+
+`portal_call` lowers to `syscall(SYS_sendto, PORTAL_MAGIC, user_magic, argc,
+&args, 0, 0)` — identical to `portal_call.h`. The host intercepts the `sendto`
+syscall (filtered on `PORTAL_MAGIC = 0xc1d1e1f1`), reads the argument array, and
+dispatches to the matching `@portalcall(M)` handler; its integer return value
+comes back as `portal_call`'s result. Arguments are register-width integers; to
+pass a buffer, pass its address and length and have the host handler read guest
+memory (this is what `penguest.log` does).
+
+## `penguest.log` / `penguest.report`
+
+Typed helpers built on `portal_call` for the common case of handing text to the
+host:
+
+```python
+penguest.log("boot reached stage 2", level="warning")
+penguest.report("suspicious write to /dev/mtd0")   # == log(..., level="finding")
+```
+
+Each packs the message into a buffer and makes a `portal_call` carrying
+`(pointer, length, level)`. The **host bridge** (`pyplugins/apis/penguest.py`,
+on by default) reads the string out of guest memory and emits it into the run's
+penguin log, prefixed `[guest]` (or `[guest finding]` for `report`, the hook the
+#835 AI-rehosting loop consumes). Levels: `debug`/`info`/`warning`/`error`/
+`finding`. Guest log lines are also persisted (lazily, on first use) to
+`<results>/…/penguest_guest.log` as `level<TAB>message`, so they survive the run
+for tooling and the AI loop to read back.
+
+## `penguest.vsock` — AF_VSOCK request/response
+
+For payloads bigger or streamier than a portalcall's register args, connect to
+the host over vsock (from a guest, the host is always CID `2`):
+
+```python
+with penguest.vsock.connect() as c:        # -> host penguest endpoint (CID 2)
+    c.send_json({"op": "ping"})
+    reply = c.recv_json()                  # {"pong": True}
+```
+
+`VsockConn` frames messages as a 4-byte big-endian length prefix + JSON, so a
+receiver recovers message boundaries on the byte stream. `connect()` defaults to
+`PENGUEST_VSOCK_PORT`, the port of the host endpoint below.
+
+### Host endpoint
+
+`pyplugins/apis/penguest_vsock.py` (on by default) is the host side. With
+vhost-device-vsock a guest-initiated connection to `(CID 2, port P)` is forwarded
+to a host Unix socket at `<uds_path>_<P>`, so the endpoint **listens** there and
+serves framed JSON on a background thread. It ships `ping` and `echo`; any plugin
+can register more:
+
+```python
+@plugins.penguest_vsock.endpoint("whoami")
+def _whoami(req):
+    return {"pid": req.get("pid")}
+```
+
+The endpoint is a no-op on runs without vsock (`vpn` disabled). The transport
+itself is already wired — the custom QEMU builds `CONFIG_AF_VSOCK` and Penguin
+launches `vhost-device-vsock` (pinned **v0.2.0**) for the guest.
+
+Typed convenience wrappers over more portal ops (read/write mem, osi_proc, …)
+remain a follow-on (draft 16 Slice 1+).
+
+### Architecture note
+
+`portal_call.h` gets `SYS_sendto` from the C toolchain at compile time; the
+ctypes shim resolves it at runtime. The authoritative source is the
+`PENGUEST_SYS_SENDTO` environment variable; absent that, `penguest` derives it
+from `os.uname().machine` via a built-in per-arch table. It issues the raw
+`sendto` syscall (not libc's `sendto()` wrapper) to mirror `portal_call.h`
+exactly and to avoid arches that might route `sendto()` through the legacy
+`socketcall` multiplexer.
+
+## Staging
+
+- **Interpreter:** the CPython closure is baked into the base image at
+  `/igloo/nix/store/...`; the per-run wrapper `/igloo/utils/python3` runs it
+  inside a private mount namespace (see `pyplugins/core/live_image.py`).
+- **Module:** the `penguest` package is installed into the guest at
+  `/igloo/pylib/penguest/` via `static_files` (see
+  `penguin_config/__init__.py`), and the `/igloo/utils/python3` wrapper puts
+  `/igloo/pylib` on `PYTHONPATH`. So any script run through that interpreter —
+  including a `.py` [init drop-in](init_dropins.md) — can `import penguest`
+  with no extra setup. `PYTHONPATH` is scoped to the wrapper and is **not**
+  leaked into the firmware's own environment.
+
+## Testing
+
+- **Host unit tests** (`tests/unit/test_penguest.py`): the `portal_call` packing
+  matches `portal_call.h`, a two-sided round-trip through the real
+  `portalcall.py`, the `vsock` JSON framing, `log`/`report` packing, the host
+  bridge reading guest memory + persisting the log file, and the host vsock
+  endpoint (dispatch, a guest `VsockConn` ↔ host round-trip over a socket pair,
+  and a live listener bind/serve/teardown).
+- **In-guest integration test** (`tests/integration/test_target/patches/tests/penguest.yaml`):
+  a `.py` driver exec'd via its `#!/igloo/utils/python3` shebang that imports
+  `penguest`, makes a `portal_call` to a host handler, calls `log`/`report`, and
+  does a `vsock.connect()` round-trip to the host endpoint (guest →
+  vhost-device-vsock → `penguest_vsock`). This is the one place the daemon's
+  guest→host forwarding is exercised end-to-end. It proves the whole path on real
+  guest CPython and runs on the full arch matrix. (The 32-bit guest-python3 hang/ENOSYS, penguin#876, is fixed in
+  the pinned penguin-tools via penguin-tools#20's glibc vDSO runtime-gate for
+  mipsel/mipseb/armel; 64-bit arches were never affected.)
+
+## Security
+
+The guest is untrusted firmware, so these are host-facing channels. Notes:
+
+- The `portal_call` transport is already always-on (any guest process can make
+  the raw `sendto`); the `penguest` binding adds no new transport, only handlers.
+- **Two handlers are on by default** (`default_plugins`): the `penguest` log
+  bridge and the `penguest_vsock` endpoint. Both take untrusted guest input, so
+  they are hardened: the log bridge caps the read (64 KiB), strips control chars
+  from the message (no log-line forgery / terminal-escape injection), and bounds
+  the persisted log file; the vsock endpoint serves each connection on a capped
+  pool of workers with a per-connection recv timeout, so a stalled or flooding
+  guest can't wedge it, and rejects oversize frames.
+- **Disable per run** (e.g. for adversarial-firmware analysis):
+
+  ```yaml
+  plugins:
+    penguest: { enabled: false }        # drop the guest -> host log handler
+    penguest_vsock: { enabled: false }  # no host vsock listener
+  ```
+
+  `penguest_vsock` is also inherently a no-op when `vpn`/vsock is off. Tunables:
+  `vsock_max_conns`, `vsock_conn_timeout`, `guest_log_max_bytes`.
+
+## Follow-ons (not yet implemented)
+
+Draft 16 Slices 2 & 4:
+
+- **Host-driven guest execution** — `run_guest_python(script, args)` over
+  guesthopper's vsock command channel (guesthopper isn't checked out in this
+  worktree).
+- **Binding to the live cartography model / the #835 loop** — as vsock endpoint
+  ops (`@plugins.penguest_vsock.endpoint(...)`) that query the model and report
+  findings.
+
+These build on `portal_call`, the `vsock` client + host endpoint, and the
+staging above.

--- a/docs/penguest.md
+++ b/docs/penguest.md
@@ -118,6 +118,11 @@ exactly and to avoid arches that might route `sendto()` through the legacy
   with no extra setup. `PYTHONPATH` is scoped to the wrapper and is **not**
   leaked into the firmware's own environment.
 
+> **Don't name your script `penguest.py`.** CPython puts a script's own
+> directory first on `sys.path`, so a script literally named `penguest.py`
+> shadows the staged package and `import penguest` imports the script itself.
+> Name drivers/probes something else (e.g. `penguest_probe.py`).
+
 ## Testing
 
 - **Host unit tests** (`tests/unit/test_penguest.py`): the `portal_call` packing

--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -731,7 +731,7 @@ true
 |__Type__|string or null|
 |__Default__|`null`|
 
-Shell script body dropped into /igloo/init.d to run during guest boot. Installed under a name that sorts after other init.d entries so it runs last. A '#!/igloo/utils/sh' shebang is prepended automatically.
+Shell script body dropped into /igloo/init.d to run during guest boot. Installed under a name that sorts after other init.d entries so it runs last. A '#!/igloo/utils/sh' shebang is prepended automatically. For multiple scripts (shell or Python), drop files into the project's init.d/ and source.d/ folders instead; see docs/init_dropins.md.
 
 ```yaml
 'ip link set eth0 up

--- a/pyplugins/apis/penguest.py
+++ b/pyplugins/apis/penguest.py
@@ -1,0 +1,86 @@
+"""Host bridge for the guest ``penguest`` binding.
+
+Registers the portalcall handlers that the guest-side ``penguest`` module
+(shipped to ``/igloo/pylib``; see ``docs/penguest.md``) calls. Today that is
+guest -> host logging (``penguest.log`` / ``penguest.report``): the guest passes
+a (pointer, length, level) triple over the portal, and this plugin reads the
+string out of guest memory and emits it into the run's penguin log.
+
+The real logging logic lives in :meth:`Penguest.handle_log` (a plain portal
+generator) so it can be unit-tested host-side without the portalcall decorator.
+"""
+
+import os
+import re
+
+from penguin import Plugin, plugins
+
+# Must match PENGUEST_LOG_MAGIC in src/resources/penguest/__init__.py.
+PENGUEST_LOG_MAGIC = 0x7067104C
+
+# Must match _LOG_LEVELS in src/resources/penguest/__init__.py.
+_LEVEL_NAMES = {0: "debug", 1: "info", 2: "warning", 3: "error", 4: "finding"}
+_MAX_LOG_BYTES = 64 * 1024
+
+# The message is guest-controlled, so strip control chars (newlines, ANSI/terminal
+# escapes, NULs) before it reaches the log or the log file -- this blocks log-line
+# forgery and terminal-escape injection. Tabs go too so the TSV log file stays clean.
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+# Bound the persisted log so a guest spamming penguest.log can't fill host disk.
+_MAX_LOG_FILE = 8 * 1024 * 1024
+
+
+class Penguest(Plugin):
+    """Host side of the guest ``penguest`` binding."""
+
+    def __init__(self):
+        # Persist guest log lines to <outdir>/penguest_guest.log (created lazily
+        # on first guest log) so they survive the run and the AI loop / tests can
+        # read them back, in addition to the live penguin log.
+        outdir = self.get_arg("outdir")
+        self._guest_log_path = (
+            os.path.join(outdir, "penguest_guest.log") if outdir else None)
+        self._log_bytes = 0
+        self._log_capped = False
+        self._log_cap = int(self.get_arg("guest_log_max_bytes") or _MAX_LOG_FILE)
+
+    @plugins.portalcall.portalcall(PENGUEST_LOG_MAGIC)
+    def _on_guest_log(self, ptr, length, level):
+        return (yield from self.handle_log(ptr, length, level))
+
+    def handle_log(self, ptr, length, level):
+        """Read a ``length``-byte UTF-8 string from guest memory at ``ptr`` and
+        log it at ``level``. Returns 0 (the guest ignores the value)."""
+        length = int(length) & 0xFFFFFFFF
+        if length > _MAX_LOG_BYTES:
+            self.logger.warning(
+                f"penguest.log: truncating oversized message ({length} bytes)")
+            length = _MAX_LOG_BYTES
+        data = b""
+        if length:
+            data = bytes((yield from plugins.mem.read_bytes(ptr, length)))
+        msg = _CONTROL_CHARS.sub("�", data.decode("utf-8", "replace"))
+        self._emit(_LEVEL_NAMES.get(int(level) & 0xFFFFFFFF, "info"), msg)
+        return 0
+
+    def _emit(self, level_name, msg):
+        prefix = "[guest finding] " if level_name == "finding" else "[guest] "
+        {
+            "debug": self.logger.debug,
+            "info": self.logger.info,
+            "warning": self.logger.warning,
+            "error": self.logger.error,
+            "finding": self.logger.info,
+        }[level_name](prefix + msg)
+        if not self._guest_log_path or self._log_capped:
+            return
+        line = f"{level_name}\t{msg}\n".encode("utf-8")
+        if self._log_bytes + len(line) > self._log_cap:
+            self._log_capped = True
+            self.logger.warning(
+                "penguest guest log hit its %d-byte cap; further guest log lines "
+                "are logged but not persisted", self._log_cap)
+            return
+        with open(self._guest_log_path, "ab") as f:
+            f.write(line)
+        self._log_bytes += len(line)

--- a/pyplugins/apis/penguest_vsock.py
+++ b/pyplugins/apis/penguest_vsock.py
@@ -1,0 +1,209 @@
+"""Host vsock endpoint for the guest ``penguest.vsock`` client (draft 16, Slice 3).
+
+The guest connects out to ``(CID 2, PENGUEST_VSOCK_PORT)`` (see
+``penguest.vsock.connect``). With vhost-device-vsock a guest-initiated connection
+to port P is forwarded to a host Unix socket at ``<uds_path>_<P>`` -- so this
+plugin *listens* on that path, accepts connections, and serves length-prefixed
+JSON requests off a background thread. It is the structured/streaming complement
+to the synchronous ``portalcall`` path.
+
+Register handlers by op name from any plugin::
+
+    @plugins.penguest_vsock.endpoint("whoami")
+    def _whoami(req):
+        return {"pid": req.get("pid")}
+
+Built-ins ``ping`` and ``echo`` give an out-of-the-box round-trip. The endpoint
+is a no-op when vsock isn't enabled for the run.
+"""
+
+import json
+import os
+import socket
+import struct
+import threading
+
+from penguin import Plugin
+
+# Guest-visible vsock port for this endpoint. Must match PENGUEST_VSOCK_PORT in
+# src/resources/penguest/vsock.py.
+PENGUEST_VSOCK_PORT = 0xC1D1  # 49617
+
+# Frame = 4-byte big-endian length + JSON. Must match src/resources/penguest/vsock.py.
+# The cap here is a receiver-side sanity limit against a hostile guest; these are
+# control-plane messages, so it is deliberately small (the guest's own cap can be
+# larger -- each side bounds its own recv).
+_LEN = struct.Struct("!I")
+_MAX_FRAME = 4 * 1024 * 1024
+
+# Defaults for the untrusted-input server (overridable via plugin args).
+_DEFAULT_CONN_TIMEOUT = 10.0   # seconds; drop an idle/stalled guest connection
+_DEFAULT_MAX_CONNS = 16        # concurrent connection cap
+
+
+def _recvn(sock, n):
+    chunks, remaining = [], n
+    while remaining:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            return None
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _read_frame(sock):
+    """Read one framed JSON message, or None on clean EOF."""
+    header = _recvn(sock, _LEN.size)
+    if header is None:
+        return None
+    (length,) = _LEN.unpack(header)
+    if length > _MAX_FRAME:
+        raise ValueError(f"incoming frame too large: {length} bytes")
+    body = _recvn(sock, length)
+    if body is None:
+        return None
+    return json.loads(body.decode("utf-8"))
+
+
+def _write_frame(sock, obj):
+    payload = json.dumps(obj).encode("utf-8")
+    sock.sendall(_LEN.pack(len(payload)) + payload)
+
+
+class PenguestVsock(Plugin):
+    """Host side of the guest ``penguest.vsock`` channel."""
+
+    def __init__(self):
+        self._handlers = {}
+        self._stop = threading.Event()
+        self._thread = None
+        self._listen_sock = None
+        self._sock_path = None
+
+        # Built-in handlers so the channel round-trips out of the box.
+        self.register("ping", lambda req: {"pong": True})
+        self.register("echo", lambda req: {"echo": req.get("data")})
+
+        self.port = int(self.get_arg("vsock_endpoint_port") or PENGUEST_VSOCK_PORT)
+        self._conn_timeout = float(
+            self.get_arg("vsock_conn_timeout") or _DEFAULT_CONN_TIMEOUT)
+        self._max_conns = int(self.get_arg("vsock_max_conns") or _DEFAULT_MAX_CONNS)
+        self._conn_sem = threading.Semaphore(self._max_conns)
+        uds_path = self.get_arg("uds_path")
+        if not self.get_arg_bool("vpn_enabled") or not uds_path:
+            self.logger.debug(
+                "penguest vsock endpoint disabled (no vsock/uds_path for this run)")
+            return
+        self._sock_path = f"{uds_path}_{self.port}"
+        self._start_listener()
+
+    # -- handler registry --------------------------------------------------- #
+    def register(self, op, handler):
+        """Register ``handler(request_dict) -> response_dict`` for op ``op``."""
+        self._handlers[op] = handler
+        return handler
+
+    def endpoint(self, op):
+        """Decorator form of :meth:`register`."""
+        def deco(fn):
+            self.register(op, fn)
+            return fn
+        return deco
+
+    def dispatch(self, request):
+        """Route one request dict to its handler; never raises."""
+        if not isinstance(request, dict):
+            return {"error": "request must be a JSON object"}
+        op = request.get("op")
+        handler = self._handlers.get(op)
+        if handler is None:
+            return {"error": f"unknown op {op!r}"}
+        try:
+            return handler(request)
+        except Exception as e:  # a handler bug must not kill the accept loop
+            self.logger.error(f"penguest vsock handler {op!r} raised: {e}")
+            return {"error": str(e)}
+
+    # -- transport ---------------------------------------------------------- #
+    def _start_listener(self):
+        try:
+            if os.path.exists(self._sock_path):
+                os.unlink(self._sock_path)
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.bind(self._sock_path)
+            sock.listen(8)
+        except OSError as e:
+            self.logger.error(
+                f"penguest vsock endpoint: cannot listen on {self._sock_path}: {e}")
+            return
+        self._listen_sock = sock
+        self._thread = threading.Thread(
+            target=self._accept_loop, name="penguest-vsock", daemon=True)
+        self._thread.start()
+        self.logger.info(
+            f"penguest vsock endpoint listening on {self._sock_path} "
+            f"(guest port {self.port})")
+
+    def _accept_loop(self):
+        # A timeout makes accept() return periodically so shutdown is deterministic
+        # -- closing the socket from another thread does NOT reliably wake a blocked
+        # accept() on Linux.
+        self._listen_sock.settimeout(0.5)
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._listen_sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break  # listener closed during shutdown
+            try:
+                # Hand each connection to a short-lived worker so one slow/hostile
+                # guest can't wedge the accept loop, and cap concurrency so it
+                # can't spawn unbounded threads. Over the cap -> drop immediately.
+                if not self._conn_sem.acquire(blocking=False):
+                    self.logger.warning(
+                        "penguest vsock: connection cap (%d) reached; dropping",
+                        self._max_conns)
+                    conn.close()
+                    continue
+                threading.Thread(target=self._handle_conn, args=(conn,),
+                                 name="penguest-vsock-conn", daemon=True).start()
+            except Exception as e:  # never let one bad connection kill the loop
+                self.logger.debug(f"penguest vsock accept error: {e}")
+                conn.close()
+
+    def _handle_conn(self, conn):
+        try:
+            # A per-connection timeout means a guest that connects and stalls
+            # mid-frame is dropped rather than blocking a worker forever.
+            conn.settimeout(self._conn_timeout)
+            self._serve_conn(conn)
+        except (OSError, ValueError) as e:
+            self.logger.debug(f"penguest vsock connection error: {e}")
+        finally:
+            conn.close()
+            self._conn_sem.release()
+
+    def _serve_conn(self, conn):
+        """Serve framed request/response exchanges until the client closes."""
+        while True:
+            request = _read_frame(conn)
+            if request is None:
+                return
+            _write_frame(conn, self.dispatch(request))
+
+    def uninit(self):
+        self._stop.set()
+        if self._listen_sock is not None:
+            try:
+                self._listen_sock.close()  # unblocks accept()
+            except OSError:
+                pass
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+        if self._sock_path and os.path.exists(self._sock_path):
+            try:
+                os.unlink(self._sock_path)
+            except OSError:
+                pass

--- a/pyplugins/apis/penguest_vsock.py
+++ b/pyplugins/apis/penguest_vsock.py
@@ -90,8 +90,12 @@ class PenguestVsock(Plugin):
             self.get_arg("vsock_conn_timeout") or _DEFAULT_CONN_TIMEOUT)
         self._max_conns = int(self.get_arg("vsock_max_conns") or _DEFAULT_MAX_CONNS)
         self._conn_sem = threading.Semaphore(self._max_conns)
+        # uds_path is injected into the global plugin args by penguin_run only
+        # when the vpn/vsock stack is enabled (vpn_args), so its presence *is*
+        # the "this run has vsock" signal -- there is no vpn_enabled plugin arg
+        # (that key exists only in runtime.yaml).
         uds_path = self.get_arg("uds_path")
-        if not self.get_arg_bool("vpn_enabled") or not uds_path:
+        if not uds_path:
             self.logger.debug(
                 "penguest vsock endpoint disabled (no vsock/uds_path for this run)")
             return

--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -166,11 +166,19 @@ class LiveImage(Plugin):
         utils_dir = staging_dir / "igloo" / "utils"
         utils_dir.mkdir(parents=True, exist_ok=True)
         for tool, exe in tool_manifest.items():
+            # python3 gets the guest-side `penguest` binding (staged at
+            # /igloo/pylib by penguin_config) on its path, so in-guest scripts
+            # and .py init.d drop-ins can `import penguest` (draft 16). Scoped to
+            # this wrapper -- we don't leak PYTHONPATH into the firmware's env.
+            env_prefix = ""
+            if tool == "python3":
+                env_prefix = "export PYTHONPATH=/igloo/pylib${PYTHONPATH:+:$PYTHONPATH}\n"
             # busybox unshare -m runs the inner sh in a fresh mount namespace;
             # the bind mount is private to it and torn down on exit. $0 is the
             # in-store exe, "$@" the caller's args.
             wrapper = (
                 "#!/igloo/utils/sh\n"
+                + env_prefix +
                 "exec /igloo/utils/busybox unshare -m /igloo/utils/sh -c "
                 "'/igloo/utils/busybox mount -o bind /igloo/nix /nix && exec \"$0\" \"$@\"' "
                 f"{shlex.quote(exe)} \"$@\"\n"

--- a/pyplugins/testing/penguest_test.py
+++ b/pyplugins/testing/penguest_test.py
@@ -1,0 +1,56 @@
+"""Integration test plugin for the guest ``penguest`` binding.
+
+The guest driver ``/tests/penguest.py`` runs under the staged in-guest CPython
+(``/igloo/utils/python3``), ``import penguest``, and calls
+``penguest.portal_call(PENGUEST_TEST_MAGIC, ...)`` plus ``penguest.log`` /
+``penguest.report``. This plugin is the host handler for the test magic: it
+checks the args and writes ``penguest_test.txt`` for the verifier. The log side
+is verified separately via the ``penguest`` host bridge's
+``<outdir>/penguest_guest.log``.
+
+See ``tests/integration/test_target/patches/tests/penguest.yaml``.
+"""
+
+from os.path import join
+
+from penguin import Plugin, plugins
+
+# Must match /tests/penguest.py in the penguest.yaml test patch.
+PENGUEST_TEST_MAGIC = 0x70677401  # 'pgt' + 1
+PENGUEST_ARG1 = 0xDEADBEEFF1F1F1F1
+PENGUEST_ARG2 = 0x1337C0DEFEEDC0DE
+
+
+class PenguestTest(Plugin):
+    """Host handler proving a guest Python script reaches the host via penguest."""
+
+    def __init__(self):
+        self.outdir = self.get_arg("outdir")
+        self.reported = False
+
+    @plugins.portalcall.portalcall(PENGUEST_TEST_MAGIC)
+    def _on_test(self, a1, a2):
+        return self.handle_test(a1, a2)
+
+    def handle_test(self, a1, a2):
+        ok = (a1 == PENGUEST_ARG1 and a2 == PENGUEST_ARG2)
+        if not ok:
+            self.logger.error(
+                f"PENGUEST test failed: a1={a1:#x} (want {PENGUEST_ARG1:#x}), "
+                f"a2={a2:#x} (want {PENGUEST_ARG2:#x})")
+        self._report(ok)
+        return 13
+
+    def _report(self, ok):
+        if self.reported:
+            return
+        self.reported = True
+        res = "passed" if ok else "failed"
+        self.logger.info(f"PENGUEST test: {res}")
+        with open(join(self.outdir, "penguest_test.txt"), "w") as f:
+            f.write(f"PENGUEST test: {res}\n")
+
+    def uninit(self):
+        # If the guest never made the call, record a failure so the verifier
+        # doesn't hang on a missing file.
+        self._report(False)

--- a/src/penguin/defaults.py
+++ b/src/penguin/defaults.py
@@ -10,7 +10,7 @@ library injection mappings used throughout Penguin.
 
 import os
 from copy import deepcopy
-from os.path import dirname
+from os.path import dirname, join
 
 # Stable resources dir, pinned by PENGUIN_RESOURCES in the image (see
 # penguin.config_patchers.RESOURCES for why); install-relative fallback for
@@ -18,6 +18,12 @@ from os.path import dirname
 _resources_dir: str = os.environ.get("PENGUIN_RESOURCES") or f"{dirname(dirname(__file__))}/resources"
 
 vnc_password: str = "IGLOOPassw0rd!"
+
+# Packaged guest/host resources (shipped as package data; see src/pyproject.toml).
+resources_dir: str = join(dirname(dirname(__file__)), "resources")
+# The guest-side `penguest` Python binding (draft 16). Staged into the guest at
+# /igloo/pylib/penguest and put on the in-guest python3's PYTHONPATH.
+penguest_src_dir: str = join(resources_dir, "penguest")
 
 default_version: int = 2
 static_dir: str = "/igloo_static/"
@@ -84,6 +90,10 @@ default_plugins: dict[str, dict] = {
     "snapshot": {},
     "indiv_debug": {},
     "scope": {},
+    # Host bridge for the guest `penguest` binding (guest -> host logging, etc.).
+    "penguest": {},
+    # Host vsock endpoint for the guest `penguest.vsock` client (no-op without vsock).
+    "penguest_vsock": {},
 }
 
 # We add ioctl wildcard -> 0 in single-iteration mode

--- a/src/penguin/defaults.py
+++ b/src/penguin/defaults.py
@@ -19,11 +19,11 @@ _resources_dir: str = os.environ.get("PENGUIN_RESOURCES") or f"{dirname(dirname(
 
 vnc_password: str = "IGLOOPassw0rd!"
 
-# Packaged guest/host resources (shipped as package data; see src/pyproject.toml).
-resources_dir: str = join(dirname(dirname(__file__)), "resources")
 # The guest-side `penguest` Python binding (draft 16). Staged into the guest at
-# /igloo/pylib/penguest and put on the in-guest python3's PYTHONPATH.
-penguest_src_dir: str = join(resources_dir, "penguest")
+# /igloo/pylib/penguest and put on the in-guest python3's PYTHONPATH. Anchored on
+# _resources_dir so it follows PENGUIN_RESOURCES in the image (/pkg/resources)
+# rather than assuming an install-relative layout.
+penguest_src_dir: str = join(_resources_dir, "penguest")
 
 default_version: int = 2
 static_dir: str = "/igloo_static/"

--- a/src/penguin/penguin_config/__init__.py
+++ b/src/penguin/penguin_config/__init__.py
@@ -294,6 +294,158 @@ def load_unpatched_config(path):
     return config
 
 
+# In-guest interpreters an init.d drop-in shebang can safely target. The boot
+# runner (src/resources/init.sh) execs each executable file in /igloo/init.d
+# directly, so the kernel needs a shebang whose interpreter actually exists in
+# the guest. The guest shell is busybox at /igloo/utils/sh (init.sh:1) and, when
+# staged, Python is the closure wrapper at /igloo/utils/python3 -- a firmware's
+# own /bin/sh or /usr/bin/python may not resolve in a minimal rootfs.
+_GUEST_SHELL_INTERP = "/igloo/utils/sh"
+_GUEST_PYTHON_INTERP = "/igloo/utils/python3"
+
+# Shebang interpreter basenames we recognize and remap to the guest equivalent.
+# NB: busybox is deliberately absent -- it is a multi-call binary whose applet
+# is the *second* token (``#!/bin/busybox awk``), so remapping it to the shell
+# would silently drop the applet. A shebang already pointing under /igloo/
+# resolves in-guest and is left untouched (see _resolve_init_dropin).
+_SHELL_SHEBANG_INTERPS = frozenset({"sh", "bash", "ash", "dash"})
+_PYTHON_SHEBANG_INTERPS = frozenset({"python", "python2", "python3"})
+
+
+def _shebang_parts(first_line):
+    """Return (interpreter_path, interpreter_basename) for a shebang line.
+
+    Resolves ``#!/usr/bin/env python3`` to ``(python3, python3)`` (the env
+    argument). Returns ``(None, None)`` when the line is not a shebang.
+    """
+    if not first_line.startswith("#!"):
+        return (None, None)
+    parts = first_line[2:].strip().split()
+    if not parts:
+        return (None, None)
+    interp = parts[0]
+    base = os.path.basename(interp)
+    if base == "env" and len(parts) > 1:
+        interp = parts[1]
+        base = os.path.basename(parts[1])
+    return (interp, base)
+
+
+def _resolve_init_dropin(host_path, filename, python_interp=None):
+    """Decide how an ``init.d/`` drop-in that is neither ``.c`` nor ``.h`` installs.
+
+    Uncompiled scripts -- ``.sh``, ``.py``, or an extension-less file carrying a
+    shell/python shebang -- are first-class init scripts: the boot runner execs
+    each executable file in ``/igloo/init.d`` directly, so the shebang must point
+    at an interpreter that exists in the guest (see the module-level notes on
+    ``/igloo/utils/sh`` / ``/igloo/utils/python3``). A missing or foreign
+    shell/python shebang is normalized to the guest interpreter (with a warning)
+    and the rewritten body installed as an ``inline_file``. Anything we do not
+    recognize as such a script -- a prebuilt binary, a ``.conf``/``.txt``, a text
+    file with a deliberate non-shell/non-python shebang -- is left verbatim,
+    preserving the historical behavior for non-script drop-ins.
+
+    ``python_interp`` is the guest Python interpreter path (``/igloo/utils/python3``)
+    when a Python interpreter is staged for the target, else None. When None,
+    ``.py`` and python-shebang drop-ins are left verbatim (the shell half of this
+    feature ships independently of in-guest Python).
+
+    Returns ``(kind, payload)``:
+      ``("verbatim", None)``    -> install ``host_path`` unchanged as a ``host_file``
+      ``("inline", contents)``  -> install ``contents`` as an ``inline_file`` (0755)
+      ``("need_python", None)`` -> a Python drop-in but ``python_interp`` is None;
+                                   the caller should fail the build with a clear
+                                   message rather than install a script that dies
+                                   at boot.
+    """
+    ext = Path(filename).suffix
+    python_kind = False
+    if ext == ".sh":
+        target = _GUEST_SHELL_INTERP
+    elif ext == ".py":
+        target = python_interp
+        python_kind = True
+    elif ext == "":
+        target = None  # extension-less: decide from the shebang below
+    else:
+        # Some other extension (.conf, .txt, ...): not a script we manage.
+        return ("verbatim", None)
+
+    try:
+        raw = Path(host_path).read_bytes()
+    except OSError:
+        return ("verbatim", None)
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        # Binary content (e.g. a prebuilt ELF dropped in extension-less): never
+        # rewrite. A non-UTF-8 .sh/.py is almost certainly a mistake, but we
+        # still won't corrupt it -- install verbatim.
+        return ("verbatim", None)
+
+    head, _, tail = text.partition("\n")
+    interp_path, interp_base = _shebang_parts(head)
+
+    if ext == "":
+        # Only claim an extension-less file if it looks like a shell/python
+        # script; otherwise leave it exactly as before.
+        if interp_base in _SHELL_SHEBANG_INTERPS:
+            target = _GUEST_SHELL_INTERP
+        elif interp_base in _PYTHON_SHEBANG_INTERPS:
+            target = python_interp
+            python_kind = True
+        else:
+            return ("verbatim", None)
+
+    if python_kind and python_interp is None:
+        # A Python drop-in with no in-guest interpreter staged for this target:
+        # let the caller fail loudly instead of installing a boot-time failure.
+        return ("need_python", None)
+
+    if target is None:
+        return ("verbatim", None)
+
+    # A shebang already pointing under /igloo/ resolves inside the guest (e.g.
+    # the target itself, or a deliberate '#!/igloo/utils/busybox awk -f'): trust
+    # it and install verbatim, no copy needed.
+    if interp_path is not None and interp_path.startswith("/igloo/"):
+        return ("verbatim", None)
+
+    if head.startswith("#!"):
+        logger.warning(
+            f"init.d drop-in {filename}: rewriting shebang {head.strip()!r} to "
+            f"'#!{target}' so it resolves inside the guest")
+        body = tail
+    else:
+        logger.warning(
+            f"init.d drop-in {filename}: no shebang found; prepending "
+            f"'#!{target}' so the boot runner can exec it")
+        body = text
+    return ("inline", f"#!{target}\n{body}")
+
+
+def _guest_python_interp(config):
+    """Return the in-guest Python interpreter path (``/igloo/utils/python3``) if
+    a Python interpreter is staged for the target architecture, else None.
+
+    The penguin-tools tool closure ships a per-arch ``manifest.json`` mapping
+    tool -> in-store exe (see live_image._stage_tool_closure); a ``python3`` key
+    means an interpreter is available for this arch. Missing closure / manifest
+    (e.g. host unit tests, arches without one) -> None.
+    """
+    import json
+    from penguin.defaults import static_dir
+    from penguin.utils import get_arch_subdir
+    try:
+        manifest = os.path.join(
+            static_dir, "closures", get_arch_subdir(config), "manifest.json")
+        with open(manifest) as f:
+            tools = json.load(f)
+    except (OSError, ValueError, KeyError):
+        return None
+    return "/igloo/utils/python3" if "python3" in tools else None
+
+
 def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=False):
     """Load penguin config from path"""
     with open(path, "r") as f:
@@ -411,8 +563,28 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
             mode=0o755,
         )
 
+    # Stage the guest-side `penguest` Python binding (draft 16) so in-guest
+    # Python -- and `.py` init.d drop-ins -- can `import penguest` to reach the
+    # host over the portalcall ABI. Files land under /igloo/pylib, which the
+    # in-guest python3 wrapper puts on PYTHONPATH (live_image._stage_tool_closure).
+    # setdefault so a user/patch override of any path still wins.
+    from penguin.defaults import penguest_src_dir
+    if os.path.isdir(penguest_src_dir):
+        for root, _dirs, files in os.walk(penguest_src_dir):
+            for fname in sorted(files):
+                if not fname.endswith(".py"):
+                    continue
+                src = os.path.join(root, fname)
+                rel = os.path.relpath(src, penguest_src_dir).replace(os.sep, "/")
+                config["static_files"].setdefault(f"/igloo/pylib/penguest/{rel}", {
+                    "type": "host_file",
+                    "host_path": src,
+                    "mode": 0o644,
+                })
+
     # Project drop-ins are applied after patches so the user's per-project
     # files always win over inherited base configs and patch layers.
+    guest_python = _guest_python_interp(config)
     for dropin_dir in ("init.d", "source.d"):
         host_dir = os.path.join(proj_dir, dropin_dir)
         if not os.path.isdir(host_dir):
@@ -425,22 +597,37 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
                 continue
             if dropin_dir == "init.d" and filename.endswith(".h"):
                 continue
+            entry = None
             if dropin_dir == "init.d" and filename.endswith(".c"):
                 static_host_path = compile_init_c_dropin(proj_dir, host_dir, host_path, config)
                 guest_path = f"/igloo/{dropin_dir}/{Path(filename).stem}"
+                entry = {"type": "host_file", "host_path": static_host_path, "mode": 0o755}
             else:
-                static_host_path = host_path
                 guest_path = f"/igloo/{dropin_dir}/{filename}"
+                # Uncompiled init.d scripts (.sh/.py/extension-less) get their
+                # shebang normalized to an in-guest interpreter; source.d/ and
+                # non-script drop-ins are installed verbatim.
+                kind, payload = ("verbatim", None)
+                if dropin_dir == "init.d":
+                    kind, payload = _resolve_init_dropin(
+                        host_path, filename, python_interp=guest_python)
+                if kind == "need_python":
+                    raise ValueError(
+                        f"init.d drop-in {host_path} is a Python script, but no "
+                        f"in-guest Python interpreter is staged for arch "
+                        f"{config['core'].get('arch')!r}. Rebuild the penguin "
+                        "image with a python3 tool closure for this architecture, "
+                        "or remove the .py drop-in.")
+                if kind == "inline":
+                    entry = {"type": "inline_file", "contents": payload, "mode": 0o755}
+                else:
+                    entry = {"type": "host_file", "host_path": host_path, "mode": 0o755}
             if guest_path in config["static_files"]:
                 logger.warning(
                     f"drop-in {host_path} is overriding existing static_files entry "
                     f"{guest_path} (previously set by a patch or base config)"
                 )
-            config["static_files"][guest_path] = {
-                "type": "host_file",
-                "host_path": static_host_path,
-                "mode": 0o755,
-            }
+            config["static_files"][guest_path] = entry
 
     startup_script = config["core"].get("startup_script")
     if startup_script:

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -639,6 +639,8 @@ class Core(PartialModelMixin, BaseModel):
                 "Shell script body dropped into /igloo/init.d to run during guest boot.",
                 "Installed under a name that sorts after other init.d entries so it runs last.",
                 "A '#!/igloo/utils/sh' shebang is prepended automatically.",
+                "For multiple scripts (shell or Python), drop files into the project's",
+                "init.d/ and source.d/ folders instead; see docs/init_dropins.md.",
             )),
             examples=["ip link set eth0 up\nudhcpc -i eth0\n"],
         ),

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -76,4 +76,6 @@ include-package-data = true
 # packages = find: (setup.cfg) — discover from the src/ project root.
 
 [tool.setuptools.package-data]
-penguin = ["scripts/*.sh", "resources/*"]
+# resources/** (recursive) ships nested resource trees such as the guest-side
+# `penguest` binding (resources/penguest/); resources/* alone is non-recursive.
+penguin = ["scripts/*.sh", "resources/*", "resources/**/*"]

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -74,8 +74,14 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 # packages = find: (setup.cfg) — discover from the src/ project root.
+# src/resources/ is a data tree, NOT an importable package, even though it now
+# contains Python sources (resources/penguest/, the guest-side binding, which is
+# copied *into the guest* rather than imported on the host). Without this exclude,
+# auto-discovery installs a top-level site-packages/resources/ holding only
+# penguest/, and nix/penguin.nix's `cp -r resources $out/.../resources` then lands
+# the real resource tree at resources/resources/ instead of overlaying it — which
+# hides resources/init.sh from defaults.py.
+exclude = ["resources*"]
 
 [tool.setuptools.package-data]
-# resources/** (recursive) ships nested resource trees such as the guest-side
-# `penguest` binding (resources/penguest/); resources/* alone is non-recursive.
-penguin = ["scripts/*.sh", "resources/*", "resources/**/*"]
+penguin = ["scripts/*.sh", "resources/*"]

--- a/src/resources/penguest/__init__.py
+++ b/src/resources/penguest/__init__.py
@@ -1,0 +1,161 @@
+"""penguest -- in-guest Python bindings for the Penguin host.
+
+This is the guest-side complement to the host's portalcall dispatcher
+(``pyplugins/apis/portalcall.py``). It gives Python scripts running *inside* the
+emulated guest the same reach the C helpers already have via
+``penguin/guest-utils/native/portal_call.h``.
+
+The one primitive is :func:`portal_call`, a thin ctypes shim that reuses the
+existing portalcall ABI -- it does not invent a new mechanism. A portalcall
+lowers to::
+
+    syscall(SYS_sendto, PORTAL_MAGIC, user_magic, argc, &args, 0, 0)
+
+which the host intercepts (it filters ``on_sys_sendto_enter`` on ``PORTAL_MAGIC``)
+and dispatches to the ``@plugins.portalcall.portalcall(user_magic)`` handler
+registered for that magic. So a guest ``portal_call(M, ...)`` lands at the
+matching host ``@portalcall(M)`` handler with zero new host plumbing.
+
+Multi-arch note
+---------------
+``portal_call.h`` gets ``SYS_sendto`` from the C toolchain at compile time; a
+ctypes shim must resolve it at runtime. The authoritative source is the
+``PENGUEST_SYS_SENDTO`` environment variable, which the host stager sets from the
+(known) target architecture -- so production never relies on guesswork. The
+built-in per-arch table below is only a best-effort fallback for standalone use;
+using the raw ``sendto`` syscall (rather than libc's ``sendto()`` wrapper) mirrors
+``portal_call.h`` exactly and avoids arches that might route ``sendto()`` through
+the legacy ``socketcall`` multiplexer.
+"""
+
+import ctypes
+import os
+
+from . import vsock
+
+__all__ = [
+    "PORTAL_MAGIC", "PortalError", "portal_call", "log", "report", "vsock",
+]
+
+# Must match PORTAL_MAGIC in portal_call.h and pyplugins/apis/portalcall.py.
+PORTAL_MAGIC = 0xC1D1E1F1
+
+# Guest -> host logging over the portal. Must match PENGUEST_LOG_MAGIC in
+# the host bridge (pyplugins/apis/penguest.py).
+PENGUEST_LOG_MAGIC = 0x7067104C  # 'pg' + log
+_LOG_LEVELS = {"debug": 0, "info": 1, "warning": 2, "error": 3, "finding": 4}
+
+_UINT64_MASK = (1 << 64) - 1
+_MAX_ARGS = 10  # matches portal_callN()'s fixed buffer in portal_call.h
+
+# __NR_sendto per Linux ABI. Keyed on the family inferred from
+# os.uname().machine. Overridden by $PENGUEST_SYS_SENDTO when set (authoritative).
+_SENDTO_NR = {
+    "x86_64": 44,
+    "aarch64": 206,    # asm-generic
+    "arm": 290,        # arm EABI
+    "riscv": 206,      # asm-generic
+    "loongarch": 206,  # asm-generic
+    "powerpc": 335,    # ppc / ppc64 (endianness-invariant)
+    "mips_o32": 4183,  # 4000 + 183
+    "mips_n64": 5045,  # 5000 + 45
+}
+
+
+class PortalError(RuntimeError):
+    """Raised when a portalcall cannot be issued (e.g. unknown architecture)."""
+
+
+def _machine_to_key(machine):
+    m = machine.lower()
+    if m in ("x86_64", "amd64"):
+        return "x86_64"
+    if m == "aarch64" or m.startswith("arm64"):
+        return "aarch64"
+    if m.startswith("arm"):
+        return "arm"
+    if m.startswith("riscv"):
+        return "riscv"
+    if m.startswith("loongarch"):
+        return "loongarch"
+    if m.startswith("ppc") or m.startswith("powerpc"):
+        return "powerpc"
+    if m.startswith("mips64"):
+        return "mips_n64"
+    if m.startswith("mips"):
+        return "mips_o32"
+    return None
+
+
+def _resolve_sendto_nr():
+    """Return the target's __NR_sendto: env override, then the per-arch table."""
+    env = os.environ.get("PENGUEST_SYS_SENDTO")
+    if env:
+        return int(env, 0)
+    key = _machine_to_key(os.uname().machine)
+    if key is not None and key in _SENDTO_NR:
+        return _SENDTO_NR[key]
+    raise PortalError(
+        "cannot resolve the sendto syscall number for this architecture "
+        f"({os.uname().machine!r}); set PENGUEST_SYS_SENDTO to __NR_sendto")
+
+
+_libc = ctypes.CDLL(None, use_errno=True)
+_libc.syscall.restype = ctypes.c_long
+
+
+def _syscall(nr, *args):
+    """Invoke libc ``syscall(nr, *args)``; every value is passed register-width.
+
+    Split out from :func:`portal_call` so tests can substitute it without a real
+    guest kernel.
+    """
+    return int(_libc.syscall(ctypes.c_long(nr),
+                             *[ctypes.c_long(a) for a in args]))
+
+
+def portal_call(user_magic, *args):
+    """Make a portalcall to the host handler registered for ``user_magic``.
+
+    Mirrors ``portal_call.h``: lowers to
+    ``syscall(SYS_sendto, PORTAL_MAGIC, user_magic, argc, &args, 0, 0)``. Each
+    positional arg is coerced to an unsigned 64-bit integer (the host reads the
+    array via ``read_uint64_array``). Returns the handler's integer result.
+    """
+    argc = len(args)
+    if argc > _MAX_ARGS:
+        raise PortalError(f"portal_call takes at most {_MAX_ARGS} args, got {argc}")
+    # A zero-length ctypes array is invalid; allocate at least one slot. argc,
+    # not the buffer length, tells the host how many to read.
+    arr = (ctypes.c_uint64 * (argc or 1))(*[int(a) & _UINT64_MASK for a in args])
+    nr = _resolve_sendto_nr()
+    return _syscall(nr,
+                    PORTAL_MAGIC,
+                    int(user_magic) & _UINT64_MASK,
+                    argc,
+                    ctypes.addressof(arr),
+                    0,
+                    0)
+
+
+def log(msg, level="info"):
+    """Send a log line to the host; it lands in the run's penguin log.
+
+    Lowers to a portalcall carrying (pointer, length, level); the host bridge
+    reads the bytes out of guest memory and logs them. ``level`` is one of
+    ``debug``/``info``/``warning``/``error``/``finding`` (unknown -> ``info``).
+    """
+    data = msg.encode("utf-8", "replace") if isinstance(msg, str) else bytes(msg)
+    lvl = _LOG_LEVELS.get(level, _LOG_LEVELS["info"])
+    n = len(data)
+    # Keep the buffer alive across the call; the host reads it synchronously
+    # while the sendto syscall is intercepted. A zero-length string still needs
+    # a 1-byte allocation, but we tell the host to read 0 bytes.
+    buf = ctypes.create_string_buffer(data, n or 1)
+    return portal_call(PENGUEST_LOG_MAGIC, ctypes.addressof(buf), n, lvl)
+
+
+def report(msg):
+    """Report a finding to the host loop -- a log line tagged as a ``finding``
+    (the hook the #835 AI-rehosting loop consumes)."""
+    return log(msg, level="finding")

--- a/src/resources/penguest/__init__.py
+++ b/src/resources/penguest/__init__.py
@@ -57,8 +57,8 @@ _SENDTO_NR = {
     "riscv": 206,      # asm-generic
     "loongarch": 206,  # asm-generic
     "powerpc": 335,    # ppc / ppc64 (endianness-invariant)
-    "mips_o32": 4183,  # 4000 + 183
-    "mips_n64": 5045,  # 5000 + 45
+    "mips_o32": 4180,  # 4000 + 180
+    "mips_n64": 5043,  # 5000 + 43
 }
 
 
@@ -129,13 +129,27 @@ def portal_call(user_magic, *args):
     # not the buffer length, tells the host how many to read.
     arr = (ctypes.c_uint64 * (argc or 1))(*[int(a) & _UINT64_MASK for a in args])
     nr = _resolve_sendto_nr()
-    return _syscall(nr,
-                    PORTAL_MAGIC,
-                    int(user_magic) & _UINT64_MASK,
-                    argc,
-                    ctypes.addressof(arr),
-                    0,
-                    0)
+    ctypes.set_errno(0)
+    ret = _syscall(nr,
+                   PORTAL_MAGIC,
+                   int(user_magic) & _UINT64_MASK,
+                   argc,
+                   ctypes.addressof(arr),
+                   0,
+                   0)
+    # -1 means the kernel took this as a *real* sendto and failed it -- i.e. the
+    # portal was never entered (wrong SYS_sendto for this arch, portal support
+    # missing, ...). It cannot be a genuine handler result: libc's syscall()
+    # collapses every kernel return in [-4095,-1] to -1 + errno, so a handler
+    # returning -1 is indistinguishable from an error anyway. Raise rather than
+    # hand back a value the caller would read as data.
+    if ret == -1:
+        err = ctypes.get_errno()
+        raise PortalError(
+            f"portalcall for magic {int(user_magic):#x} was not intercepted "
+            f"(syscall {nr} failed with errno {err}: {os.strerror(err) if err else 'unset'}); "
+            "wrong SYS_sendto for this architecture, or no portal support in the guest")
+    return ret
 
 
 def log(msg, level="info"):

--- a/src/resources/penguest/vsock.py
+++ b/src/resources/penguest/vsock.py
@@ -1,0 +1,125 @@
+"""penguest.vsock -- guest-side AF_VSOCK wrappers.
+
+For payloads bigger or streamier than a portalcall's register args, guest scripts
+talk to the host over vsock (the transport is already wired: the custom QEMU
+builds ``CONFIG_AF_VSOCK`` and Penguin launches ``vhost-device-vsock`` for the
+guest, see ``pyplugins/actuation/vpn.py``). From inside the guest the host is
+always CID ``2`` (``VMADDR_CID_HOST``).
+
+It frames messages as length-prefixed JSON and, by default, connects to the host
+``penguest`` vsock endpoint (``pyplugins/apis/penguest_vsock.py``), which serves
+JSON request/response over ``PENGUEST_VSOCK_PORT``.
+
+Example::
+
+    import penguest
+    with penguest.vsock.connect() as c:        # -> host penguest endpoint (CID 2)
+        c.send_json({"op": "ping"})
+        reply = c.recv_json()                  # {"pong": True}
+"""
+
+import json
+import socket
+import struct
+
+__all__ = [
+    "VMADDR_CID_HOST", "VMADDR_CID_ANY", "PENGUEST_VSOCK_PORT",
+    "VsockError", "VsockConn", "connect",
+]
+
+# CIDs, from a guest's point of view. The host is always CID 2.
+VMADDR_CID_HOST = 2
+VMADDR_CID_ANY = 0xFFFFFFFF
+
+# Default port of the host penguest vsock endpoint. Must match
+# PENGUEST_VSOCK_PORT in pyplugins/apis/penguest_vsock.py.
+PENGUEST_VSOCK_PORT = 0xC1D1  # 49617
+
+# 4-byte big-endian length prefix on each JSON frame.
+_LEN = struct.Struct("!I")
+_MAX_FRAME = 64 * 1024 * 1024  # sanity cap so a bad length can't allocate wildly
+
+
+class VsockError(RuntimeError):
+    """Raised for vsock setup/transport problems (incl. no AF_VSOCK support)."""
+
+
+class VsockConn:
+    """A framed connection to a host vsock endpoint.
+
+    Wraps a connected stream socket. ``send``/``recv`` move raw bytes;
+    ``send_json``/``recv_json`` add a 4-byte big-endian length prefix so a
+    receiver can recover message boundaries on a byte stream.
+    """
+
+    def __init__(self, sock):
+        self._sock = sock
+
+    # -- raw bytes ---------------------------------------------------------- #
+    def send(self, data):
+        try:
+            self._sock.sendall(data)
+        except OSError as e:
+            raise VsockError(f"send failed: {e}")
+
+    def _recvn(self, n):
+        """Read exactly ``n`` bytes; raise :class:`VsockError` on EOF/error."""
+        chunks = []
+        remaining = n
+        while remaining:
+            try:
+                chunk = self._sock.recv(remaining)
+            except OSError as e:
+                raise VsockError(f"recv failed: {e}")
+            if not chunk:
+                raise VsockError(
+                    f"connection closed with {remaining} of {n} bytes unread")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    # -- framed JSON -------------------------------------------------------- #
+    def send_json(self, obj):
+        payload = json.dumps(obj).encode("utf-8")
+        if len(payload) > _MAX_FRAME:
+            raise VsockError(f"frame too large: {len(payload)} bytes")
+        try:
+            self._sock.sendall(_LEN.pack(len(payload)) + payload)
+        except OSError as e:
+            raise VsockError(f"send failed: {e}")
+
+    def recv_json(self):
+        (length,) = _LEN.unpack(self._recvn(_LEN.size))
+        if length > _MAX_FRAME:
+            raise VsockError(f"incoming frame too large: {length} bytes")
+        return json.loads(self._recvn(length).decode("utf-8"))
+
+    # -- lifecycle ---------------------------------------------------------- #
+    def close(self):
+        self._sock.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+def connect(port=PENGUEST_VSOCK_PORT, cid=VMADDR_CID_HOST, timeout=None):
+    """Open a framed vsock connection to ``(cid, port)`` -- the host penguest
+    endpoint by default.
+
+    Raises :class:`VsockError` if this Python build lacks AF_VSOCK support or the
+    connection fails.
+    """
+    if not hasattr(socket, "AF_VSOCK"):
+        raise VsockError("this Python build has no AF_VSOCK support")
+    sock = socket.socket(socket.AF_VSOCK, socket.SOCK_STREAM)
+    try:
+        if timeout is not None:
+            sock.settimeout(timeout)
+        sock.connect((cid, port))
+    except OSError as e:
+        sock.close()
+        raise VsockError(f"vsock connect to (cid={cid}, port={port}) failed: {e}")
+    return VsockConn(sock)

--- a/tests/integration/test_target/base_config.yaml
+++ b/tests/integration/test_target/base_config.yaml
@@ -33,6 +33,7 @@ patches:
   - ./patches/tests/compat_dev_collision.yaml
   - ./patches/tests/hypercall.yaml
   - ./patches/tests/portalcall.yaml
+  - ./patches/tests/penguest.yaml
   - ./patches/tests/net_missing.yaml
   - ./patches/tests/netbinds.yaml
   - ./patches/tests/netbinds_lifecycle.yaml

--- a/tests/integration/test_target/patches/tests/penguest.yaml
+++ b/tests/integration/test_target/patches/tests/penguest.yaml
@@ -3,6 +3,11 @@
 # A .py driver is exec'd directly by run_tests.sh via its `#!/igloo/utils/python3`
 # shebang -- so this exercises, in one shot: the staged in-guest CPython, the
 # python3 wrapper's PYTHONPATH=/igloo/pylib, `import penguest`, penguest.portal_call
+#
+# NB: the driver is named penguest_probe.py, NOT penguest.py -- CPython puts the
+# script's own directory (/tests) first on sys.path, so a script named
+# penguest.py would shadow the staged `penguest` package and `import penguest`
+# would import the driver itself.
 # reaching a host @portalcall handler, and penguest.log/report reaching the host
 # bridge (captured to <outdir>/penguest_guest.log).
 #
@@ -23,7 +28,7 @@ plugins:
         string: "PENGUEST test: passed"
       penguest_guest_retval:
         type: file_contains
-        file: shared/tests/penguest.py/stdout
+        file: shared/tests/penguest_probe.py/stdout
         string: "penguest portal_call retval correct"
       penguest_guest_log:
         type: file_contains
@@ -31,11 +36,11 @@ plugins:
         string: "penguest finding from guest"
       penguest_guest_vsock:
         type: file_contains
-        file: shared/tests/penguest.py/stdout
+        file: shared/tests/penguest_probe.py/stdout
         string: "penguest vsock roundtrip correct"
 
 static_files:
-  /tests/penguest.py:
+  /tests/penguest_probe.py:
     type: inline_file
     contents: |
       #!/igloo/utils/python3

--- a/tests/integration/test_target/patches/tests/penguest.yaml
+++ b/tests/integration/test_target/patches/tests/penguest.yaml
@@ -1,0 +1,71 @@
+# End-to-end test for the guest `penguest` binding (drafts 16 + 24).
+#
+# A .py driver is exec'd directly by run_tests.sh via its `#!/igloo/utils/python3`
+# shebang -- so this exercises, in one shot: the staged in-guest CPython, the
+# python3 wrapper's PYTHONPATH=/igloo/pylib, `import penguest`, penguest.portal_call
+# reaching a host @portalcall handler, and penguest.log/report reaching the host
+# bridge (captured to <outdir>/penguest_guest.log).
+#
+# Runs on the full arch matrix: the 32-bit guest-python3 hang/ENOSYS (penguin#876)
+# is fixed in the pinned penguin-tools (>=0.0.21, via penguin-tools#20's glibc
+# vDSO runtime-gate for mipsel/mipseb/armel), and 64-bit arches were never
+# affected. This driver avoids time.* anyway, but python3 now starts cleanly on
+# every arch regardless.
+plugins:
+  penguest_test: {}
+  penguest: {}          # host bridge: guest -> host logging (penguest.log/report)
+  penguest_vsock: {}    # host vsock endpoint (needs vpn/vsock, which base_config enables)
+  verifier:
+    conditions:
+      penguest_hypervisor_test:
+        type: file_contains
+        file: penguest_test.txt
+        string: "PENGUEST test: passed"
+      penguest_guest_retval:
+        type: file_contains
+        file: shared/tests/penguest.py/stdout
+        string: "penguest portal_call retval correct"
+      penguest_guest_log:
+        type: file_contains
+        file: penguest_guest.log
+        string: "penguest finding from guest"
+      penguest_guest_vsock:
+        type: file_contains
+        file: shared/tests/penguest.py/stdout
+        string: "penguest vsock roundtrip correct"
+
+static_files:
+  /tests/penguest.py:
+    type: inline_file
+    contents: |
+      #!/igloo/utils/python3
+      import penguest
+
+      TEST_MAGIC = 0x70677401
+      A1 = 0xdeadbeeff1f1f1f1
+      A2 = 0x1337c0defeedc0de
+
+      ret = penguest.portal_call(TEST_MAGIC, A1, A2)
+      print("penguest portal_call returned:", ret)
+      if ret == 13:
+          print("penguest portal_call retval correct")
+
+      # Exercise the log/report path (verified via penguest_guest.log).
+      penguest.log("penguest log line from guest", level="info")
+      penguest.report("penguest finding from guest")
+      print("penguest log sent")
+
+      # vsock round-trip to the host penguest endpoint (guest -> vhost-device-vsock
+      # -> pyplugins/apis/penguest_vsock.py). Last + guarded so a vsock hiccup
+      # can't swallow the portal/log prints above.
+      try:
+          with penguest.vsock.connect() as c:
+              c.send_json({"op": "echo", "data": "vsock-roundtrip"})
+              reply = c.recv_json()
+          if reply == {"echo": "vsock-roundtrip"}:
+              print("penguest vsock roundtrip correct")
+          else:
+              print("penguest vsock roundtrip WRONG:", reply)
+      except Exception as e:
+          print("penguest vsock error:", repr(e))
+    mode: 0o755

--- a/tests/unit/test_init_dropins.py
+++ b/tests/unit/test_init_dropins.py
@@ -1,0 +1,216 @@
+"""
+Unit tests for uncompiled init drop-ins (draft 24).
+
+Covers the shell half: `.sh` / extension-less shell scripts placed in a
+project's `init.d/` are recognized as first-class init scripts, their shebang is
+normalized to the in-guest interpreter (`/igloo/utils/sh`), and they land in
+`static_files` at `/igloo/init.d/<name>`, mode 0755, with a runnable shebang.
+`source.d/` and non-script drop-ins are installed verbatim.
+
+Pure host logic: no rootfs contents, no kernel, no container.
+"""
+
+import tarfile
+import tempfile
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import penguin.penguin_config as pc
+
+
+GUEST_SH = "/igloo/utils/sh"
+GUEST_PY = "/igloo/utils/python3"
+
+
+# --------------------------------------------------------------------------- #
+# _resolve_init_dropin: shebang normalization decisions
+# --------------------------------------------------------------------------- #
+def _resolve(tmp, filename, content, python_interp=None):
+    if isinstance(content, str):
+        content = content.encode()
+    host_path = Path(tmp) / filename
+    host_path.write_bytes(content)
+    return pc._resolve_init_dropin(str(host_path), filename, python_interp=python_interp)
+
+
+def test_sh_without_shebang_gets_shell_shebang_prepended():
+    with tempfile.TemporaryDirectory() as tmp:
+        kind, payload = _resolve(tmp, "10_net.sh", "ip link set eth0 up\n")
+    assert kind == "inline"
+    assert payload == f"#!{GUEST_SH}\nip link set eth0 up\n"
+
+
+def test_sh_with_foreign_shebang_is_rewritten_body_preserved():
+    with tempfile.TemporaryDirectory() as tmp:
+        kind, payload = _resolve(tmp, "boot.sh", "#!/bin/sh\necho hi\nexit 0\n")
+    assert kind == "inline"
+    assert payload == f"#!{GUEST_SH}\necho hi\nexit 0\n"
+
+
+def test_sh_already_targeting_guest_shell_is_verbatim():
+    with tempfile.TemporaryDirectory() as tmp:
+        kind, payload = _resolve(tmp, "ok.sh", f"#!{GUEST_SH}\necho hi\n")
+    assert kind == "verbatim"
+    assert payload is None
+
+
+def test_extensionless_shell_shebang_is_normalized():
+    with tempfile.TemporaryDirectory() as tmp:
+        kind, payload = _resolve(tmp, "runme", "#!/bin/bash\necho hi\n")
+    assert kind == "inline"
+    assert payload == f"#!{GUEST_SH}\necho hi\n"
+
+
+def test_extensionless_env_python_shebang_normalized_when_python_staged():
+    with tempfile.TemporaryDirectory() as tmp:
+        kind, payload = _resolve(
+            tmp, "probe", "#!/usr/bin/env python3\nprint('hi')\n",
+            python_interp=GUEST_PY)
+    assert kind == "inline"
+    assert payload == f"#!{GUEST_PY}\nprint('hi')\n"
+
+
+def test_extensionless_unknown_shebang_left_verbatim():
+    # A deliberate non-shell/non-python interpreter is the user's choice.
+    with tempfile.TemporaryDirectory() as tmp:
+        kind, payload = _resolve(tmp, "tool", "#!/igloo/utils/busybox awk -f\nBEGIN{}\n")
+    assert kind == "verbatim"
+    assert payload is None
+
+
+def test_extensionless_binary_left_verbatim():
+    # A prebuilt ELF dropped in must never be rewritten.
+    elf = b"\x7fELF\x01\x01\x01\x00" + b"\x00" * 32
+    with tempfile.TemporaryDirectory() as tmp:
+        kind, payload = _resolve(tmp, "prebuilt", elf)
+    assert kind == "verbatim"
+    assert payload is None
+
+
+def test_other_extension_left_verbatim():
+    with tempfile.TemporaryDirectory() as tmp:
+        kind, payload = _resolve(tmp, "settings.conf", "key=value\n")
+    assert kind == "verbatim"
+    assert payload is None
+
+
+def test_py_needs_python_when_no_interpreter_staged():
+    # A .py drop-in with no staged interpreter is a build error signal, not a
+    # silent verbatim install of a script that would die at boot.
+    with tempfile.TemporaryDirectory() as tmp:
+        kind, payload = _resolve(tmp, "probe.py", "#!/usr/bin/python3\nprint('hi')\n")
+    assert kind == "need_python"
+    assert payload is None
+
+
+def test_extensionless_python_shebang_needs_python_when_unstaged():
+    with tempfile.TemporaryDirectory() as tmp:
+        kind, payload = _resolve(tmp, "probe", "#!/usr/bin/env python3\nprint('hi')\n")
+    assert kind == "need_python"
+    assert payload is None
+
+
+def test_py_normalized_when_python_interpreter_staged():
+    with tempfile.TemporaryDirectory() as tmp:
+        kind, payload = _resolve(
+            tmp, "probe.py", "print('hi')\n", python_interp=GUEST_PY)
+    assert kind == "inline"
+    assert payload == f"#!{GUEST_PY}\nprint('hi')\n"
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end through load_config
+# --------------------------------------------------------------------------- #
+def _project_with_dropins(tmp, init_d=None, source_d=None):
+    proj = Path(tmp, "proj")
+    (proj / "base").mkdir(parents=True)
+    with tarfile.open(proj / "base" / "fs.tar.gz", "w"):
+        pass
+    for folder, files in (("init.d", init_d or {}), ("source.d", source_d or {})):
+        if files:
+            (proj / folder).mkdir()
+            for name, body in files.items():
+                (proj / folder / name).write_text(body)
+    (proj / "config.yaml").write_text(textwrap.dedent("""
+        core:
+          arch: armel
+          version: 2
+        env: {}
+        pseudofiles: {}
+        nvram: {}
+        lib_inject: {}
+        static_files: {}
+        plugins: {}
+    """))
+    return proj
+
+
+def _load(proj):
+    return pc.load_config(
+        str(proj), str(proj / "config.yaml"), validate=True,
+        resolved_kernel="/igloo_static/kernels/6.13/zImage.armel",
+    )
+
+
+def test_end_to_end_sh_dropin_lands_in_static_files():
+    with tempfile.TemporaryDirectory() as tmp:
+        proj = _project_with_dropins(tmp, init_d={"10_net.sh": "ip link set eth0 up\n"})
+        cfg = _load(proj)
+
+    entry = cfg["static_files"]["/igloo/init.d/10_net.sh"]
+    assert entry["type"] == "inline_file"
+    assert entry["mode"] == 0o755
+    assert entry["contents"].startswith(f"#!{GUEST_SH}\n")
+    assert "ip link set eth0 up" in entry["contents"]
+
+
+def test_end_to_end_correct_shebang_stays_host_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        proj = _project_with_dropins(
+            tmp, init_d={"20_ok.sh": f"#!{GUEST_SH}\necho hi\n"})
+        cfg = _load(proj)
+
+    entry = cfg["static_files"]["/igloo/init.d/20_ok.sh"]
+    # No rewrite needed -> installed verbatim as a host_file (zero-copy).
+    assert entry["type"] == "host_file"
+    assert entry["mode"] == 0o755
+    assert entry["host_path"].endswith("init.d/20_ok.sh")
+
+
+def test_end_to_end_source_d_is_not_normalized():
+    with tempfile.TemporaryDirectory() as tmp:
+        proj = _project_with_dropins(
+            tmp, source_d={"env.sh": "export FOO=bar\n"})
+        cfg = _load(proj)
+
+    entry = cfg["static_files"]["/igloo/source.d/env.sh"]
+    # source.d/ is sourced, not exec'd: installed verbatim, never rewritten.
+    assert entry["type"] == "host_file"
+    assert entry["mode"] == 0o755
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: .py drop-ins (gated on a staged in-guest interpreter)
+# --------------------------------------------------------------------------- #
+def test_end_to_end_py_dropin_resolves_to_guest_python(monkeypatch):
+    # Pretend a python3 closure is staged for the target arch.
+    monkeypatch.setattr(pc, "_guest_python_interp", lambda config: GUEST_PY)
+    with tempfile.TemporaryDirectory() as tmp:
+        proj = _project_with_dropins(tmp, init_d={"probe.py": "print('hi')\n"})
+        cfg = _load(proj)
+
+    entry = cfg["static_files"]["/igloo/init.d/probe.py"]
+    assert entry["type"] == "inline_file"
+    assert entry["mode"] == 0o755
+    assert entry["contents"] == f"#!{GUEST_PY}\nprint('hi')\n"
+
+
+def test_end_to_end_py_dropin_without_interpreter_fails_build(monkeypatch):
+    # No interpreter staged for the target (host unit-test default).
+    monkeypatch.setattr(pc, "_guest_python_interp", lambda config: None)
+    with tempfile.TemporaryDirectory() as tmp:
+        proj = _project_with_dropins(tmp, init_d={"probe.py": "print('hi')\n"})
+        with pytest.raises(ValueError, match="no in-guest Python interpreter"):
+            _load(proj)

--- a/tests/unit/test_penguest.py
+++ b/tests/unit/test_penguest.py
@@ -1,0 +1,600 @@
+"""Host-side tests for the guest ``penguest`` binding (draft 16, Slice 0).
+
+``penguest`` is guest code, but its host-testable contract is that
+:func:`penguest.portal_call` packs the ``sendto`` syscall exactly like
+``penguin/guest-utils/native/portal_call.h`` -- so the host portalcall
+dispatcher (``pyplugins/apis/portalcall.py``) reads it back correctly and lands
+at the matching ``@portalcall`` handler.
+
+Two levels:
+  * packing (always runs): substitute ``penguest._syscall`` and assert the
+    register values + the in-memory arg array match the ABI.
+  * round-trip (skips offline): let ``penguest`` pack a real buffer and feed the
+    SAME pointer to the *real* ``portalcall.py`` dispatcher via the test harness,
+    proving both ends agree. The in-guest boot round-trip is an integration
+    fixture that comes once the module + interpreter are staged (Steps 3/4).
+
+The interpreter running these tests is the host's own CPython (it has ctypes and
+libc), which is enough to exercise the packing without any guest.
+"""
+import ctypes
+import importlib.util
+import os
+import socket
+import sys
+import tarfile
+import tempfile
+import textwrap
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import penguin.penguin_config as pc
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PENGUEST_SRC = REPO_ROOT / "src" / "resources" / "penguest" / "__init__.py"
+PORTALCALL = str(REPO_ROOT / "pyplugins" / "apis" / "portalcall.py")
+PENGUEST_HOST = str(REPO_ROOT / "pyplugins" / "apis" / "penguest.py")
+PENGUEST_VSOCK = str(REPO_ROOT / "pyplugins" / "apis" / "penguest_vsock.py")
+PENGUEST_TEST_PLUGIN = str(REPO_ROOT / "pyplugins" / "testing" / "penguest_test.py")
+
+DEMO_MAGIC = 0x70656E67  # "peng"; a 32-bit user_magic
+
+
+def demo_sum_handler(a, b):
+    """Demo @portalcall handler: sum the two args (module-level so its bare
+    ``__qualname__`` isn't mistaken for a ``Class.method`` to re-resolve)."""
+    return (a + b) & 0xFFFFFFFF
+
+
+def _load_penguest():
+    # Load as a package so `from . import vsock` resolves against the submodule.
+    spec = importlib.util.spec_from_file_location(
+        "penguest", PENGUEST_SRC,
+        submodule_search_locations=[str(PENGUEST_SRC.parent)])
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["penguest"] = mod  # so the relative import finds the package
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def penguest():
+    return _load_penguest()
+
+
+# --------------------------------------------------------------------------- #
+# sendto syscall-number resolution
+# --------------------------------------------------------------------------- #
+def test_sendto_nr_env_override_wins(penguest, monkeypatch):
+    monkeypatch.setenv("PENGUEST_SYS_SENDTO", "1234")
+    assert penguest._resolve_sendto_nr() == 1234
+    monkeypatch.setenv("PENGUEST_SYS_SENDTO", "0x2c")
+    assert penguest._resolve_sendto_nr() == 0x2C
+
+
+def test_sendto_nr_table_by_machine(penguest, monkeypatch):
+    monkeypatch.delenv("PENGUEST_SYS_SENDTO", raising=False)
+    cases = {
+        "x86_64": 44, "aarch64": 206, "armv7l": 290, "riscv64": 206,
+        "mips": 4183, "mips64": 5045, "ppc64le": 335, "loongarch64": 206,
+    }
+    for machine, expected in cases.items():
+        monkeypatch.setattr(penguest.os, "uname",
+                            lambda m=machine: type("U", (), {"machine": m})())
+        assert penguest._resolve_sendto_nr() == expected, machine
+
+
+def test_sendto_nr_unknown_arch_raises(penguest, monkeypatch):
+    monkeypatch.delenv("PENGUEST_SYS_SENDTO", raising=False)
+    monkeypatch.setattr(penguest.os, "uname",
+                        lambda: type("U", (), {"machine": "s390x"})())
+    with pytest.raises(penguest.PortalError):
+        penguest._resolve_sendto_nr()
+
+
+# --------------------------------------------------------------------------- #
+# packing: portal_call lowers exactly like portal_call.h
+# --------------------------------------------------------------------------- #
+def test_portal_call_packs_like_portal_call_h(penguest, monkeypatch):
+    monkeypatch.setenv("PENGUEST_SYS_SENDTO", "44")  # x86_64
+    seen = {}
+
+    def fake_syscall(nr, magic, user_magic, argc, argsptr, a4, a5):
+        # Read the packed args now, while portal_call's buffer is still alive.
+        arr = (ctypes.c_uint64 * argc).from_address(argsptr) if argc else []
+        seen.update(nr=nr, magic=magic, user_magic=user_magic, argc=argc,
+                    argv=[int(arr[i]) for i in range(argc)], a4=a4, a5=a5)
+        return 0
+
+    monkeypatch.setattr(penguest, "_syscall", fake_syscall)
+    penguest.portal_call(DEMO_MAGIC, 0x11, 0xDEADBEEFF1F1F1F1)
+
+    assert seen["nr"] == 44
+    assert seen["magic"] == penguest.PORTAL_MAGIC        # arg0 = PORTAL_MAGIC
+    assert seen["user_magic"] == DEMO_MAGIC              # arg1 = user_magic
+    assert seen["argc"] == 2                             # arg2 = argc
+    assert seen["argv"] == [0x11, 0xDEADBEEFF1F1F1F1]    # arg3 -> &args[]
+    assert seen["a4"] == 0 and seen["a5"] == 0           # dest_addr, addrlen
+
+
+def test_portal_call_zero_args_ok(penguest, monkeypatch):
+    monkeypatch.setenv("PENGUEST_SYS_SENDTO", "44")
+    seen = {}
+    monkeypatch.setattr(penguest, "_syscall",
+                        lambda nr, m, um, argc, p, a4, a5: seen.update(argc=argc) or 7)
+    assert penguest.portal_call(DEMO_MAGIC) == 7
+    assert seen["argc"] == 0
+
+
+def test_portal_call_rejects_too_many_args(penguest, monkeypatch):
+    monkeypatch.setattr(penguest, "_syscall", lambda *a: 0)
+    with pytest.raises(penguest.PortalError):
+        penguest.portal_call(DEMO_MAGIC, *range(penguest._MAX_ARGS + 1))
+
+
+# --------------------------------------------------------------------------- #
+# round-trip: penguest packs -> real portalcall.py dispatches -> handler runs
+# --------------------------------------------------------------------------- #
+class _MemDouble:
+    """Satisfies portalcall's ``plugins.mem.read_uint64_array`` by reading the
+    guest arg array straight out of the host address penguest packed it at."""
+
+    def read_uint64_array(self, addr, count):
+        arr = (ctypes.c_uint64 * count).from_address(addr)
+        vals = [int(arr[i]) for i in range(count)]
+        if False:  # make this a generator (the caller does `yield from`)
+            yield
+        return vals
+
+
+def test_roundtrip_penguest_to_portalcall_handler(penguest, monkeypatch, tmp_path,
+                                                  igloo_ko_isf):
+    from penguin.testing import drive, load_pyplugin
+
+    monkeypatch.setenv("PENGUEST_SYS_SENDTO", "44")
+    lp = load_pyplugin(PORTALCALL, outdir=tmp_path,
+                       doubles={"mem": _MemDouble()}, real_isf=igloo_ko_isf)
+
+    # The demo handler: sum the args (exercises the arg-array read path).
+    lp.plugin.portalcall(DEMO_MAGIC)(demo_sum_handler)
+
+    box = {}
+
+    def fake_syscall(nr, magic, user_magic, argc, argsptr, a4, a5):
+        # Dispatch on the host while penguest's buffer is still alive. This is
+        # the genuine host code path: read_uint64_array -> registered handler.
+        ret, _ = drive(lp.plugin._dispatch_portalcall(user_magic, argc, argsptr),
+                       responses=[], collect=True)
+        box["ret"] = ret
+        return ret
+
+    monkeypatch.setattr(penguest, "_syscall", fake_syscall)
+    rv = penguest.portal_call(DEMO_MAGIC, 0x11, 0x22)
+    assert rv == 0x33
+    assert box["ret"] == 0x33
+
+
+# --------------------------------------------------------------------------- #
+# staging: penguest lands in static_files under /igloo/pylib (Slice 1)
+# --------------------------------------------------------------------------- #
+def test_penguest_staged_into_guest_pylib():
+    with tempfile.TemporaryDirectory() as tmp:
+        proj = Path(tmp, "proj")
+        (proj / "base").mkdir(parents=True)
+        with tarfile.open(proj / "base" / "fs.tar.gz", "w"):
+            pass
+        (proj / "config.yaml").write_text(textwrap.dedent("""
+            core: {arch: armel, version: 2}
+            env: {}
+            pseudofiles: {}
+            nvram: {}
+            lib_inject: {}
+            static_files: {}
+            plugins: {}
+        """))
+        cfg = pc.load_config(
+            str(proj), str(proj / "config.yaml"), validate=True,
+            resolved_kernel="/igloo_static/kernels/6.13/zImage.armel",
+        )
+
+    entry = cfg["static_files"]["/igloo/pylib/penguest/__init__.py"]
+    assert entry["type"] == "host_file"
+    assert entry["mode"] == 0o644
+    assert entry["host_path"] == str(PENGUEST_SRC)
+    # The whole package is staged, not just __init__ -- vsock.py too.
+    vs = cfg["static_files"]["/igloo/pylib/penguest/vsock.py"]
+    assert vs["type"] == "host_file"
+    assert vs["host_path"] == str(PENGUEST_SRC.parent / "vsock.py")
+
+
+# --------------------------------------------------------------------------- #
+# penguest.vsock: AF_VSOCK wrapper (guest transport)
+# --------------------------------------------------------------------------- #
+def test_vsock_json_framing_roundtrip(penguest):
+    # A real AF_UNIX stream pair stands in for the vsock stream; the framing
+    # (4-byte length prefix + JSON) is transport-agnostic.
+    a, b = socket.socketpair()
+    try:
+        ca, cb = penguest.vsock.VsockConn(a), penguest.vsock.VsockConn(b)
+        ca.send_json({"op": "ping", "n": 5, "s": "héllo"})
+        assert cb.recv_json() == {"op": "ping", "n": 5, "s": "héllo"}
+        cb.send_json([1, 2, 3])
+        assert ca.recv_json() == [1, 2, 3]
+    finally:
+        a.close()
+        b.close()
+
+
+def test_vsock_recv_json_raises_on_short_stream(penguest):
+    a, b = socket.socketpair()
+    try:
+        # Send a length header claiming 10 bytes, then close with none sent.
+        a.sendall(penguest.vsock._LEN.pack(10))
+        a.close()
+        with pytest.raises(penguest.vsock.VsockError):
+            penguest.vsock.VsockConn(b).recv_json()
+    finally:
+        b.close()
+
+
+def test_vsock_connect_without_af_vsock_raises(penguest, monkeypatch):
+    monkeypatch.delattr(socket, "AF_VSOCK", raising=False)
+    with pytest.raises(penguest.vsock.VsockError, match="AF_VSOCK"):
+        penguest.vsock.connect(port=9999)
+
+
+def test_vsock_connect_targets_host_cid(penguest, monkeypatch):
+    calls = {}
+
+    class _FakeSock:
+        def __init__(self, family, type_):
+            calls["family"], calls["type"] = family, type_
+
+        def settimeout(self, t):
+            calls["timeout"] = t
+
+        def connect(self, addr):
+            calls["addr"] = addr
+
+        def close(self):
+            calls["closed"] = True
+
+    monkeypatch.setattr(socket, "AF_VSOCK", 40, raising=False)
+    monkeypatch.setattr(penguest.vsock.socket, "socket",
+                        lambda fam, typ: _FakeSock(fam, typ))
+    conn = penguest.vsock.connect(port=9999, timeout=3)
+    assert calls["family"] == 40                       # AF_VSOCK
+    assert calls["type"] == socket.SOCK_STREAM
+    assert calls["addr"] == (penguest.vsock.VMADDR_CID_HOST, 9999)  # host = CID 2
+    assert calls["timeout"] == 3
+    assert isinstance(conn, penguest.vsock.VsockConn)
+
+
+# --------------------------------------------------------------------------- #
+# penguest.log / report: pack a string over the portal
+# --------------------------------------------------------------------------- #
+def test_log_packs_string_pointer_and_level(penguest, monkeypatch):
+    monkeypatch.setenv("PENGUEST_SYS_SENDTO", "44")
+    seen = {}
+
+    def fake_syscall(nr, magic, user_magic, argc, argsptr, a4, a5):
+        arr = (ctypes.c_uint64 * argc).from_address(argsptr)
+        strptr, length, level = int(arr[0]), int(arr[1]), int(arr[2])
+        raw = ctypes.string_at(strptr, length)
+        seen.update(magic=magic, user_magic=user_magic, argc=argc,
+                    text=raw.decode(), level=level)
+        return 0
+
+    monkeypatch.setattr(penguest, "_syscall", fake_syscall)
+    penguest.log("boot reached stage 2", level="warning")
+
+    assert seen["magic"] == penguest.PORTAL_MAGIC
+    assert seen["user_magic"] == penguest.PENGUEST_LOG_MAGIC
+    assert seen["argc"] == 3
+    assert seen["text"] == "boot reached stage 2"
+    assert seen["level"] == penguest._LOG_LEVELS["warning"]
+
+
+def test_report_uses_finding_level(penguest, monkeypatch):
+    monkeypatch.setenv("PENGUEST_SYS_SENDTO", "44")
+    seen = {}
+    monkeypatch.setattr(penguest, "_syscall",
+                        lambda nr, m, um, argc, p, a4, a5:
+                        seen.update(level=int((ctypes.c_uint64 * argc)
+                                              .from_address(p)[2])) or 0)
+    penguest.report("suspicious write to /dev/mtd0")
+    assert seen["level"] == penguest._LOG_LEVELS["finding"]
+
+
+# --------------------------------------------------------------------------- #
+# host bridge: handle_log reads guest memory and logs (Penguest pyplugin)
+# --------------------------------------------------------------------------- #
+class _MemBytesDouble:
+    def read_bytes(self, addr, size):
+        data = ctypes.string_at(addr, size)
+        if False:  # generator (caller does `yield from`)
+            yield
+        return data
+
+
+class _CapturingLogger:
+    def __init__(self):
+        self.records = []
+
+    def _rec(self, level):
+        # Match logging.Logger.<level>(msg, *args): args are %-formatted.
+        def rec(msg, *args):
+            self.records.append((level, (msg % args) if args else msg))
+        return rec
+
+    def __getattr__(self, level):
+        return self._rec(level)
+
+
+def test_host_bridge_handle_log_reads_and_logs(tmp_path):
+    from penguin.testing import drive, load_pyplugin
+
+    lp = load_pyplugin(PENGUEST_HOST, outdir=tmp_path,
+                       doubles={"mem": _MemBytesDouble()})
+    logger = _CapturingLogger()
+    lp.plugin.logger = logger
+
+    data = b"hello from guest"
+    buf = ctypes.create_string_buffer(data, len(data))
+    ret, _ = drive(lp.plugin.handle_log(ctypes.addressof(buf), len(data), 4),
+                   collect=True)  # level 4 = finding
+    assert ret == 0
+    assert logger.records == [("info", "[guest finding] hello from guest")]
+
+
+def test_host_bridge_handle_log_zero_length(tmp_path):
+    from penguin.testing import drive, load_pyplugin
+
+    lp = load_pyplugin(PENGUEST_HOST, outdir=tmp_path,
+                       doubles={"mem": _MemBytesDouble()})
+    logger = _CapturingLogger()
+    lp.plugin.logger = logger
+    ret, _ = drive(lp.plugin.handle_log(0, 0, 1), collect=True)  # level 1 = info
+    assert ret == 0
+    assert logger.records == [("info", "[guest] ")]
+
+
+def test_host_bridge_persists_guest_log_to_file(tmp_path):
+    from penguin.testing import drive, load_pyplugin
+
+    lp = load_pyplugin(PENGUEST_HOST, outdir=tmp_path,
+                       doubles={"mem": _MemBytesDouble()})
+    lp.plugin.logger = _CapturingLogger()
+
+    msg = b"a finding worth keeping"
+    buf = ctypes.create_string_buffer(msg, len(msg))
+    drive(lp.plugin.handle_log(ctypes.addressof(buf), len(msg), 4), collect=True)
+
+    log_file = tmp_path / "penguest_guest.log"
+    assert log_file.exists()
+    assert log_file.read_text() == "finding\ta finding worth keeping\n"
+
+
+# --------------------------------------------------------------------------- #
+# penguest_test integration plugin: host handler logic
+# --------------------------------------------------------------------------- #
+# These mirror PENGUEST_ARG1/2 in pyplugins/testing/penguest_test.py and the
+# /tests/penguest.py driver in penguest.yaml; they must stay in sync.
+_TEST_A1 = 0xDEADBEEFF1F1F1F1
+_TEST_A2 = 0x1337C0DEFEEDC0DE
+
+
+def test_penguest_test_plugin_writes_pass_on_correct_args(tmp_path):
+    from penguin.testing import load_pyplugin
+
+    lp = load_pyplugin(PENGUEST_TEST_PLUGIN, outdir=tmp_path)
+    assert lp.plugin.handle_test(_TEST_A1, _TEST_A2) == 13
+    assert (tmp_path / "penguest_test.txt").read_text() == "PENGUEST test: passed\n"
+
+
+def test_penguest_test_plugin_writes_fail_on_wrong_args(tmp_path):
+    from penguin.testing import load_pyplugin
+
+    lp = load_pyplugin(PENGUEST_TEST_PLUGIN, outdir=tmp_path)
+    lp.plugin.logger = _CapturingLogger()
+    assert lp.plugin.handle_test(0x1, 0x2) == 13
+    assert (tmp_path / "penguest_test.txt").read_text() == "PENGUEST test: failed\n"
+
+
+# --------------------------------------------------------------------------- #
+# host vsock endpoint: dispatch + guest-client round-trip (Slice 3)
+# --------------------------------------------------------------------------- #
+def _boom(req):
+    raise RuntimeError("boom")
+
+
+def test_vsock_endpoint_dispatch(tmp_path):
+    from penguin.testing import load_pyplugin
+
+    lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path, args={"vpn_enabled": False})
+    lp.plugin.logger = _CapturingLogger()
+    assert lp.plugin.dispatch({"op": "ping"}) == {"pong": True}
+    assert lp.plugin.dispatch({"op": "echo", "data": [1, 2]}) == {"echo": [1, 2]}
+    assert "error" in lp.plugin.dispatch({"op": "nope"})
+    assert "error" in lp.plugin.dispatch("not-a-dict")
+    lp.plugin.register("boom", _boom)
+    assert lp.plugin.dispatch({"op": "boom"}) == {"error": "boom"}
+    # Disabled (no vsock) -> no listener thread was started.
+    assert lp.plugin._thread is None
+
+
+def test_vsock_endpoint_serves_guest_client(tmp_path):
+    from penguin.testing import load_pyplugin
+
+    penguest = _load_penguest()
+    lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path, args={"vpn_enabled": False})
+    # Guest client (penguest.vsock) and host endpoint agree on the port + framing.
+    assert lp.plugin.port == penguest.vsock.PENGUEST_VSOCK_PORT
+
+    a, b = socket.socketpair()
+    t = threading.Thread(target=lp.plugin._serve_conn, args=(a,), daemon=True)
+    t.start()
+    try:
+        client = penguest.vsock.VsockConn(b)
+        client.send_json({"op": "ping"})
+        assert client.recv_json() == {"pong": True}
+        client.send_json({"op": "echo", "data": {"k": "v"}})
+        assert client.recv_json() == {"echo": {"k": "v"}}
+    finally:
+        b.close()          # EOF -> _serve_conn returns
+        t.join(timeout=2)
+        a.close()
+    assert not t.is_alive()
+
+
+def test_vsock_endpoint_live_listener_and_teardown(tmp_path):
+    # Exercise the real accept loop + teardown: with vsock "enabled", the plugin
+    # binds <uds_path>_<port> (a plain AF_UNIX socket here) and serves clients on
+    # a background thread. This is exactly what vhost-device-vsock connects to for
+    # a guest-initiated connection.
+    from penguin.testing import load_pyplugin
+
+    penguest = _load_penguest()
+    uds = tmp_path / "vsocket"
+    lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path,
+                       args={"vpn_enabled": True, "uds_path": str(uds)})
+    lp.plugin.logger = _CapturingLogger()
+    sock_path = f"{uds}_{penguest.vsock.PENGUEST_VSOCK_PORT}"
+    try:
+        assert lp.plugin._thread is not None
+        for _ in range(200):                     # wait for bind()/listen()
+            if os.path.exists(sock_path):
+                break
+            time.sleep(0.005)
+        assert os.path.exists(sock_path)
+
+        c = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        c.connect(sock_path)
+        client = penguest.vsock.VsockConn(c)
+        client.send_json({"op": "echo", "data": "roundtrip"})
+        assert client.recv_json() == {"echo": "roundtrip"}
+        c.close()
+    finally:
+        lp.plugin.uninit()
+
+    assert not lp.plugin._thread.is_alive()      # thread joined
+    assert not os.path.exists(sock_path)         # socket unlinked
+
+
+def test_vsock_endpoint_stalled_conn_does_not_wedge(tmp_path):
+    # A guest that connects and stalls mid-frame must not block other clients
+    # (per-connection workers) -- the hardening that matters most for untrusted
+    # guest input.
+    from penguin.testing import load_pyplugin
+
+    penguest = _load_penguest()
+    uds = tmp_path / "vsocket"
+    lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path,
+                       args={"vpn_enabled": True, "uds_path": str(uds)})
+    lp.plugin.logger = _CapturingLogger()
+    sock_path = f"{uds}_{penguest.vsock.PENGUEST_VSOCK_PORT}"
+    stalled = None
+    try:
+        for _ in range(200):
+            if os.path.exists(sock_path):
+                break
+            time.sleep(0.005)
+        # Connection 1: send a length header, then nothing (stall mid-frame).
+        stalled = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        stalled.connect(sock_path)
+        stalled.sendall(b"\x00\x00\x00\x10")  # promises 16 bytes, sends none
+
+        # Connection 2 must still be served concurrently.
+        c = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        c.connect(sock_path)
+        client = penguest.vsock.VsockConn(c)
+        client.send_json({"op": "ping"})
+        assert client.recv_json() == {"pong": True}
+        c.close()
+    finally:
+        if stalled is not None:
+            stalled.close()
+        lp.plugin.uninit()
+
+
+def test_vsock_endpoint_connection_cap(tmp_path):
+    from penguin.testing import load_pyplugin
+
+    penguest = _load_penguest()
+    uds = tmp_path / "vsocket"
+    lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path,
+                       args={"vpn_enabled": True, "uds_path": str(uds),
+                             "vsock_max_conns": 1})
+    lp.plugin.logger = _CapturingLogger()
+    sock_path = f"{uds}_{penguest.vsock.PENGUEST_VSOCK_PORT}"
+    hold = None
+    try:
+        for _ in range(200):
+            if os.path.exists(sock_path):
+                break
+            time.sleep(0.005)
+        # Hold the one allowed slot open (stalled mid-frame).
+        hold = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        hold.connect(sock_path)
+        hold.sendall(b"\x00\x00\x00\x10")
+        time.sleep(0.05)  # let the worker acquire the sole slot
+
+        # Over the cap -> the endpoint drops the connection (closes it).
+        over = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        over.connect(sock_path)
+        client = penguest.vsock.VsockConn(over)
+        # Server dropped it (over cap) -> the send or the read hits the closed
+        # peer; either way the guest surfaces a VsockError.
+        with pytest.raises(penguest.vsock.VsockError):
+            client.send_json({"op": "ping"})
+            client.recv_json()
+        over.close()
+    finally:
+        if hold is not None:
+            hold.close()
+        lp.plugin.uninit()
+
+
+# --------------------------------------------------------------------------- #
+# host bridge hardening: sanitize guest-controlled log text + bound the file
+# --------------------------------------------------------------------------- #
+def test_host_bridge_sanitizes_control_chars(tmp_path):
+    from penguin.testing import drive, load_pyplugin
+
+    lp = load_pyplugin(PENGUEST_HOST, outdir=tmp_path,
+                       doubles={"mem": _MemBytesDouble()})
+    logger = _CapturingLogger()
+    lp.plugin.logger = logger
+
+    # newline (log-line forgery) + ANSI escape (terminal injection) + NUL.
+    evil = b"line1\nFAKE level\x1b[31mred\x00end"
+    buf = ctypes.create_string_buffer(evil, len(evil))
+    drive(lp.plugin.handle_log(ctypes.addressof(buf), len(evil), 1), collect=True)
+
+    level, msg = logger.records[0]
+    assert level == "info"
+    assert "\n" not in msg and "\x1b" not in msg and "\x00" not in msg
+    assert msg == "[guest] line1�FAKE level�[31mred�end"
+    # The persisted line is single-line (no injected newline before its own).
+    assert (tmp_path / "penguest_guest.log").read_text().count("\n") == 1
+
+
+def test_host_bridge_log_file_is_bounded(tmp_path):
+    from penguin.testing import drive, load_pyplugin
+
+    lp = load_pyplugin(PENGUEST_HOST, outdir=tmp_path,
+                       args={"guest_log_max_bytes": 64},
+                       doubles={"mem": _MemBytesDouble()})
+    lp.plugin.logger = _CapturingLogger()
+
+    chunk = b"x" * 40
+    buf = ctypes.create_string_buffer(chunk, len(chunk))
+    for _ in range(5):  # 5 * ~48 bytes > 64-byte cap
+        drive(lp.plugin.handle_log(ctypes.addressof(buf), len(chunk), 1),
+              collect=True)
+
+    assert lp.plugin._log_capped
+    assert (tmp_path / "penguest_guest.log").stat().st_size <= 64

--- a/tests/unit/test_penguest.py
+++ b/tests/unit/test_penguest.py
@@ -31,10 +31,16 @@ from pathlib import Path
 
 import pytest
 
+import penguin.defaults as _defaults
 import penguin.penguin_config as pc
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-PENGUEST_SRC = REPO_ROOT / "src" / "resources" / "penguest" / "__init__.py"
+# Locate the guest module the same way the config staging does, via
+# defaults.penguest_src_dir -- so this works both in a source checkout
+# (src/resources/penguest) and against an installed penguin, where the resources
+# tree lives beside the package and `src/` isn't present at all (the packaged
+# test tree ships tests/ + pyplugins/ only).
+PENGUEST_SRC = Path(_defaults.penguest_src_dir) / "__init__.py"
 PORTALCALL = str(REPO_ROOT / "pyplugins" / "apis" / "portalcall.py")
 PENGUEST_HOST = str(REPO_ROOT / "pyplugins" / "apis" / "penguest.py")
 PENGUEST_VSOCK = str(REPO_ROOT / "pyplugins" / "apis" / "penguest_vsock.py")

--- a/tests/unit/test_penguest.py
+++ b/tests/unit/test_penguest.py
@@ -420,7 +420,7 @@ def _boom(req):
 def test_vsock_endpoint_dispatch(tmp_path):
     from penguin.testing import load_pyplugin
 
-    lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path, args={"vpn_enabled": False})
+    lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path, args={})
     lp.plugin.logger = _CapturingLogger()
     assert lp.plugin.dispatch({"op": "ping"}) == {"pong": True}
     assert lp.plugin.dispatch({"op": "echo", "data": [1, 2]}) == {"echo": [1, 2]}
@@ -436,7 +436,7 @@ def test_vsock_endpoint_serves_guest_client(tmp_path):
     from penguin.testing import load_pyplugin
 
     penguest = _load_penguest()
-    lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path, args={"vpn_enabled": False})
+    lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path, args={})
     # Guest client (penguest.vsock) and host endpoint agree on the port + framing.
     assert lp.plugin.port == penguest.vsock.PENGUEST_VSOCK_PORT
 
@@ -466,7 +466,7 @@ def test_vsock_endpoint_live_listener_and_teardown(tmp_path):
     penguest = _load_penguest()
     uds = tmp_path / "vsocket"
     lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path,
-                       args={"vpn_enabled": True, "uds_path": str(uds)})
+                       args={"uds_path": str(uds)})
     lp.plugin.logger = _CapturingLogger()
     sock_path = f"{uds}_{penguest.vsock.PENGUEST_VSOCK_PORT}"
     try:
@@ -499,7 +499,7 @@ def test_vsock_endpoint_stalled_conn_does_not_wedge(tmp_path):
     penguest = _load_penguest()
     uds = tmp_path / "vsocket"
     lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path,
-                       args={"vpn_enabled": True, "uds_path": str(uds)})
+                       args={"uds_path": str(uds)})
     lp.plugin.logger = _CapturingLogger()
     sock_path = f"{uds}_{penguest.vsock.PENGUEST_VSOCK_PORT}"
     stalled = None
@@ -532,7 +532,7 @@ def test_vsock_endpoint_connection_cap(tmp_path):
     penguest = _load_penguest()
     uds = tmp_path / "vsocket"
     lp = load_pyplugin(PENGUEST_VSOCK, outdir=tmp_path,
-                       args={"vpn_enabled": True, "uds_path": str(uds),
+                       args={"uds_path": str(uds),
                              "vsock_max_conns": 1})
     lp.plugin.logger = _CapturingLogger()
     sock_path = f"{uds}_{penguest.vsock.PENGUEST_VSOCK_PORT}"

--- a/tests/unit/test_penguest.py
+++ b/tests/unit/test_penguest.py
@@ -82,10 +82,13 @@ def test_sendto_nr_env_override_wins(penguest, monkeypatch):
 
 
 def test_sendto_nr_table_by_machine(penguest, monkeypatch):
+    """Expected values are __NR_sendto from the target toolchain's
+    bits/syscall.h (musl 1.2.5), i.e. the same number portal_call.h compiles
+    against -- not derived by hand from a syscall-table offset."""
     monkeypatch.delenv("PENGUEST_SYS_SENDTO", raising=False)
     cases = {
         "x86_64": 44, "aarch64": 206, "armv7l": 290, "riscv64": 206,
-        "mips": 4183, "mips64": 5045, "ppc64le": 335, "loongarch64": 206,
+        "mips": 4180, "mips64": 5043, "ppc64le": 335, "loongarch64": 206,
     }
     for machine, expected in cases.items():
         monkeypatch.setattr(penguest.os, "uname",
@@ -133,6 +136,21 @@ def test_portal_call_zero_args_ok(penguest, monkeypatch):
                         lambda nr, m, um, argc, p, a4, a5: seen.update(argc=argc) or 7)
     assert penguest.portal_call(DEMO_MAGIC) == 7
     assert seen["argc"] == 0
+
+
+def test_portal_call_raises_when_not_intercepted(penguest, monkeypatch):
+    """A -1 return means the kernel serviced it as a real sendto and failed --
+    the portal was never entered. That must not look like a handler result."""
+    monkeypatch.setenv("PENGUEST_SYS_SENDTO", "44")
+
+    def failing_syscall(nr, *a):
+        ctypes.set_errno(9)  # EBADF
+        return -1
+
+    monkeypatch.setattr(penguest, "_syscall", failing_syscall)
+    with pytest.raises(penguest.PortalError) as ei:
+        penguest.portal_call(DEMO_MAGIC, 1, 2)
+    assert "not intercepted" in str(ei.value)
 
 
 def test_portal_call_rejects_too_many_args(penguest, monkeypatch):


### PR DESCRIPTION
## Summary

Implements two coupled planning drafts:

- **Draft 24 — first-class uncompiled init drop-ins.** `.sh`/`.py` files (and extension-less scripts with a shell/python shebang) dropped in `init.d/` are now treated like the existing `.c` compileables: their shebang is normalized to a guest interpreter (`/igloo/utils/sh`, `/igloo/utils/python3`), a foreign/missing one is rewritten with a warning, and the body is installed into `/igloo/init.d/`. Non-scripts (prebuilt binaries, `.conf`/`.txt`, deliberate foreign shebangs, busybox multi-call shebangs) stay verbatim.
- **Draft 16 — guest Python + host comms.** A guest-side `penguest` Python module (staged into `/igloo/pylib/penguest/`, on `PYTHONPATH` via the python3 wrapper) that wraps:
  - `portal_call(magic, *args)` — the existing portalcall `sendto` ABI (per-arch syscall table), plus typed `log()` / `report()` helpers.
  - `penguest.vsock` — a framed length-prefixed-JSON AF_VSOCK client to the host.

  Host side (both in `default_plugins`): `apis/penguest.py` (log bridge → run log + persisted `penguest_guest.log`) and `apis/penguest_vsock.py` (vsock endpoint, `ping`/`echo` built in, `@endpoint` registration).

The two are coupled: `.py` drop-ins only make sense because in-guest CPython is staged, and `import penguest` works with no extra setup.

## Security

The guest is untrusted firmware, so these are host-facing channels. `portal_call` adds no new transport (the raw `sendto` was always available). The two new default handlers take untrusted guest input and are hardened accordingly:

- **log bridge**: 64 KiB read cap, control-char sanitization (no log-line forgery / terminal-escape injection), bounded log file.
- **vsock endpoint**: capped worker pool (`vsock_max_conns`) with a per-connection recv timeout (`vsock_conn_timeout`) so a stalled/flooding guest can't wedge it, 4 MiB frame cap, deterministic teardown.

Disable per run for adversarial-firmware analysis:

```yaml
plugins:
  penguest: { enabled: false }
  penguest_vsock: { enabled: false }
```

`penguest_vsock` is inherently a no-op when vsock/vpn is off.

## Testing

- **Unit** (`tests/unit/`, per the #881 host-testing contract): `test_init_dropins.py` (shebang resolution + end-to-end config load) and `test_penguest.py` (portal_call packing vs `portal_call.h`, a round-trip through the real `portalcall.py`, vsock JSON framing, log/report packing, the host bridge reading guest memory + persisting/bounding the log, and the vsock endpoint incl. a live listener, connection cap, and stalled-connection drop). Run the way CI does — `nix build .#checks.x86_64-linux.unit-tests` — the full suite is **833 passed**, flake8 clean, `schema_doc.md` in sync.
- **Integration** (`tests/integration/test_target/patches/tests/penguest.yaml`, default arch matrix): a `.py` driver run via its `#!/igloo/utils/python3` shebang that `import penguest`, makes a `portal_call`, calls `log`/`report`, and does a `vsock.connect()` echo round-trip through `vhost-device-vsock` — the one place the guest→host forwarding is exercised end-to-end on real guest CPython.

### Bugs the arch matrix caught (fixed in this branch)

The in-guest matrix found three real defects that the host suite did not, each fixed here:

1. **Module shadowing** — the integration driver was named `penguest.py`, and CPython puts a script's own directory first on `sys.path`, so `import penguest` imported the driver instead of the staged package. Renamed to `penguest_probe.py`, with the caveat documented.
2. **Endpoint gated on a nonexistent arg** — `penguest_vsock` checked `get_arg_bool("vpn_enabled")`, but `vpn_enabled` only ever reaches `runtime.yaml`; the vsock wiring arrives as the `vpn_args` (`uds_path`/`socket_path`/`CID`) merged into the global plugin args. The check was always false, so the endpoint silently never listened. Now gated on `uds_path`, which is present exactly when vsock is enabled.
3. **Wrong MIPS `__NR_sendto`** — the per-arch table had `mips_o32=4183` / `mips_n64=5045`, hand-derived from a syscall-table offset. The real values (musl `bits/syscall.h`, what `portal_call.h` compiles against) are **4180** / **5043**, so every portalcall on the four MIPS variants fell through to a real `sendto` and failed.

Two of those were *confirmed* rather than caught by my own unit tests, which had passed a fabricated `vpn_enabled=True` and asserted the same wrong syscall numbers. Both fixtures now mirror production (`uds_path` only; no args at all for the disabled path) and the expected syscall numbers cite `bits/syscall.h` as their source.

Related hardening from the same investigation: `portal_call` now raises `PortalError` on a `-1` return instead of returning it. `-1` means the kernel serviced the call as a genuine `sendto` and failed, so the portal was never entered — and it cannot be a real handler result either, since libc's `syscall()` collapses every kernel return in `[-4095,-1]` to `-1 + errno`. Returning it silently is what let a wrong syscall number masquerade as data.

Also fixed here: adding `resources/penguest/__init__.py` made setuptools auto-discover `resources` as a package, so the wheel installed a top-level `site-packages/resources/` holding only `penguest/`; `nix/penguin.nix`'s `cp -r resources $out/.../resources` then nested the real tree at `resources/resources/` and hid `resources/init.sh`, breaking every unit test in the nix `checks.unit-tests` derivation. `src/resources` is now excluded from package discovery (it is data copied into the guest, never imported on the host) and `penguest_src_dir` is anchored on `_resources_dir` so it follows `PENGUIN_RESOURCES`.

## Docs

`docs/init_dropins.md`, `docs/penguest.md` (incl. Security section), regenerated `docs/schema_doc.md`.