### PR TITLE
pseudofiles: add 'blocking' and 'periodic' poll models

### DIFF
--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -211,13 +211,13 @@ lighttpd: 9999
 
 VM snapshot (savevm/loadvm) configuration.
 
-    Snapshotting is *active* whenever ``save_at`` or ``boot_from`` is set — there
-    is no separate enable flag. When active, the guest runs on a persistent
-    qcow2 overlay (rather than the throwaway immutable overlay) so an internal VM
-    snapshot can be saved and later restored. Saving a snapshot at a chosen point
-    lets a later run boot directly from that state instead of re-booting the
-    firmware.
-    
+Snapshotting is *active* whenever ``save_at`` or ``boot_from`` is set — there
+is no separate enable flag. When active, the guest runs on a persistent
+qcow2 overlay (rather than the throwaway immutable overlay) so an internal VM
+snapshot can be saved and later restored. Saving a snapshot at a chosen point
+lets a later run boot directly from that state instead of re-booting the
+firmware.
+
 
 #### `core.snapshot.backend` Snapshot backend
 
@@ -398,10 +398,10 @@ true
 
 Host<->guest shared directory (9p) configuration.
 
-    Accepted in ``core.shared_dir`` as ``true`` (enable with defaults), a string
-    (shorthand for ``path``), or this object. Core dumps ride the same single
-    mount (see ``core.core_dumps``); they do not need this feature enabled.
-    
+Accepted in ``core.shared_dir`` as ``true`` (enable with defaults), a string
+(shorthand for ``path``), or this object. Core dumps ride the same single
+mount (see ``core.core_dumps``); they do not need this feature enabled.
+
 
 ```yaml
 true
@@ -471,11 +471,11 @@ Override the 9p transport buffer size. Unset uses the default 8MB with an automa
 
 Guest core-dump capture configuration.
 
-    Accepted in ``core.core_dumps`` as ``true`` (enable with defaults), a string
-    (shorthand for ``pattern``), or this object. When enabled, penguin points
-    core_pattern at /igloo/core_dumps (a symlink into the shared mount) and
-    brings that mount up even when core.shared_dir is unset.
-    
+Accepted in ``core.core_dumps`` as ``true`` (enable with defaults), a string
+(shorthand for ``pattern``), or this object. When enabled, penguin points
+core_pattern at /igloo/core_dumps (a symlink into the shared mount) and
+brings that mount up even when core.shared_dir is unset.
+
 
 ```yaml
 true
@@ -1630,6 +1630,54 @@ Constant POLLIN|POLLRDNORM|POLLOUT|POLLWRNORM mask (legacy behavior).
 
 Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
 
+##### `pseudofiles.<string>.poll.<model=blocking>` Never report ready (block the waiter)
+
+Return a zero mask so poll()/select()/epoll parks the caller on the node's wait queue instead of spinning. Models an event-source device whose read() blocks until a hardware event that never occurs under emulation (e.g. a watchdog). A write to the node wakes any parked waiter.
+
+###### `pseudofiles.<string>.poll.<model=blocking>.model` Poll modelling method (never report ready (block the waiter))
+
+|||
+|-|-|
+|__Type__|`"blocking"`|
+
+
+###### `pseudofiles.<string>.poll.<model=blocking>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+##### `pseudofiles.<string>.poll.<model=periodic>` Report ready on a fixed cadence (heartbeat)
+
+Report the node readable once every 'interval_ms', parking the waiter on the node's wait queue in between. An igloo_driver kernel timer drives the cadence, so a poll()/epoll(timeout=-1) main loop advances at a fixed rate instead of spinning (always_ready) or deadlocking (blocking). Models a device that delivers a periodic hardware event (e.g. a watchdog heartbeat). Note the interval is in guest time, which runs slower than wall-clock under emulation.
+
+###### `pseudofiles.<string>.poll.<model=periodic>.model` Poll modelling method (report ready on a fixed cadence (heartbeat))
+
+|||
+|-|-|
+|__Type__|`"periodic"`|
+
+
+###### `pseudofiles.<string>.poll.<model=periodic>.provenance` Model provenance
+
+|||
+|-|-|
+|__Type__|string or null|
+|__Default__|`null`|
+
+Origin tag. Set 'default' for a synthesized stub (it reports its hits into pseudofiles_failures.yaml); leave unset for author-intentional models.
+
+###### `pseudofiles.<string>.poll.<model=periodic>.interval_ms` Heartbeat interval (guest milliseconds)
+
+|||
+|-|-|
+|__Type__|integer|
+|__Default__|`1000`|
+
+
 ##### `pseudofiles.<string>.poll.<model=from_plugin>` Poll from a custom PyPlugin
 
 Data-aware poll: the plugin returns a poll mask reflecting actual readiness.
