### PR TITLE
nix: fix the image's creation timestamp and add OCI annotations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -180,6 +180,22 @@
           gitRev = self.shortRev or self.dirtyShortRev or "unknown";
           penguinVersion = if overrideVersion != "" then overrideVersion else "0.0.0.dev0+g${gitRev}";
 
+          # Creation timestamp stamped into the image config. dockerTools
+          # defaults it to the epoch, which is reproducible but reports every
+          # release as 56 years old in `docker images` / registry UIs.
+          #
+          # self.lastModifiedDate is the HEAD commit's date, so this stays a
+          # pure function of the source (same commit -> same image) while
+          # meaning something to a user. It is also the commit date for a *dirty*
+          # tree, so local rebuilds don't churn the image derivation between
+          # commits.
+          imageCreated =
+            let
+              d = self.lastModifiedDate; # "YYYYMMDDHHMMSS", UTC
+              at = start: len: builtins.substring start len d;
+            in
+            "${at 0 4}-${at 4 2}-${at 6 2}T${at 8 2}:${at 10 2}:${at 12 2}Z";
+
           # ---- Penguin core Python environment ----------------------------
           # The post-prune dependency set (angr/symex and the 13 unused
           # packages are gone). Firmware-extraction Python backends (binwalk
@@ -406,6 +422,7 @@
             import ./nix/mk-image.nix (
               {
                 inherit pkgs iglooStatic penguinQemu vhostDeviceVsock;
+                created = imageCreated;
                 extractionBundle = fw2tar.packages.${system}.extractionBundle;
                 pypluginsSrc = lib.fileset.toSource {
                   root = ./pyplugins;

--- a/flake.nix
+++ b/flake.nix
@@ -196,6 +196,28 @@
             in
             "${at 0 4}-${at 4 2}-${at 6 2}T${at 8 2}:${at 10 2}:${at 12 2}Z";
 
+          # Standard OCI annotations. The Dockerfile set no LABELs at all, so
+          # `docker inspect rehosting/penguin` reported `Labels: null` and a
+          # pulled image carried nothing tying it back to the commit that built
+          # it -- `revision` is the one that makes a user-reported image
+          # reproducible on our side. These live in the config blob, so they add
+          # a few hundred bytes and leave every layer digest untouched.
+          imageLabels = {
+            "org.opencontainers.image.title" = "penguin";
+            "org.opencontainers.image.description" =
+              "Configuration-based firmware rehosting framework";
+            "org.opencontainers.image.source" = "https://github.com/rehosting/penguin";
+            "org.opencontainers.image.url" = "https://github.com/rehosting/penguin";
+            "org.opencontainers.image.documentation" = "https://docs.rehosti.ng/";
+            "org.opencontainers.image.licenses" = "GPL-2.0-or-later";
+            "org.opencontainers.image.vendor" = "MIT Lincoln Laboratory";
+            "org.opencontainers.image.created" = imageCreated;
+            "org.opencontainers.image.version" = penguinVersion;
+            # Full rev, not the short one used for the version string: this is
+            # what someone pastes back to us from `docker inspect`.
+            "org.opencontainers.image.revision" = self.rev or self.dirtyRev or "unknown";
+          };
+
           # ---- Penguin core Python environment ----------------------------
           # The post-prune dependency set (angr/symex and the 13 unused
           # packages are gone). Firmware-extraction Python backends (binwalk
@@ -423,6 +445,7 @@
               {
                 inherit pkgs iglooStatic penguinQemu vhostDeviceVsock;
                 created = imageCreated;
+                labels = imageLabels;
                 extractionBundle = fw2tar.packages.${system}.extractionBundle;
                 pypluginsSrc = lib.fileset.toSource {
                   root = ./pyplugins;

--- a/nix/mk-image.nix
+++ b/nix/mk-image.nix
@@ -31,6 +31,9 @@
   # cannot be silently forgotten and fall back to dockerTools' epoch. flake.nix
   # derives it from the flake's own last-modified date; see the comment there.
   created,
+  # OCI annotations for the image config (org.opencontainers.image.*), supplied
+  # by flake.nix. Same rationale as `created`: required, not defaulted.
+  labels,
   extraContents ? [ ], # extra packages to union into the root (docsImage adds texlive)
   # When true, build with dockerTools.streamLayeredImage instead of
   # buildLayeredImage: the result is an executable that writes the image tarball
@@ -364,6 +367,11 @@ let
 
   config = {
     Cmd = [ "/usr/local/bin/banner.sh" ];
+    # The Dockerfile set no LABELs, so `docker inspect` reported Labels: null
+    # and nothing tied a pulled image back to the commit that built it. These
+    # are the standard OCI annotations; they live in the config blob, so they
+    # add a few hundred bytes and don't touch any layer.
+    Labels = labels;
     Env = [
       # Nix-provided tools live under /usr/local/bin and the merged /bin; the
       # ubuntu base's userland (apt, dpkg, etc.) is in /usr/bin and /sbin.

--- a/nix/mk-image.nix
+++ b/nix/mk-image.nix
@@ -27,6 +27,10 @@
   wrapperSrc, # the host ./penguin wrapper script
   resourcesSrc, # src/resources (banner.sh, penguin_install[.local])
   tag ? "latest", # image tag (docsImage overrides to "docs")
+  # Image creation timestamp, ISO-8601. Required rather than defaulted, so it
+  # cannot be silently forgotten and fall back to dockerTools' epoch. flake.nix
+  # derives it from the flake's own last-modified date; see the comment there.
+  created,
   extraContents ? [ ], # extra packages to union into the root (docsImage adds texlive)
   # When true, build with dockerTools.streamLayeredImage instead of
   # buildLayeredImage: the result is an executable that writes the image tarball
@@ -487,6 +491,11 @@ in
 (if stream then pkgs.dockerTools.streamLayeredImage else pkgs.dockerTools.buildLayeredImage) {
   name = "rehosting/penguin";
   inherit tag;
+  # Only `created` (the image config's timestamp), never dockerTools' `mtime`:
+  # mtime is stamped into every file header in every layer tarball, so moving it
+  # would change all 115 layer digests on each release and destroy pull/push
+  # dedup. `created` lives in the config blob alone, which is a few KB.
+  inherit created;
   # Layer the Nix contents on top of the ubuntu:22.04 base (FHS userland + apt).
   fromImage = ubuntuBase;
   # hostToolCheck contributes only a marker file, but including it here makes


### PR DESCRIPTION
Two bits of image metadata the Dockerfile never set, both living entirely in the image **config blob** — so neither touches a layer digest, and pull/push dedup between releases is unaffected.

## 1. Creation timestamp

The image reported `1970-01-01T00:00:01Z` — dockerTools' default for `created` — so every release showed up as 56 years old in `docker images` and registry UIs.

Set from `self.lastModifiedDate` (the HEAD commit's date, reformatted to ISO-8601).

**Why not `"now"`:** dockerTools accepts it, but it taints the derivation as impure and makes every build differ. The commit date is meaningful *and* keeps the image a pure function of the source. Nix also reports the last-commit date for a **dirty** tree, so an edit-and-rebuild loop doesn't churn the image derivation.

**Why `created` and not `mtime`:** `mtime` is stamped into every file header of every layer tarball; moving it would change all 115 layer digests each release and destroy dedup. `created` is config-only.

## 2. OCI annotations

`docker inspect rehosting/penguin` reported `Labels: null`. Nothing in a pulled image tied it back to the commit that built it. Added the standard `org.opencontainers.image.*` set: `title`, `description`, `source`, `url`, `documentation`, `licenses` (GPL-2.0-or-later, per LICENSE), `vendor`, `created`, `version` (matches `penguin --version`), and `revision`.

`revision` is the one that earns its keep — it is what makes a user-reported image reproducible on our side.

## Verification

Checked the derivation graph rather than the source:

```
$ nix derivation show -r .#dockerImage | grep -o '"created":"[^"]*"'
"created":"2026-08-11T17:01:02Z"        # == HEAD commit date, UTC
$ ... | grep -o '"mtime":"[^"]*"'
"mtime":"1970-01-01T00:00:01Z"          # unchanged, as intended
$ ... | grep -o 'org.opencontainers[^,]*'
... all 10 annotations, revision == HEAD sha
```

`date -Iseconds -d <value>` parses, which is the conversion dockerTools itself applies. All four image outputs (`dockerImage`, `dockerImageStream`, `dockerImageStreamHashed`, `docsImage`) evaluate.
