### PR TITLE
silence mke2fs banner https://github.com/rehosting/penguin/issues/702

### DIFF
--- a/src/penguin/gen_image.py
+++ b/src/penguin/gen_image.py
@@ -251,7 +251,8 @@ def make_image(fs: str, out: str, artifacts: str | None, config: dict) -> None:
                 "-N", str(NUMBER_OF_INODES),
                 "-d", str(uncompressed_tar),
                 str(IMAGE)
-            ])
+            ], stderr=subprocess.STDOUT)
+
             # Convert to qcow2
             check_output(["qemu-img", "convert", "-f", "raw", "-O", "qcow2", str(IMAGE), str(qcow)])
             if delete_tar:


### PR DESCRIPTION
Captures stderr on ret 0. Also could pass -q into mke2fs but that would silence a bunch of error while this throws an error on any non 0 exit.