@@ -2689,12 +2737,12 @@ Custom source code for library functions to intercept and model
 
 Declarative symbol stubs, grouped by library/object.
 
-    Each key is a library/object (an absolute guest path like ``/lib/libc.so``
-    or a bare basename like ``libX.so`` searched for in the rootfs). Each value
-    maps a symbol key to a stub action. A symbol key is either a symbol name, a
-    glob such as ``nvram_*`` (expanded against the library's exported symbols at
-    build time; symbol-return stubs only), or ``symbol@offset`` (assembly-body
-    stubs only, where ``offset`` is added to the symbol address).
+Each key is a library/object (an absolute guest path like ``/lib/libc.so``
+or a bare basename like ``libX.so`` searched for in the rootfs). Each value
+maps a symbol key to a stub action. A symbol key is either a symbol name, a
+glob such as ``nvram_*`` (expanded against the library's exported symbols at
+build time; symbol-return stubs only), or ``symbol@offset`` (assembly-body
+stubs only, where ``offset`` is added to the symbol address).
 
 ```yaml
 {}
@@ -2722,8 +2770,8 @@ libX.so:
 #### `lib_inject.stubs.<string>` Per-library symbol stubs
 
 Symbols (or globs) to stub within one library/object. The library key is
-    an organizational label and the glob-resolution target; aliasing itself is
-    global (``--defsym``).
+an organizational label and the glob-resolution target; aliasing itself is
+global (``--defsym``).
 
 ##### `lib_inject.stubs.<string>.<string>` Symbol stub
 
@@ -2932,10 +2980,10 @@ A list of binary edits applied to this file after it is staged into the guest, i
 ###### `static_files.<string>.<type=inline_file>.patches.<item>` Binary patch entry
 
 A single edit within a ``binary_patch`` action: bytes to write at one
-    file offset, optionally guarded by an ``expect`` check. Multiple entries can
-    target one file via the action's ``patches`` list; they are applied
-    host-side to one buffer in a single pass, and overlapping write ranges are
-    rejected.
+file offset, optionally guarded by an ``expect`` check. Multiple entries can
+target one file via the action's ``patches`` list; they are applied
+host-side to one buffer in a single pass, and overlapping write ranges are
+rejected.
 
 ###### `static_files.<string>.<type=inline_file>.patches.<item>.file_offset` File offset (integer)
 
@@ -3089,10 +3137,10 @@ A list of binary edits applied to this file after it is staged into the guest, i
 ###### `static_files.<string>.<type=host_file>.patches.<item>` Binary patch entry
 
 A single edit within a ``binary_patch`` action: bytes to write at one
-    file offset, optionally guarded by an ``expect`` check. Multiple entries can
-    target one file via the action's ``patches`` list; they are applied
-    host-side to one buffer in a single pass, and overlapping write ranges are
-    rejected.
+file offset, optionally guarded by an ``expect`` check. Multiple entries can
+target one file via the action's ``patches`` list; they are applied
+host-side to one buffer in a single pass, and overlapping write ranges are
+rejected.
 
 ###### `static_files.<string>.<type=host_file>.patches.<item>.file_offset` File offset (integer)
 
@@ -3517,10 +3565,10 @@ A list of edits applied to this one file in a single host-side pass. Use this in
 ###### `static_files.<string>.<type=binary_patch>.patches.<item>` Binary patch entry
 
 A single edit within a ``binary_patch`` action: bytes to write at one
-    file offset, optionally guarded by an ``expect`` check. Multiple entries can
-    target one file via the action's ``patches`` list; they are applied
-    host-side to one buffer in a single pass, and overlapping write ranges are
-    rejected.
+file offset, optionally guarded by an ``expect`` check. Multiple entries can
+target one file via the action's ``patches`` list; they are applied
+host-side to one buffer in a single pass, and overlapping write ranges are
+rejected.
 
 ###### `static_files.<string>.<type=binary_patch>.patches.<item>.file_offset` File offset (integer)
 

--- a/docs/schema_doc.md
+++ b/docs/schema_doc.md
@@ -211,13 +211,13 @@ lighttpd: 9999
 
 VM snapshot (savevm/loadvm) configuration.
 
-Snapshotting is *active* whenever ``save_at`` or ``boot_from`` is set — there
-is no separate enable flag. When active, the guest runs on a persistent
-qcow2 overlay (rather than the throwaway immutable overlay) so an internal VM
-snapshot can be saved and later restored. Saving a snapshot at a chosen point
-lets a later run boot directly from that state instead of re-booting the
-firmware.
-
+    Snapshotting is *active* whenever ``save_at`` or ``boot_from`` is set — there
+    is no separate enable flag. When active, the guest runs on a persistent
+    qcow2 overlay (rather than the throwaway immutable overlay) so an internal VM
+    snapshot can be saved and later restored. Saving a snapshot at a chosen point
+    lets a later run boot directly from that state instead of re-booting the
+    firmware.
+    
 
 #### `core.snapshot.backend` Snapshot backend
 
@@ -398,10 +398,10 @@ true
 
 Host<->guest shared directory (9p) configuration.
 
-Accepted in ``core.shared_dir`` as ``true`` (enable with defaults), a string
-(shorthand for ``path``), or this object. Core dumps ride the same single
-mount (see ``core.core_dumps``); they do not need this feature enabled.
-
+    Accepted in ``core.shared_dir`` as ``true`` (enable with defaults), a string
+    (shorthand for ``path``), or this object. Core dumps ride the same single
+    mount (see ``core.core_dumps``); they do not need this feature enabled.
+    
 
 ```yaml
 true
