### PR TITLE
Inject lib_inject into 32-bit processes on mixed-ABI targets

### DIFF
--- a/pyplugins/interventions/nvram2.py
+++ b/pyplugins/interventions/nvram2.py
@@ -274,9 +274,16 @@ def add_lib_inject_all_abis(conf, cache_dir, proj_dir=None, build_log_path=None)
         type="symlink",
         target=f"/igloo/lib_inject_{arch_info['default_abi']}.so",
     )
+    # Use the bare soname (not the absolute /igloo/dylibs path, which is
+    # symlinked to the default ABI) so the loader resolves lib_inject per-ABI
+    # via the /lib symlinks placed next to each libc.so.  On a mixed 32/64-bit
+    # target the absolute path pins the default (64-bit) class, so 32-bit
+    # daemons hit "wrong ELF class ELFCLASS64: ignored" and get no
+    # interception.  A slashless entry is class-filtered by the loader, matching
+    # the env LD_PRELOAD=lib_inject.so mechanism.
     conf["static_files"]["/etc/ld.so.preload"] = dict(
         type="inline_file",
-        contents="/igloo/dylibs/lib_inject.so\n",
+        contents="lib_inject.so\n",
         mode=0o644,
     )
 

--- a/src/penguin/penguin_prep.py
+++ b/src/penguin/penguin_prep.py
@@ -289,9 +289,16 @@ def add_lib_inject_all_abis(conf):
         type="symlink",
         target=f"/igloo/lib_inject_{arch_info['default_abi']}.so",
     )
+    # Use the bare soname (not the absolute /igloo/dylibs path, which is
+    # symlinked to the default ABI) so the loader resolves lib_inject per-ABI
+    # via the /lib symlinks placed next to each libc.so.  On a mixed 32/64-bit
+    # target the absolute path pins the default (64-bit) class, so 32-bit
+    # daemons hit "wrong ELF class ELFCLASS64: ignored" and get no
+    # interception.  A slashless entry is class-filtered by the loader, matching
+    # the env LD_PRELOAD=lib_inject.so mechanism.
     conf["static_files"]["/etc/ld.so.preload"] = dict(
         type="inline_file",
-        contents="/igloo/dylibs/lib_inject.so\n",
+        contents="lib_inject.so\n",
         mode=0o644,
     )
 

--- a/tests/unit/test_lib_inject_preload.py
+++ b/tests/unit/test_lib_inject_preload.py
@@ -1,0 +1,76 @@
+"""Regression coverage for the dual-ABI lib_inject preload wiring.
+
+Both writers of ``/etc/ld.so.preload`` (``penguin.penguin_prep`` and the
+``interventions.nvram2`` intervention) must write the **bare soname**
+``lib_inject.so`` rather than the absolute ``/igloo/dylibs/lib_inject.so``
+path.  The absolute path is symlinked to the *default* ABI, so on a mixed
+32/64-bit target (e.g. an aarch64 platform that also runs 32-bit ARM daemons)
+it pins the 64-bit class -- 32-bit processes then hit ``wrong ELF class
+ELFCLASS64: ignored`` and get no interception.  A slashless entry is
+class-filtered by the loader and resolves per-ABI via the ``lib_inject.so``
+symlinks placed next to each ``libc.so``, matching the env
+``LD_PRELOAD=lib_inject.so`` mechanism.
+
+``add_lib_inject_all_abis`` normally shells out to clang to build a ``.so``
+per ABI (impossible host-side without the toolchain image), so we stub the
+per-ABI builder and exercise only the static-file wiring.
+"""
+import importlib
+from pathlib import Path
+
+import pytest
+
+from penguin.testing import load_module
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NVRAM2 = REPO_ROOT / "pyplugins" / "interventions" / "nvram2.py"
+
+# aarch64 is genuinely multi-ABI: default (64-bit) + soft_float/hard_float
+# (32-bit ARM), which is exactly the mixed-ABI case this guards.
+MULTI_ABI_ARCH = "aarch64"
+
+
+def _base_conf():
+    return {"core": {"arch": MULTI_ABI_ARCH}, "static_files": {}}
+
+
+def _penguin_prep(monkeypatch):
+    mod = importlib.import_module("penguin.penguin_prep")
+    # Skip the clang build; we only care about the static-file wiring.
+    monkeypatch.setattr(mod, "add_lib_inject_for_abi", lambda *a, **k: None)
+    return mod, lambda conf: mod.add_lib_inject_all_abis(conf)
+
+
+def _nvram2(monkeypatch):
+    # nvram2's Plugin class body resolves `plugins.<name>` at import, so it
+    # can't be plain-imported; load it through the pyplugin harness (null
+    # plugins bound) and stub the per-ABI clang build.
+    mod, _mgr = load_module(str(NVRAM2))
+    monkeypatch.setattr(mod, "add_lib_inject_for_abi", lambda *a, **k: None)
+    return mod, lambda conf: mod.add_lib_inject_all_abis(conf, cache_dir=None)
+
+
+WRITERS = {"penguin_prep": _penguin_prep, "nvram2": _nvram2}
+
+
+@pytest.mark.parametrize("writer", WRITERS.values(), ids=WRITERS.keys())
+def test_ld_so_preload_is_bare_soname(monkeypatch, writer):
+    _mod, call = writer(monkeypatch)
+
+    conf = _base_conf()
+    call(conf)
+
+    preload = conf["static_files"]["/etc/ld.so.preload"]
+    assert preload["contents"] == "lib_inject.so\n", (
+        "ld.so.preload must be the bare soname so the loader resolves it "
+        "per-ABI; an absolute path pins the default (64-bit) ABI and breaks "
+        "32-bit daemons on a mixed 32/64-bit target"
+    )
+    # A slash-bearing entry would be pinned to one class rather than resolved
+    # per-process, defeating dual-ABI injection.
+    assert "/" not in preload["contents"].strip()
+
+    # The /igloo/dylibs symlink itself is still needed by /igloo/utils binaries.
+    symlink = conf["static_files"]["/igloo/dylibs/lib_inject.so"]
+    assert symlink["type"] == "symlink"
+    assert symlink["target"] == "/igloo/lib_inject_default.so"


