### PR TITLE
build.yaml: pin buildkit to v0.30.0 (/proc/acpi fleet break)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -179,7 +179,17 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver-opts: |
+            image=moby/buildkit:v0.30.0
             network=host
+          # Pin buildkit: the floating buildx-stable-1 default advanced to
+          # v0.31.2, whose runc masks /proc/acpi in a way the 5.4-kernel Arc
+          # runners reject ("can't mask dir /proc/acpi ... invalid argument"),
+          # breaking every build. The nodes prune images every 30m, so a bad
+          # floating-tag move hits the whole fleet within one cycle. v0.30.0 is
+          # the last minor before the bad runc and an immutable release tag.
+          # (This workflow hand-rolls buildx instead of using
+          # rehosting/ci arc-registry-setup, so the org-wide default pin there
+          # doesn't reach it.) Revisit once the runner kernel is bumped.
           buildkitd-config-inline: |
             [registry."${{ env.REGISTRY }}"]
               insecure = true


### PR DESCRIPTION
## What
Pin the buildx driver to `moby/buildkit:v0.30.0` on the raw `setup-buildx-action@v3` in the **Test Container** workflow (`build.yaml`), which gates every PR.

## Why
`build.yaml` hand-rolls buildx (raw `setup-buildx-action@v3`, no pin), so it boots the floating `buildx-stable-1` default — which advanced to **v0.31.2**, whose runc masks `/proc/acpi` in a way the **kernel-5.4** Arc runners reject:
```
runc run failed: ... can't mask dir "/proc/acpi": ... invalid argument
```
This fails the first `RUN` of the image build, so **every PR that builds the container is currently red** (e.g. run 29613786357 on `workspace/proctree-ux`).

Because this workflow does **not** go through `rehosting/ci`'s `arc-registry-setup`, the org-wide default pin in [rehosting/ci#14](https://github.com/rehosting/ci/pull/14) does **not** reach it — it needs its own pin. (`docs.yaml`/`publish.yaml` do use the shared action and are covered by ci#14.)

## Why now
Docker floated `buildx-stable-1` onto v0.31.2 between the 07-16 (green) and 07-17 (red) nightlies. The shared-docker nodes prune images every 30 min, so there's no stale-cache buffer — a bad floating-tag move hits the whole fleet within one cycle. Pinning severs the dependency on the floating tag.

## Verification
Same `v0.30.0` pin proven green end-to-end on `rehosting/igloo-dev`'s source publish (igloo-dev#14). After merge I'll re-run an affected PR's build to confirm.

## Follow-up
Longer term, migrate `build.yaml` to `rehosting/ci/actions/arc-registry-setup` so it stops duplicating cert/buildx/login and inherits the central pin. Un-pin once the runner kernel is bumped past 5.4.