@@ -471,11 +471,11 @@ Override the 9p transport buffer size. Unset uses the default 8MB with an automa
 
 Guest core-dump capture configuration.
 
-Accepted in ``core.core_dumps`` as ``true`` (enable with defaults), a string
-(shorthand for ``pattern``), or this object. When enabled, penguin points
-core_pattern at /igloo/core_dumps (a symlink into the shared mount) and
-brings that mount up even when core.shared_dir is unset.
-
+    Accepted in ``core.core_dumps`` as ``true`` (enable with defaults), a string
+    (shorthand for ``pattern``), or this object. When enabled, penguin points
+    core_pattern at /igloo/core_dumps (a symlink into the shared mount) and
+    brings that mount up even when core.shared_dir is unset.
+    
 
 ```yaml
 true
@@ -2737,12 +2737,12 @@ Custom source code for library functions to intercept and model
 
 Declarative symbol stubs, grouped by library/object.
 
-Each key is a library/object (an absolute guest path like ``/lib/libc.so``
-or a bare basename like ``libX.so`` searched for in the rootfs). Each value
-maps a symbol key to a stub action. A symbol key is either a symbol name, a
-glob such as ``nvram_*`` (expanded against the library's exported symbols at
-build time; symbol-return stubs only), or ``symbol@offset`` (assembly-body
-stubs only, where ``offset`` is added to the symbol address).
+    Each key is a library/object (an absolute guest path like ``/lib/libc.so``
+    or a bare basename like ``libX.so`` searched for in the rootfs). Each value
+    maps a symbol key to a stub action. A symbol key is either a symbol name, a
+    glob such as ``nvram_*`` (expanded against the library's exported symbols at
+    build time; symbol-return stubs only), or ``symbol@offset`` (assembly-body
+    stubs only, where ``offset`` is added to the symbol address).
 
 ```yaml
 {}
@@ -2770,8 +2770,8 @@ libX.so:
 #### `lib_inject.stubs.<string>` Per-library symbol stubs
 
 Symbols (or globs) to stub within one library/object. The library key is
