### PR TITLE
arch: identify Cavium Octeon MIPS64 and select the Octeon CPU model

### DIFF
--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -10,7 +10,7 @@ Core configuration options for this rehosting
 
 |||
 |-|-|
-|__Type__|`"armel"` or `"arm"` or `"armle"` or `"aarch64"` or `"arm64"` or `"mipsel"` or `"mipseb"` or `"mipsbe"` or `"mips64el"` or `"mips64eb"` or `"mips64be"` or `"powerpc"` or `"ppc"` or `"powerpc64"` or `"ppc64"` or `"powerpc64le"` or `"ppc64le"` or `"powerpc64el"` or `"ppc64el"` or `"riscv64"` or `"riscv"` or `"rv64"` or `"loongarch64"` or `"loongarch"` or `"la64"` or `"x86_64"` or `"intel64"` or `"amd64"` or `"x86-64"` or `"x64"` or null|
+|__Type__|`"armel"` or `"arm"` or `"armle"` or `"aarch64"` or `"arm64"` or `"mipsel"` or `"mipseb"` or `"mipsbe"` or `"mips64el"` or `"mips64eb"` or `"mips64be"` or `"mips64eb_octeon"` or `"octeon"` or `"mips64be_octeon"` or `"mips64el_octeon"` or `"octeonel"` or `"powerpc"` or `"ppc"` or `"powerpc64"` or `"ppc64"` or `"powerpc64le"` or `"ppc64le"` or `"powerpc64el"` or `"ppc64el"` or `"riscv64"` or `"riscv"` or `"rv64"` or `"loongarch64"` or `"loongarch"` or `"la64"` or `"x86_64"` or `"intel64"` or `"amd64"` or `"x86-64"` or `"x64"` or null|
 |__Default__|`null`|
 
 Canonical name or an accepted alias (normalized at load, e.g. intel64 -> x86_64).

--- a/src/penguin/arch.py
+++ b/src/penguin/arch.py
@@ -5,6 +5,17 @@ from penguin import getColoredLogger
 
 logger = getColoredLogger("penguin.arch")
 
