### PR TITLE
fix(image cache): identify the base filesystem, not just its mtime

### DIFF
--- a/src/penguin/utils.py
+++ b/src/penguin/utils.py
@@ -299,13 +299,42 @@ def resolve_arch_asset(arch: str, base_dir: str, prefix: str = "", suffix: str =
     return s.canonical
 
 
+#: The project-relative filesystem path whose cache key is left BYTE-COMPATIBLE with
+#: earlier releases. ``penguin init`` writes ``base/fs.tar.gz`` and penguin_config fills
+#: ``core.fs`` with ``./base/fs.tar.gz``, so nearly every project's filesystem lives
+#: here; leaving this one path alone means the fix below does not invalidate their
+#: already-built images.
+#:
+#: This is safe precisely because a project can hold at most ONE archive at this path,
+#: so the legacy key can never be the key SHARED by two different filesystems -- which
+#: is the substitution being fixed. Any second archive in a project necessarily has some
+#: other path, and gets that path folded in.
+LEGACY_KEY_FS_PATH = "base/fs.tar.gz"
+
+
 def hash_image_inputs(proj_dir: str, conf: Dict[str, Any]) -> str:
     """
     Create a hash of all the inputs of the image creation process.
 
-    In the new build process this is just the preinit script and the
-    modification time of the base filesystem (since we don't control
-    its contents).
+    For the base filesystem this is its modification time, plus -- unless it sits at
+    the default ``base/fs.tar.gz`` -- the path it was named by and its size.
+
+    It used to be the mtime ALONE, which left the key blind to WHICH filesystem was
+    being built: two different archives that shared an mtime produced the same key, so
+    the image built from the first was silently reused for the second and the run booted
+    a filesystem the config did not ask for. Archives sharing an mtime is not exotic --
+    one extraction, copy or checkout pass stamps everything it writes with the same
+    timestamp -- and nothing downstream can notice, because the config, the logs and the
+    output directory all still name the archive that was requested.
+
+    The default path keeps its old key so that existing projects do not all rebuild;
+    see ``LEGACY_KEY_FS_PATH`` for why that cannot reintroduce the substitution. Path and
+    size come from stat data the mtime already required, so this adds no I/O.
+
+    Not covered: an archive replaced in place, under the same name, with the same size
+    and timestamp. Hashing the contents would close that, at the cost of reading an
+    archive that can be tens of gigabytes on every invocation -- a poor trade for the
+    residual risk.
 
     We specifically do NOT include the busybox binary in this hash despite
     its potential effect on the image because we expect them to be fairly
@@ -328,6 +357,17 @@ def hash_image_inputs(proj_dir: str, conf: Dict[str, Any]) -> str:
         hsh.update(get_file_hash(path).encode())
     modification_timestamp = os.path.getmtime(fs)
     hsh.update(f"{modification_timestamp}".encode())
+    # Say WHICH filesystem this is, not just when it was written. Skipped for the
+    # default path so those projects keep the key -- and the built image -- they already
+    # have; only one archive per project can be there, so it cannot be a shared key.
+    fs_rel = os.path.normpath(os.path.relpath(fs, proj_dir))
+    if fs_rel != LEGACY_KEY_FS_PATH:
+        fs_stat = os.stat(fs)
+        hsh.update(fs_rel.encode())
+        hsh.update(f"{fs_stat.st_size}".encode())
+        # Nanosecond mtime as well, since this path is being rekeyed anyway: it catches
+        # a same-size rewrite that lands inside the same whole second.
+        hsh.update(f"{fs_stat.st_mtime_ns}".encode())
     # add the fstype - if it changes we need to rebuild
     hsh.update("ext4".encode())
     # The debugging-tool closure is baked into the base image (gen_image.

--- a/tests/unit/test_image_cache_key.py
+++ b/tests/unit/test_image_cache_key.py
@@ -1,0 +1,167 @@
+"""
+Unit tests for the built-image cache key (``penguin.utils.hash_image_inputs``).
+
+The key names the qcow2 that a run boots, so it has to distinguish two different base
+filesystems. It used to fold in only the filesystem's mtime, which meant two different
+archives that happened to share a timestamp -- the normal outcome of one extraction,
+copy or checkout pass -- hashed identically, and the image built from the first was
+silently reused for the second.
+
+The default path (``base/fs.tar.gz``) deliberately keeps its old key so existing
+projects do not all rebuild; the tests below cover both that compatibility and the fact
+that it cannot reintroduce the substitution.
+
+Everything here runs without a rootfs, kernel, or container.
+"""
+
+import os
+
+import pytest
+
+from penguin import utils
+
+#: Hard-coded rather than read from the module, so this suite still runs against a
+#: build that predates the constant -- and so the compatibility path is pinned by the
+#: test rather than by whatever the code happens to say.
+DEFAULT_FS = "base/fs.tar.gz"
+
+
+@pytest.fixture
+def arch_dir(tmp_path, monkeypatch):
+    """Stub out the arch assets so only the base filesystem varies."""
+    arch = tmp_path / "arch"
+    arch.mkdir()
+    for name in ("busybox", "hyp_file_op", "send_portalcall", "igloo.ko"):
+        (arch / name).write_bytes(name.encode())
+
+    monkeypatch.setattr(utils, "get_arch_dir", lambda conf: str(arch))
+    monkeypatch.setattr(utils, "get_driver_kmod_path", lambda conf: "igloo.ko")
+    monkeypatch.setattr(utils, "get_arch_subdir", lambda conf: "testarch")
+    return arch
+
+
+def _archive(proj_dir, name, contents, mtime):
+    path = proj_dir / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(contents)
+    os.utime(path, (mtime, mtime))
+    return {"core": {"fs": name, "arch": "armel", "kernel": "/kernels/zImage"}}
+
+
+def test_the_compatibility_path_is_the_one_penguin_init_writes() -> None:
+    """``penguin init`` writes base/fs.tar.gz and penguin_config points core.fs at it."""
+    assert utils.LEGACY_KEY_FS_PATH == DEFAULT_FS
+
+
+def test_two_archives_sharing_an_mtime_are_different_images(tmp_path, arch_dir):
+    """The substitution this key must never allow.
+
+    Two filesystems, one timestamp: before the path was part of the key these hashed
+    the same, and the second run booted the first one's image.
+    """
+    one = _archive(tmp_path, "base/one.tar.gz", b"filesystem one", mtime=1_700_000_000)
+    two = _archive(tmp_path, "base/two.tar.gz", b"filesystem two", mtime=1_700_000_000)
+
+    assert utils.hash_image_inputs(str(tmp_path), one) != utils.hash_image_inputs(
+        str(tmp_path), two
+    )
+
+
+def test_a_second_archive_never_collides_with_the_default_one(tmp_path, arch_dir):
+    """The default path stays on the legacy key, so this pairing has to be checked.
+
+    A project with the default filesystem plus one more -- both stamped by the same
+    extraction pass -- is the realistic shape of the bug.
+    """
+    default = _archive(tmp_path, DEFAULT_FS, b"the default fs", mtime=1_700_000_000)
+    other = _archive(tmp_path, "base/other.tar.gz", b"another fs", mtime=1_700_000_000)
+
+    assert utils.hash_image_inputs(str(tmp_path), default) != utils.hash_image_inputs(
+        str(tmp_path), other
+    )
+
+
+def test_the_default_path_keeps_its_legacy_key(tmp_path, arch_dir):
+    """Existing projects must not be forced to rebuild.
+
+    The observable signature of the unchanged key is that, for this one path, the digest
+    still depends on nothing but the mtime -- so a same-mtime change of size does not
+    move it. That is the pre-existing behaviour, kept deliberately: a project can hold
+    only one archive here, so this path can never be the key shared by two filesystems.
+    """
+    conf = _archive(tmp_path, DEFAULT_FS, b"the default fs", mtime=1_700_000_000)
+    before = utils.hash_image_inputs(str(tmp_path), conf)
+
+    fs = tmp_path / DEFAULT_FS
+    fs.write_bytes(b"the default fs, now a different length")
+    os.utime(fs, (1_700_000_000, 1_700_000_000))
+
+    assert utils.hash_image_inputs(str(tmp_path), conf) == before
+
+
+def test_the_leading_dot_slash_form_is_the_same_path(tmp_path, arch_dir):
+    """penguin_config writes ``./base/fs.tar.gz``; that must not read as non-default.
+
+    Otherwise the compatibility above would apply to hand-written configs and not to
+    generated ones, and the generated majority would rebuild.
+    """
+    plain = _archive(tmp_path, DEFAULT_FS, b"the default fs", mtime=1_700_000_000)
+    dotted = dict(plain, core=dict(plain["core"], fs=f"./{DEFAULT_FS}"))
+
+    assert utils.hash_image_inputs(str(tmp_path), plain) == utils.hash_image_inputs(
+        str(tmp_path), dotted
+    )
+
+
+def test_a_non_default_archive_is_keyed_on_its_size(tmp_path, arch_dir):
+    """Size is the cheap half: for a rekeyed path, a changed byte count cannot be missed
+    even if the timestamp was restored."""
+    conf = _archive(tmp_path, "base/fw.tar.gz", b"filesystem", mtime=1_700_000_000)
+    before = utils.hash_image_inputs(str(tmp_path), conf)
+
+    fs = tmp_path / "base/fw.tar.gz"
+    fs.write_bytes(b"filesystem, now longer")
+    os.utime(fs, (1_700_000_000, 1_700_000_000))  # timestamp deliberately restored
+
+    assert utils.hash_image_inputs(str(tmp_path), conf) != before
+
+
+def test_a_rewritten_archive_is_a_different_image(tmp_path, arch_dir):
+    """The ordinary case, on either path: writing the file advances its mtime."""
+    for name in (DEFAULT_FS, "base/fw.tar.gz"):
+        conf = _archive(tmp_path, name, b"filesystem", mtime=1_700_000_000)
+        before = utils.hash_image_inputs(str(tmp_path), conf)
+
+        (tmp_path / name).write_bytes(b"filesystem, rebuilt")
+
+        assert utils.hash_image_inputs(str(tmp_path), conf) != before, name
+
+
+def test_the_same_archive_under_a_different_name_is_a_different_image(tmp_path, arch_dir):
+    """The path is part of the key, so a built image stays traceable to its config."""
+    one = _archive(tmp_path, "base/one.tar.gz", b"same bytes", mtime=1_700_000_000)
+    two = _archive(tmp_path, "base/two.tar.gz", b"same bytes", mtime=1_700_000_000)
+
+    assert utils.hash_image_inputs(str(tmp_path), one) != utils.hash_image_inputs(
+        str(tmp_path), two
+    )
+
+
+def test_a_subdirectory_is_part_of_the_identity(tmp_path, arch_dir):
+    """Same basename, different directory: still two filesystems."""
+    one = _archive(tmp_path, "a/fs.tar.gz", b"same bytes", mtime=1_700_000_000)
+    two = _archive(tmp_path, "b/fs.tar.gz", b"same bytes", mtime=1_700_000_000)
+
+    assert utils.hash_image_inputs(str(tmp_path), one) != utils.hash_image_inputs(
+        str(tmp_path), two
+    )
+
+
+def test_the_key_is_stable_across_calls(tmp_path, arch_dir):
+    """An unchanged filesystem must keep its image: this is still a cache."""
+    for name in (DEFAULT_FS, "base/fw.tar.gz"):
+        conf = _archive(tmp_path, name, b"filesystem", mtime=1_700_000_000)
+
+        assert utils.hash_image_inputs(str(tmp_path), conf) == utils.hash_image_inputs(
+            str(tmp_path), conf
+        ), name


### PR DESCRIPTION
## The problem

`hash_image_inputs()` names the built image (`qcows/image_<h>.qcow2`), and the base
filesystem's only contribution to that name was its **mtime**:

```python
modification_timestamp = os.path.getmtime(fs)
hsh.update(f"{modification_timestamp}".encode())
```

So the key records *when* the filesystem was last written, not *which* filesystem it is.
Two different archives that share an mtime produce the same key: the image built from the
first is silently reused for the second, and the run boots a filesystem the config did
not ask for.

Archives sharing an mtime is not exotic — one extraction, copy, or checkout pass stamps
everything it writes with the same timestamp, so a project holding several base
filesystems can easily have all of them collide.

The substitution is invisible from the outside. The resolved config, the log lines and
the output directory all still name the archive that was requested; only the guest's own
contents disagree. A project with N such archives can run its whole matrix against
whichever one happened to be built first with nothing reporting a problem.

## The change

Fold the project-relative **path**, the **size** and the **nanosecond mtime** into the
key. All come from stat data the mtime already required, so this adds no I/O.

```python
fs_rel = os.path.normpath(os.path.relpath(fs, proj_dir))
if fs_rel != LEGACY_KEY_FS_PATH:
    fs_stat = os.stat(fs)
    hsh.update(fs_rel.encode())
    hsh.update(f"{fs_stat.st_size}".encode())
    hsh.update(f"{fs_stat.st_mtime_ns}".encode())
```

### `base/fs.tar.gz` keeps its existing key

`penguin init` writes that path and `penguin_config` fills `core.fs` with
`./base/fs.tar.gz`, so rekeying it would invalidate the built image of nearly every
existing project — for a bug those projects cannot have.

That exemption is safe for a structural reason, not a probabilistic one: **a project can
hold at most one archive at that path**, so the legacy key can never be the key *shared*
by two different filesystems, which is the whole failure mode. Any second archive
necessarily has some other path, and gets that path folded in. The
`./base/fs.tar.gz` and `base/fs.tar.gz` spellings are normalised to the same path, so
generated and hand-written configs are treated alike.

The consequence is that a project on the default path keeps today's behaviour exactly,
including today's narrower gap (same name, same mtime, new bytes).

### What it deliberately does not do

It does not hash the archive's contents. That would additionally catch an in-place
replacement preserving name, size *and* timestamp, but a base filesystem can be tens of
gigabytes and reading it on every invocation is a poor trade for the residual risk.

## Compatibility

Projects using `base/fs.tar.gz` keep their cached images. Projects with a filesystem at
any other path are rekeyed once and rebuild on the first run after this lands.

## Tests

New `tests/unit/test_image_cache_key.py` (host-side, no rootfs/kernel/container).
Against `main` it scores 4/10; with this change, 10/10. What flips:

- two archives sharing an mtime → different images
- the default archive vs a second archive sharing its mtime → different images
- same name and mtime, different size (non-default path) → different images
- same bytes under a different name → different images
- same basename in a different subdirectory → different images

What passes either way pins the behaviour that must *not* change: the default path keeps
its legacy key (its digest still moves only with mtime), `./base/fs.tar.gz` is the same
path as `base/fs.tar.gz`, a rewritten archive gets a new image, and an untouched one
keeps its image.