-an organizational label and the glob-resolution target; aliasing itself is
-global (``--defsym``).
+    an organizational label and the glob-resolution target; aliasing itself is
+    global (``--defsym``).
 
 ##### `lib_inject.stubs.<string>.<string>` Symbol stub
 
@@ -2980,10 +2980,10 @@ A list of binary edits applied to this file after it is staged into the guest, i
 ###### `static_files.<string>.<type=inline_file>.patches.<item>` Binary patch entry
 
 A single edit within a ``binary_patch`` action: bytes to write at one
-file offset, optionally guarded by an ``expect`` check. Multiple entries can
-target one file via the action's ``patches`` list; they are applied
-host-side to one buffer in a single pass, and overlapping write ranges are
-rejected.
+    file offset, optionally guarded by an ``expect`` check. Multiple entries can
+    target one file via the action's ``patches`` list; they are applied
+    host-side to one buffer in a single pass, and overlapping write ranges are
+    rejected.
 
 ###### `static_files.<string>.<type=inline_file>.patches.<item>.file_offset` File offset (integer)
 
@@ -3137,10 +3137,10 @@ A list of binary edits applied to this file after it is staged into the guest, i
 ###### `static_files.<string>.<type=host_file>.patches.<item>` Binary patch entry
 
 A single edit within a ``binary_patch`` action: bytes to write at one
-file offset, optionally guarded by an ``expect`` check. Multiple entries can
-target one file via the action's ``patches`` list; they are applied
-host-side to one buffer in a single pass, and overlapping write ranges are
-rejected.
+    file offset, optionally guarded by an ``expect`` check. Multiple entries can
+    target one file via the action's ``patches`` list; they are applied
+    host-side to one buffer in a single pass, and overlapping write ranges are
+    rejected.
 
 ###### `static_files.<string>.<type=host_file>.patches.<item>.file_offset` File offset (integer)
 
@@ -3565,10 +3565,10 @@ A list of edits applied to this one file in a single host-side pass. Use this in
 ###### `static_files.<string>.<type=binary_patch>.patches.<item>` Binary patch entry
 
 A single edit within a ``binary_patch`` action: bytes to write at one
-file offset, optionally guarded by an ``expect`` check. Multiple entries can
-target one file via the action's ``patches`` list; they are applied
-host-side to one buffer in a single pass, and overlapping write ranges are
-rejected.
+    file offset, optionally guarded by an ``expect`` check. Multiple entries can
+    target one file via the action's ``patches`` list; they are applied
+    host-side to one buffer in a single pass, and overlapping write ranges are
+    rejected.
 
 ###### `static_files.<string>.<type=binary_patch>.patches.<item>.file_offset` File offset (integer)
 

--- a/flake.lock
+++ b/flake.lock
@@ -133,14 +133,14 @@
     "igloo-driver": {
       "flake": false,
       "locked": {
-        "lastModified": 1786471290,
-        "narHash": "sha256-n+xrWnKnts3EDN+ZorOp6dctrbDXuFYHDWYboRgmo8I=",
+        "lastModified": 1786551473,
+        "narHash": "sha256-K9Jncy3ANJhYZ0GA9nNC0jDdnzPJNKc42elABCQ3DhY=",
         "type": "tarball",
-        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94/igloo_driver.tar.gz"
+        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.96/igloo_driver.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94/igloo_driver.tar.gz"
+        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.96/igloo_driver.tar.gz"
       }
     },
     "kernels": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
     flake = false;
   };
   inputs.igloo-driver = {
-    url = "https://github.com/rehosting/igloo_driver/releases/download/v0.0.94/igloo_driver.tar.gz";
+    url = "https://github.com/rehosting/igloo_driver/releases/download/v0.0.96/igloo_driver.tar.gz";
     flake = false;
   };
   # v0.0.25 is the slimmed penguin-tools: it no longer ships the forked guest

--- a/pyplugins/hyperfile/devfs.py
+++ b/pyplugins/hyperfile/devfs.py
@@ -203,7 +203,11 @@ class Devfs(Plugin):
                 "mode": getattr(devfs_file, "MODE", 0o666),
                 "support_mmap": 1 if support_mmap else 0,
                 "is_block": 1 if getattr(devfs_file, "IS_BLOCK", False) else 0,