### PR DESCRIPTION
Closes #907
Closes #856

## Problem

On a **mixed 32/64-bit** target (a 64-bit ARM platform that also runs 32-bit ARM daemons, or an o32 userland on mips64eb), `lib_inject` is not injected into processes whose ABI differs from the arch default. Those daemons hit `wrong ELF class …: ignored`, get zero interception, nvram reads fail, and the guest reboots early.

The multi-ABI build works — `add_lib_inject_all_abis` builds a `lib_inject.so` per ABI, and the loader-symlink pass drops a `lib_inject.so` symlink next to each `libc.so` pointing at the matching-ABI lib. The env path is also correct: `LD_PRELOAD=lib_inject.so` is a **bare soname** the loader resolves per-process (class-filtered) via those symlinks.

## Root cause

`/etc/ld.so.preload` was written with the **absolute path** `/igloo/dylibs/lib_inject.so`, which is symlinked to the **default ABI** — pinning the global preload to one class. Unlike env `LD_PRELOAD` (inherited-only), `ld.so.preload` is **global**: every process reads it. Firmware init doesn't always propagate the env to its daemons, so the global preload is often the only active injection path — and it was hard-pinned to the default ABI.

Latent on single-ABI targets (the default-ABI path is the right class there); only surfaces on a mixed-ABI userland.

## Fix

Write the **bare soname** `lib_inject.so` (matching env `LD_PRELOAD`) in both writers (`penguin_prep.py`, `interventions/nvram2.py`). A slashless entry is class-filtered by the loader and resolves per-ABI via the `/lib` symlinks, so each process loads the matching-class lib. The `/igloo/dylibs/lib_inject.so` symlink is kept — `/igloo/utils` binaries use it; only the `ld.so.preload` *contents* change.

**No default-ABI regression:** this makes the global preload path identical to the already-working env `LD_PRELOAD` bare-soname mechanism — same soname, same search dirs, same class filtering.

## Tests

- New `tests/unit/test_lib_inject_preload.py` asserts **both** writers emit the bare soname (not a slash-bearing path) for a multi-ABI arch and keep the `/igloo/dylibs` symlink.
- Full `tests/unit` suite: 671 passed; flake8 clean.

**Note:** prep rewrites `/etc/ld.so.preload` itself, so a config override won't stick — the fix must be in the image (`--build`).

_Rebased onto current main and force-pushed; earlier red CI predates the Arc/buildkit fix._