+# MIPS "machine" (SoC family) selector in e_flags. pyelftools' E_FLAGS/
+# E_FLAGS_MASKS don't expose these, so transcribe the binutils values
+# (include/elf/mips.h EF_MIPS_MACH_*). Cavium Octeon parts implement custom
+# MIPS64 ASE opcodes that fault on QEMU's generic MIPS64R2 CPU, so we have to
+# identify them here and route them to the Octeon CPU model.
+EF_MIPS_MACH = 0x00FF0000
+EF_MIPS_MACH_OCTEON = 0x008B0000   # Octeon (CN3xxx/CN5xxx)
+EF_MIPS_MACH_OCTEON2 = 0x008D0000  # Octeon II (CN6xxx/CN7xxx)
+EF_MIPS_MACH_OCTEON3 = 0x008E0000  # Octeon III
+_OCTEON_MACHS = (EF_MIPS_MACH_OCTEON, EF_MIPS_MACH_OCTEON2, EF_MIPS_MACH_OCTEON3)
+
 
 def get_dylib_subdir(arch_name: str) -> str:
     """
@@ -137,8 +148,12 @@ def _identify_mips_arch(header):
     if flags & E_FLAGS.EF_MIPS_ARCH == E_FLAGS.EF_MIPS_ARCH_64:
         mips_arch = "mips64"
 
+    is_octeon = (flags & EF_MIPS_MACH) in _OCTEON_MACHS
+
     # Some extra flags that only affect what gets printed
     description = "mips"
+    if is_octeon:
+        description += ", octeon"
     if flags & E_FLAGS.EF_MIPS_NOREORDER:
         description += ", noreorder"
     if flags & E_FLAGS.EF_MIPS_PIC:
@@ -182,6 +197,17 @@ def _identify_mips_arch(header):
         logger.error(
             "Unexpected MIPS architecture: bits %d, endianness %s", bits, endianness
         )
+    elif is_octeon and bits == 64:
+        # Octeon is a MIPS64 superset: same kernels/dylibs/ABI, but it needs
+        # QEMU's Octeon CPU model (the generic MIPS64R2 CPU faults on the
+        # Cavium-specific opcodes). Route to the dedicated arch spec, which
+        # reuses the mips64{el,eb} assets and only overrides the CPU model.
+        arch += "_octeon"
+    elif is_octeon:
+        # 32-bit ELFs (e.g. n32) can carry the Octeon MACH tag too; the 64-bit
+        # kernel is what actually needs the CPU model, so a 32-bit-only view
+        # stays generic but we note it for debugging.
+        logger.debug("Octeon MACH flag on a %d-bit MIPS ELF; keeping arch=%s", bits, arch)
 
     return ArchInfo(
         arch=arch, abi=abi, bits=bits, endianness=endianness, description=description

--- a/src/penguin/arch_registry.py
+++ b/src/penguin/arch_registry.py
@@ -159,6 +159,41 @@ _SPECS = (
         serial=(4, 65),
         endianness="big",
     ),
+    # Cavium Octeon is a MIPS64 superset. It runs the stock mips64{eb,el}
+    # kernel, dylibs, kmod and ABI, so every asset/subdir points back at the
+    # base arch; the ONLY difference is the QEMU CPU model, which must expose
+    # the Cavium ASE opcodes. arch.py emits these names when it sees the Octeon
+    # EF_MIPS_MACH tag in a 64-bit ELF.
+    ArchSpec(
+        canonical="mips64eb_octeon",
+        aliases=("octeon", "mips64be_octeon"),
+        arch_subdir="mips64eb",
+        dylib_subdir="mips64eb",
+        _kmod_subdir="mips64eb",
+        qemu_arch="mips64",
+        qemu_machine="malta",
+        cpu="Octeon68XX",
+        _kconf_group="mips64eb",
+        _kernel_whole="vmlinux.mips64eb",
+        _abi_key="mips64eb",
+        serial=(4, 65),
+        endianness="big",
+    ),
+    ArchSpec(
+        canonical="mips64el_octeon",
+        aliases=("octeonel",),
+        arch_subdir="mips64el",
+        dylib_subdir="mips64el",
+        _kmod_subdir="mips64el",
+        qemu_arch="mips64el",
+        qemu_machine="malta",
+        cpu="Octeon68XX",
+        _kconf_group="mips64el",
+        _kernel_whole="vmlinux.mips64el",
+        _abi_key="mips64el",
+        serial=(4, 65),
+        endianness="little",
+    ),
     ArchSpec(
         canonical="powerpc",
         aliases=("ppc",),

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -329,6 +329,8 @@ class Core(PartialModelMixin, BaseModel):
             "mipseb", "mipsbe",
             "mips64el",
             "mips64eb", "mips64be",
+            "mips64eb_octeon", "octeon", "mips64be_octeon",
+            "mips64el_octeon", "octeonel",
             "powerpc", "ppc",
             "powerpc64", "ppc64",
             "powerpc64le", "ppc64le", "powerpc64el", "ppc64el",

--- a/tests/unit/test_arch_octeon.py
+++ b/tests/unit/test_arch_octeon.py
@@ -1,0 +1,96 @@
+"""
+Octeon CPU identification.
+
+Cavium Octeon parts are MIPS64 supersets that implement custom ASE opcodes;
+the generic MIPS64R2 QEMU CPU faults on them. ``_identify_mips_arch`` must spot
+the ``EF_MIPS_MACH`` Octeon tag in a 64-bit ELF and emit the dedicated
+``mips64{eb,el}_octeon`` arch, which reuses the base mips64 assets and only
+overrides the QEMU CPU model to ``Octeon68XX``.
+"""
+
+import pytest
+from elftools.elf.constants import E_FLAGS
+
+from penguin import arch_registry
+from penguin.arch import (
+    _identify_mips_arch,
+    EF_MIPS_MACH_OCTEON,
+    EF_MIPS_MACH_OCTEON2,
+    EF_MIPS_MACH_OCTEON3,
+)
+
+
+class _FakeHeader:
+    """Minimal stand-in for a pyelftools ELF header: attribute e_ident + [] flags."""
+
+    def __init__(self, *, bits, data, e_flags):
+        self.e_ident = {
+            "EI_CLASS": "ELFCLASS64" if bits == 64 else "ELFCLASS32",
+            "EI_DATA": data,
+        }
+        self._flags = e_flags
+
+    def __getitem__(self, key):
+        assert key == "e_flags"
+        return self._flags
+
+
+# n64 ABI (no O32/O64/n32 bits) at MIPS64R2 — the assignment mips_arch needs.
+_MIPS64_BASE = E_FLAGS.EF_MIPS_ARCH_64R2
+
+
+def _hdr(bits, data, mach=0):
+    return _FakeHeader(bits=bits, data=data, e_flags=_MIPS64_BASE | mach)
+
+
+@pytest.mark.parametrize("mach", [EF_MIPS_MACH_OCTEON, EF_MIPS_MACH_OCTEON2, EF_MIPS_MACH_OCTEON3])
+def test_octeon_big_endian_64bit(mach):
+    info = _identify_mips_arch(_hdr(64, "ELFDATA2MSB", mach))
+    assert info.arch == "mips64eb_octeon"
+    assert info.bits == 64
+    assert "octeon" in info.description
+
+
+@pytest.mark.parametrize("mach", [EF_MIPS_MACH_OCTEON, EF_MIPS_MACH_OCTEON2, EF_MIPS_MACH_OCTEON3])
+def test_octeon_little_endian_64bit(mach):
+    info = _identify_mips_arch(_hdr(64, "ELFDATA2LSB", mach))
+    assert info.arch == "mips64el_octeon"
+
+
+def test_generic_mips64_unaffected():
+    # No MACH tag -> plain mips64eb, exactly as before.
+    info = _identify_mips_arch(_hdr(64, "ELFDATA2MSB", mach=0))
+    assert info.arch == "mips64eb"
+    assert "octeon" not in info.description
+
+
+def test_octeon_tag_on_32bit_stays_generic():
+    # A 32-bit ELF carrying the Octeon MACH tag: the 64-bit kernel is what needs
+    # the CPU model, so a 32-bit-only view must not claim the octeon arch.
+    info = _identify_mips_arch(_FakeHeader(bits=32, data="ELFDATA2MSB", e_flags=EF_MIPS_MACH_OCTEON2))
+    assert info.arch == "mipseb"
+
+
+def test_octeon_arch_reuses_base_assets_and_overrides_cpu():
+    base = arch_registry.spec("mips64eb")
+    oct_be = arch_registry.spec("mips64eb_octeon")
+    # CPU model is the ONLY thing that changes.
+    assert oct_be.cpu == "Octeon68XX"
+    assert base.cpu != oct_be.cpu
+    # Every asset/subdir points back at the base arch.
+    for attr in ("arch_subdir", "dylib_subdir", "kmod_subdir", "kernel_whole",
+                 "abi_key", "kconf_group", "panda_arch", "qemu_machine"):
+        assert getattr(oct_be, attr) == getattr(base, attr), attr
+
+
+def test_octeon_aliases_resolve():
+    assert arch_registry.normalize_arch("octeon") == "mips64eb_octeon"
+    assert arch_registry.normalize_arch("octeonel") == "mips64el_octeon"
+
+
+def test_octeon_runnable_via_q_config():
+    from penguin.q_config import load_q_config
+    q = load_q_config({"core": {"arch": "mips64eb_octeon"}})
+    assert q["cpu"] == "Octeon68XX"
+    assert q["qemu_machine"] == "malta"
+    assert q["arch"] == "mips64"


### PR DESCRIPTION
## Summary

Picks up the dropped **CPU-identification path** for MIPS: Penguin now recognizes Cavium **Octeon** MIPS64 SoCs and boots them on QEMU's Octeon CPU model instead of the generic one.

Octeon is a MIPS64 superset — it runs the stock `mips64{eb,el}` kernel, dylibs and ABI, but implements Cavium ASE opcodes that **fault on QEMU's generic `MIPS64R2-generic` CPU**. Previously these targets were identified as plain `mips64eb`/`mips64el` and could crash on their own instructions.

## How

- **Detection (`arch.py`)** — `_identify_mips_arch` now reads the ELF `EF_MIPS_MACH` field. pyelftools doesn't expose it, so the binutils `OCTEON` / `OCTEON2` / `OCTEON3` mask values are transcribed. A 64-bit MIPS ELF carrying the Octeon tag yields `mips64eb_octeon` / `mips64el_octeon`.
- **Registry (`arch_registry.py`)** — two new `ArchSpec`s whose every asset/subdir (arch/dylib/kmod/kernel/abi/kconf) points back at the base `mips64{eb,el}` arch, so **no new asset trees are needed** — the *only* change is `cpu → Octeon68XX`. The shipped qemu fork already implements this CPU (`target/mips/tcg/octeon_translate.c`, `-cpu Octeon68XX` = `CPU_MIPS64R2 | INSN_OCTEON`).
- **Schema** — `core.arch` Literal extended with the new canonical names + `octeon`/`octeonel` aliases (kept in sync with `arch_registry.all_names()` by the existing parity test); `docs/schema_doc.md` regenerated.

## Tests (`tests/unit/test_arch_octeon.py`, 11 cases)

Detection across all three Octeon MACH variants × both endiannesses, generic mips64 left unaffected, 32-bit-tagged ELFs stay generic (the 64-bit kernel is what needs the CPU), the asset-reuse/CPU-override invariant, alias resolution, and end-to-end `q_config` runnability (`cpu == Octeon68XX`, `machine == malta`). Full `test_config.py` + new suite: **158 passed**. flake8 clean.

## Known limitation / follow-up

`arch_id` picks the single most common arch across userspace ELFs. A firmware that mixes Octeon-tagged and generic mips64 binaries could tally to generic and miss the Octeon CPU. Real Octeon images are uniformly tagged, so this is rare; a "prefer Octeon if any Octeon ELF is present" tie-break is a reasonable follow-up if it ever bites.

🤖 Draft — reconstructed from the CPU-identification path we'd set aside.
