### PR TITLE
Add libinject/ ld preload disable flag.

### DIFF
--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -2620,6 +2620,23 @@ Signals numbers to block within the guest. Supported values are 6 (SIGABRT), 9 (
 
 Library functions to be intercepted
 
+### `lib_inject.enabled` Enables LD_PRELOAD in init script
+
+|||
+|-|-|
+|__Type__|boolean or null|
+|__Default__|`true`|
+
+Whether to enable LD_PRELOAD variable in init script
+
+```yaml
+false
+```
+
+```yaml
+true
+```
+
 ### `lib_inject.aliases` Injected library aliases
 
 |||

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -1525,6 +1525,15 @@ class LibInject(PartialModelMixin, BaseModel):
 
     model_config = ConfigDict(title="Injected library configuration", extra="forbid")
 
+    enabled: Annotated[
+        Optional[bool],
+        Field(
+            True,
+            title="Enables LD_PRELOAD in init script",
+            description="Whether to enable LD_PRELOAD variable in init script",
+            examples=[False, True],
+        ),
+    ]
     aliases: Annotated[
         Optional[LibInjectAliases],
         Field(

--- a/src/penguin/penguin_run.py
+++ b/src/penguin/penguin_run.py
@@ -680,8 +680,8 @@ def run_config(
     graphics = conf["core"].get("graphics", False)
     show_output_bool = conf["core"].get("show_output", False)
     root_shell_enabled = conf["core"].get("root_shell", False)
-    #remove ldpreload for libinject if libinject is disabled
-    ldpreload_enabled = conf.get("lib_inject",dict()).get("enabled", True)
+    # remove ldpreload for libinject if libinject is disabled
+    ldpreload_enabled = conf.get("lib_inject", dict()).get("enabled", True)
     if not ldpreload_enabled:
         conf["env"].pop("LD_PRELOAD", None)
 

--- a/src/penguin/penguin_run.py
+++ b/src/penguin/penguin_run.py
@@ -680,6 +680,10 @@ def run_config(
     graphics = conf["core"].get("graphics", False)
     show_output_bool = conf["core"].get("show_output", False)
     root_shell_enabled = conf["core"].get("root_shell", False)
+    #remove ldpreload for libinject if libinject is disabled
+    ldpreload_enabled = conf.get("lib_inject",dict()).get("enabled", True)
+    if not ldpreload_enabled:
+        conf["env"].pop("LD_PRELOAD", None)
 
     _write_runtime_metadata(out_dir, {
         "pid": os.getpid(),


### PR DESCRIPTION
This removes LD_PRELOAD from pointing at libinject.so It doesn't remove building libinject currently, just the env. Another option is edit static_patches -> lib_inject.core.yaml -> env. This just changes it at runtime instead editing the patch. 

https://github.com/rehosting/penguin/issues/143