-                "logical_block_size": getattr(devfs_file, "LOGICAL_BLOCK_SIZE", 512)
+                "logical_block_size": getattr(devfs_file, "LOGICAL_BLOCK_SIZE", 512),
+                # Periodic poll heartbeat cadence (PollPeriodic sets this; 0 =
+                # disabled). dwarffi drops keys the target struct lacks, so this
+                # is a no-op against a driver that predates the field.
+                "poll_interval_ms": int(getattr(devfs_file, "POLL_INTERVAL_MS", 0) or 0),
             }
             if mmap_phys_addr:
                 init_data["mmap_phys_addr"] = mmap_phys_addr

--- a/pyplugins/hyperfile/models/poll.py
+++ b/pyplugins/hyperfile/models/poll.py
@@ -24,6 +24,51 @@ class PollAlwaysReady:
         ptregs.retval = self._POLL_READY_MASK
 
 
+class PollNeverReady:
+    """
+    Report the node permanently *not* ready: poll()/select()/epoll return a
+    zero mask, so the waiter parks on the per-device wait queue (the devfs poll
+    proxy calls poll_wait() before consulting us — issue #77) instead of
+    spinning. Use this for event-source nodes whose read() blocks until a
+    hardware event that never occurs under emulation (e.g. a watchdog device
+    whose service-manager thread does poll()->read() and would busy-loop forever
+    against the always-ready default). A later write to the node wakes
+    the parked waiter via the proxy's wake_up_interruptible(), so a
+    request/response device can still make progress.
+    """
+
+    def poll(self, ptregs: PtRegsWrapper, file: FilePtr, poll_table_struct: PollTablePtr):
+        ptregs.retval = 0
+
+
+class PollPeriodic:
+    """
+    Report the node readable on a fixed cadence. An igloo_driver kernel timer
+    marks the node ready every ``interval_ms`` and wakes the per-device wait
+    queue; the devfs poll proxy then returns POLLIN once per tick and parks the
+    waiter in between (issue #77 supplies the wait queue). Models an event-source
+    device that delivers a periodic hardware heartbeat -- e.g. a watchdog whose
+    service-manager main loop epoll_wait()s with an infinite timeout and only
+    advances its service state machine when the watchdog ticks.
+    always-ready spins that loop; never-ready (``blocking``) deadlocks it;
+    periodic readiness matches real hardware.
+
+    The cadence lives entirely in the driver timer: a host-side poll model
+    cannot re-arm an epoll(timeout=-1) waiter, since poll() is only re-invoked
+    when poll_wq is woken. This mixin therefore only carries the interval down
+    to devfs registration (via ``POLL_INTERVAL_MS``, read by devfs.py) so the
+    driver arms its timer. Its poll() is a park fallback for a driver that
+    predates the timer field.
+    """
+
+    def __init__(self, *, interval_ms: int = 1000, **kwargs):
+        self.POLL_INTERVAL_MS = int(interval_ms)
+        super().__init__(**kwargs)
+
+    def poll(self, ptregs: PtRegsWrapper, file: FilePtr, poll_table_struct: PollTablePtr):
+        ptregs.retval = 0
+
+
 class PollExternalVFS:
     """
     Modern Adapter: Calls a plugin function with the standard VFS poll

--- a/pyplugins/hyperfile/pseudofiles.py
+++ b/pyplugins/hyperfile/pseudofiles.py
@@ -39,7 +39,7 @@ from hyperfile.models.ioctl import (
     IoctlPluginVFS,
     IoctlPluginLegacy,
 )
-from hyperfile.models.poll import PollAlwaysReady, PollExternalVFS
+from hyperfile.models.poll import PollAlwaysReady, PollNeverReady, PollPeriodic, PollExternalVFS
 from hyperfile.models.registry import get_model
 from hyperfile.models.seek import (
     SeekDefault,
@@ -152,6 +152,8 @@ class Pseudofiles(Plugin):
 
     poll_models = {
         "always_ready": PollAlwaysReady,
+        "blocking": PollNeverReady,
+        "periodic": PollPeriodic,
     }
 
     # Per-operation models for the rest of the VFS surface. Each maps a model

--- a/src/penguin/penguin_config/structure.py
+++ b/src/penguin/penguin_config/structure.py
@@ -965,6 +965,38 @@ Poll = _union(
             fields=(),
         ),
         dict(
+            discrim_val="blocking",
+            title="Never report ready (block the waiter)",
+            description=(
+                "Return a zero mask so poll()/select()/epoll parks the caller on "
+                "the node's wait queue instead of spinning. Models an "
+                "event-source device whose read() blocks until a hardware event "
+                "that never occurs under emulation (e.g. a watchdog). A write "
+                "to the node wakes any parked waiter."
+            ),
+            fields=(),
+        ),
+        dict(
+            discrim_val="periodic",
+            title="Report ready on a fixed cadence (heartbeat)",
+            description=(
+                "Report the node readable once every 'interval_ms', parking the "
+                "waiter on the node's wait queue in between. An igloo_driver "
+                "kernel timer drives the cadence, so a poll()/epoll(timeout=-1) "
+                "main loop advances at a fixed rate instead of spinning "
+                "(always_ready) or deadlocking (blocking). Models a device that "
+                "delivers a periodic hardware event (e.g. a watchdog "
+                "heartbeat). Note the interval is in guest time, "
+                "which runs slower than wall-clock under emulation."
+            ),
+            fields=(
+                ("interval_ms", int, Field(
+                    title="Heartbeat interval (guest milliseconds)",
+                    default=1000,
+                )),
+            ),
+        ),
+        dict(
             discrim_val="from_plugin",
             title="Poll from a custom PyPlugin",
             description="Data-aware poll: the plugin returns a poll mask reflecting actual readiness.",

--- a/tests/integration/test_target/base_config.yaml
+++ b/tests/integration/test_target/base_config.yaml
@@ -54,6 +54,7 @@ patches:
   - ./patches/tests/pseudofile_sysfs.yaml
   - ./patches/tests/pseudofile_from_plugin.yaml
   - ./patches/tests/pseudofile_poll_backing.yaml
+  - ./patches/tests/pseudofile_poll_periodic.yaml
   - ./patches/tests/shared_dir.yaml
   # - ./patches/tests/syscall.yaml
   - ./patches/tests/indiv_debug.yaml

--- a/tests/integration/test_target/patches/tests/pseudofile_poll_periodic.yaml
+++ b/tests/integration/test_target/patches/tests/pseudofile_poll_periodic.yaml
@@ -1,0 +1,117 @@
+# tests/integration/test_target/patches/tests/pseudofile_poll_periodic.yaml
+#
+# End-to-end cover for the two non-default poll models against the real
+# igloo_driver build: `periodic` (driver kernel timer marks the node readable
+# once per interval and wakes the per-device wait queue) and `blocking` (zero
+# mask, waiter parks). The unit suite only proves model resolution and that
+# interval_ms is carried down as POLL_INTERVAL_MS; the cadence itself lives in
+# the driver timer, so nothing but a booted guest can show it actually ticks.
+plugins:
+  verifier:
+    conditions:
+      poll_periodic+console:
+        type: file_contains
+        file: console.log
+        string: "/tests/pseudofile_poll_periodic.sh PASS"
+      poll_periodic+stdout:
+        type: file_contains
+        file: shared/tests/pseudofile_poll_periodic.sh/stdout
+        string: "pseudofile_poll_periodic PASS"
+
+pseudofiles:
+  # Heartbeat node: readable once per interval, parked in between.
+  /dev/poll_heartbeat:
+    read:
+      model: zero
+    poll:
+      model: periodic
+      interval_ms: 1000
+
+  # Never-ready node: poll must report a zero mask rather than the /dev
+  # always-ready default.
+  /dev/poll_never:
+    read:
+      model: zero
+    poll:
+      model: blocking
+
+static_files:
+  /tests/pseudofile_poll_periodic.sh:
+    type: inline_file
+    mode: 73
+    contents: |
+      #!/igloo/utils/python3
+      # NB: every poll() below uses a *bounded* timeout, never -1. run_tests.sh
+      # executes /tests/* serially as guest PID1, so a poll that never returns
+      # would hang the remaining fixtures and fail the run as a CI timeout
+      # instead of an assertion. A generous bound turns a dead timer into a
+      # clean failure. The mechanism under test is identical either way: with
+      # any blocking timeout the kernel parks on the device wait queue and only
+      # re-invokes ->poll() after a wake, so a bounded wait still proves the
+      # driver timer is what delivers the tick.
+      import select
+
+      POLLIN = getattr(select, "POLLIN", 0x001)
+
+      # Well over 500ms of guest time, so only a dead timer trips it.
+      TICK_WAIT_MS = 30000
+
+      # Number of back-to-back non-blocking samples used to show the node is not
+      # *permanently* readable. Kept cheap: the poll object is built once per fd
+      # and reused, so each sample is close to a bare syscall.
+      SAMPLES = 40
+
+      def ready(events):
+          return any(m & POLLIN for _, m in events)
+
+      # --- periodic: the driver timer must wake the waiter, repeatedly --------
+      f = open("/dev/poll_heartbeat", "rb", buffering=0)
+      try:
+          po = select.poll()
+          po.register(f, POLLIN)
+
+          for i in range(3):
+              # Parks on the wait queue until the driver timer fires. Three
+              # iterations prove the timer re-arms itself, not just fires once.
+              if not ready(po.poll(TICK_WAIT_MS)):
+                  raise AssertionError(
+                      "poll_heartbeat: no POLLIN within %dms on tick %d "
+                      "(driver periodic timer not firing?)" % (TICK_WAIT_MS, i + 1))
+
+          # The node must not be *permanently* readable -- that is the /dev
+          # always-ready default this model exists to replace.
+          #
+          # Deliberately not phrased as "not readable immediately after
+          # consuming a tick". interval_ms is guest time, and the guest time
+          # this interpreter burns between two poll() calls can exceed it, so a
+          # fresh tick may legitimately have arrived by the very next call --
+          # that assertion failed on the fastest arch while passing on 16
+          # others. Sampling instead is timing-independent: under always_ready
+          # every sample reports POLLIN, whereas a heartbeat has to be quiet
+          # between ticks, so at least one sample must come back not-ready.
+          quiet = 0
+          for _ in range(SAMPLES):
+              if not ready(po.poll(0)):
+                  quiet += 1
+          if not quiet:
+              raise AssertionError(
+                  "poll_heartbeat: readable on all %d samples -- looks "
+                  "always-ready rather than periodic" % SAMPLES)
+      finally:
+          f.close()
+
+      # --- blocking: never ready ---------------------------------------------
+      f = open("/dev/poll_never", "rb", buffering=0)
+      try:
+          po = select.poll()
+          po.register(f, POLLIN)
+          if ready(po.poll(0)):
+              raise AssertionError("poll_never: reported POLLIN on a zero-mask node")
+          # And it stays not-ready across an actual wait rather than being
+          # woken by anything incidental.
+          if ready(po.poll(200)):
+              raise AssertionError("poll_never: reported POLLIN after waiting")
+      finally:
+          f.close()
+
+      print("pseudofile_poll_periodic PASS")

--- a/tests/unit/test_pseudofile_composition.py
+++ b/tests/unit/test_pseudofile_composition.py
@@ -129,6 +129,44 @@ def test_explicit_seek_model_is_composed(pf):
     assert "SeekUnsupported" in _mro_names(inst)
 
 
+def test_poll_blocking_maps_to_never_ready(pf):
+    # poll:blocking resolves to the not-ready mixin (parks the waiter on the
+    # per-device wait queue instead of spinning; see poll issue #77).
+    assert pf._resolve_mixin("poll", {"model": "blocking"}).__name__ == "PollNeverReady"
+
+
+def test_dev_node_with_blocking_poll_composes_never_ready(pf):
+    # An explicit poll:blocking overrides the /dev always-ready fallback.
+    inst = _dev(pf, {"read": {"model": "zero"}, "poll": {"model": "blocking"}})
+    names = _mro_names(inst)
+    assert "PollNeverReady" in names
+    assert "PollAlwaysReady" not in names
+
+
+def test_poll_periodic_maps_to_periodic(pf):
+    # poll:periodic resolves to the heartbeat mixin (driver timer wakes the wait
+    # queue every interval_ms; see PollPeriodic).
+    assert pf._resolve_mixin("poll", {"model": "periodic"}).__name__ == "PollPeriodic"
+
+
+def test_dev_node_with_periodic_poll_carries_interval(pf):
+    # An explicit poll:periodic composes PollPeriodic (not the /dev always-ready
+    # fallback) and carries interval_ms down as POLL_INTERVAL_MS so devfs
+    # registration can arm the driver timer.
+    inst = _dev(pf, {"read": {"model": "zero"},
+                     "poll": {"model": "periodic", "interval_ms": 250}})
+    names = _mro_names(inst)
+    assert "PollPeriodic" in names
+    assert "PollAlwaysReady" not in names
+    assert inst.POLL_INTERVAL_MS == 250
+
+
+def test_dev_node_periodic_poll_defaults_interval(pf):
+    # interval_ms is optional; PollPeriodic defaults it (matches the schema).
+    inst = _dev(pf, {"read": {"model": "zero"}, "poll": {"model": "periodic"}})
+    assert inst.POLL_INTERVAL_MS == 1000
+
+
 def test_proc_node_has_no_dev_only_fallbacks(pf):
     from importlib import import_module
     ProcFile = import_module("hyperfile.models.base").ProcFile


### PR DESCRIPTION
The `/dev` poll default is **always-ready**, which is wrong for an event-source
node whose reader is driven by `poll()`. Two new poll models cover the cases it
breaks. Both are opt-in; nothing changes for existing configs.

## `poll: {model: blocking}` — `PollNeverReady`

Returns a zero mask, so `poll()`/`select()`/`epoll` parks the waiter on the
per-device wait queue (the devfs poll proxy calls `poll_wait()` before consulting
us — issue #77) instead of spinning.

For nodes whose `read()` blocks on a hardware event that never occurs under
emulation. With the always-ready default, a reader doing `poll()`→`read()`
busy-loops on the failing read and starves the emulator — in the case that
motivated this, ~139k failed-read log lines that blocked the rest of the boot.

A later **write** to the node wakes the parked waiter, so a request/response
device still makes progress.

## `poll: {model: periodic, interval_ms: N}` — `PollPeriodic`

Reports the node readable once every `interval_ms` — driven by an igloo_driver
kernel timer — and parks the waiter in between.

This models a device that delivers a **periodic hardware heartbeat**: e.g. a
watchdog whose service-manager main loop `epoll_wait()`s with an infinite timeout
and only advances its service state machine when the watchdog ticks. The three
behaviours are genuinely distinct there:

| model | effect on such a loop |
|---|---|
| `always_ready` (default) | epoll returns instantly every iteration → spin |
| `blocking` | loop parks forever → deadlock after the last event |
| `periodic` | loop wakes at a fixed cadence → advances, like real hardware |

**Why this needs the driver:** with `timeout=-1` the kernel only re-invokes
`->poll()` after a wake on the device's wait queue, so a host-side poll model
cannot deliver ticks on its own. The cadence lives in a kernel timer:
rehosting/igloo_driver#96 (`portal_devfs`: optional `poll_interval_ms` →
self-rearming timer that wakes `poll_wq`). `POLL_INTERVAL_MS` is carried down to
devfs registration as `poll_interval_ms`.

`dwarffi` drops the unknown key on drivers that predate the field, so with an older
driver this degrades to the previous behaviour rather than failing.

Note `interval_ms` is **guest** time, which runs slower than wall-clock under
emulation.

## Tests / checks

`tests/unit/test_pseudofile_composition.py` covers both models: name resolution,
that an explicit `poll` overrides the `/dev` always-ready fallback, and that
`interval_ms` is carried down as `POLL_INTERVAL_MS` (including its default).

- **676 unit tests pass** (`tests/unit`)
- flake8 clean on the changed files
- `docs/schema_doc.md` regenerated from the schema

## Related

- Driver half: rehosting/igloo_driver#96
- Both are prerequisites for a rehosting that is staged as a draft until they land
  and a penguin release carries them.