### PR TITLE
nix: add a portable image that runs where /nix is not ours

### DIFF
--- a/.github/workflows/publish-portable.yaml
+++ b/.github/workflows/publish-portable.yaml
@@ -1,0 +1,64 @@
+name: Release Portable Container
+
+# Publishes `rehosting/penguin:<version>-portable`: the same image as the normal
+# release, but with the Nix closure relocated out of /nix so it survives on a
+# host that mounts its own /nix over the container's. See the "Portable variant"
+# comment in nix/mk-image.nix and docs/nix.md.
+#
+# ON DEMAND, not part of every release. The portable image is one large layer
+# rather than 115 (dockerTools' layering can't be used on a relocated store), so
+# it shares no blobs with the normal image and adds its full compressed size to
+# registry storage on every publish. Consumers of it -- currently the
+# pwn.college dojo -- pin an exact tag and bump deliberately, so building it per
+# release would pay that cost for nothing. Run this when a consumer is ready to
+# move.
+#
+# Usage: Actions -> Release Portable Container -> Run workflow, giving the
+# release tag to build (e.g. v3.1.4). The tag must already exist.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing release tag to build the portable image from (e.g. v3.1.4)
+        type: string
+        required: true
+      also-tag-floating:
+        description: Also push the floating `:portable` tag
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "release-portable"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    uses: rehosting/ci/.github/workflows/nix-image-push.yml@v1
+    with:
+      image: rehosting/penguin
+      flake-attr: .#portableImage
+      # Build the image from the requested release tag, not from main.
+      checkout-ref: ${{ inputs.version }}
+      cachix-name: rehosting-tools
+      nix-install-url: https://releases.nixos.org/nix/nix-2.31.2/install
+      enable-kvm: false
+      dockerhub-user: rehosting
+      extra-tags: |
+        rehosting/penguin:${{ inputs.version }}-portable
+        ${{ inputs.also-tag-floating && 'rehosting/penguin:portable' || '' }}
+      # Same version-injection contract as publish.yaml, so `penguin --version`
+      # inside the portable image reports the release it was built from rather
+      # than a git-derived dev version.
+      extra-build-args: --impure
+      build-env: |
+        PENGUIN_OVERRIDE_VERSION=${{ inputs.version }}
+    secrets:
+      registry: ${{ secrets.REHOSTING_ARC_REGISTRY }}
+      registry-user: ${{ secrets.REHOSTING_ARC_REGISTRY_USER }}
+      registry-password: ${{ secrets.REHOSTING_ARC_REGISTRY_PASSWORD }}
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+      cachix-auth-token: ${{ secrets.CACHIX_REHOSTING }}

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -90,6 +90,7 @@ Built for both `x86_64-linux` and `aarch64-linux`. Build any with
 | `dockerImageStream` | streaming variant of `dockerImage` (`nix run .#dockerImageStream \| docker load`); no store tarball, still `:latest` |
 | `dockerImageStreamHashed` | streaming image tagged by the nix build hash (`:` `<hash>`), backing `nix run` / `.#load` |
 | `docsImage` | `rehosting/penguin:docs` — the runtime image plus the sphinx toolchain + texlive, used by the docs release job |
+| `portableImage` | `rehosting/penguin:portable` — same image with the Nix closure relocated out of `/nix`, for hosts that own `/nix` themselves ([details](#the-portable-image-running-where-something-else-owns-nix)) |
 | `pythonEnv` *(default)* | the interpreter the image runs: penguin + all runtime deps |
 | `penguin` | the penguin Python package alone |
 | `pengutils` | the `pengutils` helper package |
@@ -159,6 +160,59 @@ or a missing `INTERP` is invisible until the guest runs.
 igloo-driver, and penguin-tools release tarballs plus the `guest-utils` source,
 reproducing the Dockerfile's per-arch symlink staging. The result is
 golden-diffed against the Docker image's tree.
+
+### The portable image: running where something else owns `/nix`
+
+Everything in the normal image is a symlink into `/nix/store` — `/bin/bash`,
+`/bin/python3`, `/usr/local/bin/penguin`, `/igloo_static`, `/pyplugins`. That is
+fine until a host mounts *its own* `/nix` over the container's, which shadows the
+store and takes all of penguin with it. The image doesn't degrade; it vanishes.
+`docker run` fails before exec with `stat /usr/local/bin/penguin: no such file or
+directory`, leaving only Ubuntu's real `/usr/bin`.
+
+The concrete case is the **pwn.college dojo platform**, which starts every
+challenge container with a read-only bind of its own workspace store at `/nix`
+because its userland lives there. You can reproduce the failure against any
+normal image in one command:
+
+```sh
+mkdir /tmp/empty
+docker run --rm -v /tmp/empty:/nix:ro rehosting/penguin:latest penguin --version
+```
+
+There is no runtime workaround. Re-mounting our store over theirs needs `mount`,
+and moby's default seccomp profile — which that platform uses — gates
+`mount`/`umount2`/`unshare`/`setns`/`pivot_root` behind `CAP_SYS_ADMIN`;
+unprivileged challenge containers get only `SYS_PTRACE`.
+
+`portableImage` solves it by moving the closure somewhere nobody else claims:
+
+```sh
+nix build .#portableImage --accept-flake-config
+docker load < result                       # rehosting/penguin:portable
+
+# It still works with /nix shadowed:
+docker run --rm -v /tmp/empty:/nix:ro rehosting/penguin:portable penguin --version
+```
+
+The closure lands at **`/opt/store`** instead of `/nix/store`, and every
+reference to it is rewritten. The prefix is deliberately the **same byte
+length** as `/nix/store`, which is what makes the rewrite safe: it happens in
+place, so ELF `PT_INTERP`/`DT_RUNPATH` strings, compiled-in path constants,
+shebangs and `.pyc` paths all stay structurally valid — no `patchelf`, no
+per-format handling. `nix/relocate-store.py` does the rewrite and fails the build
+if any reference to the old store survives. `portablePrefix` in
+`nix/mk-image.nix` can change it, but only to another 10-byte path.
+
+Two things to know before reaching for it:
+
+- **It is one large layer, not 115.** `contents` can't be used, because
+  `streamLayeredImage` assembles its customisation layer with `symlinkJoin` —
+  which would leave the image a farm of symlinks back into `/nix/store`. So the
+  relocated tree is copied in as real files with `includeStorePaths = false`,
+  which forgoes per-store-path layer dedup between releases.
+- **Prefer the normal image** wherever `/nix` is yours. This variant exists for
+  hosts that take it away.
 
 ### Writable paths
 

--- a/flake.nix
+++ b/flake.nix
@@ -485,6 +485,18 @@
             tag = null;
           };
 
+          # The portable image (rehosting/penguin:portable): identical contents,
+          # but with the Nix closure relocated out of /nix so it survives on a
+          # host that bind-mounts its own /nix over the container's -- which the
+          # pwn.college dojo platform does unconditionally. See the "Portable
+          # variant" comment in nix/mk-image.nix for the mechanism and the
+          # trade-off (one large layer instead of 115).
+          portableImage = mkImage {
+            inherit pythonEnv;
+            portable = true;
+            tag = "portable";
+          };
+
           # The release docs image (rehosting/penguin:docs): the runtime image
           # plus the in-image sphinx toolchain and a LaTeX engine for the PDF
           # build. texlive scheme-medium provides pdflatex + latexmk + the
@@ -496,7 +508,7 @@
           };
         in
         {
-          inherit pythonEnv testPythonEnv penguinQemu iglooStatic muslHeaders nativeHelpersTree penguin pengutils vhostDeviceVsock dockerImage dockerImageStream dockerImageStreamHashed docsImage;
+          inherit pythonEnv testPythonEnv penguinQemu iglooStatic muslHeaders nativeHelpersTree penguin pengutils vhostDeviceVsock dockerImage dockerImageStream dockerImageStreamHashed docsImage portableImage;
           nativeHelper-x86_64 = nativeHelpers.x86_64;
           default = pythonEnv;
         }

--- a/nix/mk-image.nix
+++ b/nix/mk-image.nix
@@ -42,6 +42,15 @@
   # avoids materialising the tarball -- useful for CI push. Local `docker load`
   # keeps using the non-streaming output.
   stream ? false,
+  # When true, build the image with the Nix closure relocated OUT of /nix, so
+  # the image survives in an environment that owns /nix itself. See the
+  # "Portable variant" section below for the why and the mechanism. Mutually
+  # exclusive with `stream`.
+  portable ? false,
+  # Where the relocated closure lives in a portable image. MUST be the same byte
+  # length as the real store directory (10 bytes, "/nix/store") -- the rewrite is
+  # in-place; see nix/relocate-store.py.
+  portablePrefix ? "/opt/store",
 }:
 
 let
@@ -495,7 +504,97 @@ let
     echo "verified: ${pkgs.lib.concatStringsSep " " (requiredHostTools ++ requiredFiles)}" \
       > "$out/share/penguin/host-tools-verified"
   '';
+
+  # ---- Portable variant: the closure, relocated out of /nix ------------------
+  #
+  # WHY. Some hosts own /nix themselves. The pwn.college dojo platform is the
+  # concrete case: it creates every challenge container with
+  #   Mount("/nix", f"{HOST_DATA_PATH}/workspace/nix", "bind", read_only=True)
+  # and an entrypoint under /nix/var/nix/profiles/, because its own workspace
+  # userland lives in that store. That mount SHADOWS this image's /nix/store
+  # entirely -- and since `overlay` above notes "symlink targets are
+  # store-absolute (the store is in the image)", shadowing it deletes all of
+  # penguin at once: /usr/local/bin/penguin, /bin/bash, /bin/python3,
+  # /igloo_static and /pyplugins are all symlinks into the store. Verified on
+  # v3.1.3 by bind-mounting an empty directory at /nix: `docker run` fails before
+  # exec with "stat /usr/local/bin/penguin: no such file or directory". Only
+  # Ubuntu's real /usr/bin survives (thanks to the usrmerge restoration above).
+  #
+  # There is no runtime fix. Re-mounting our store over theirs needs `mount`, and
+  # the platform runs containers under moby's default seccomp profile, which
+  # gates mount/umount2/unshare/setns/pivot_root behind CAP_SYS_ADMIN; challenge
+  # containers get only SYS_PTRACE. A user namespace is blocked the same way.
+  #
+  # HOW. Move the closure to a prefix nobody else claims, and rewrite every
+  # reference to it. The replacement prefix is the SAME BYTE LENGTH as
+  # "/nix/store", which is what makes this tractable: the rewrite happens in
+  # place, so ELF interpreters, DT_RUNPATHs, compiled-in string constants,
+  # shebangs and .pyc paths all stay valid with no patchelf and no per-format
+  # knowledge. See nix/relocate-store.py.
+  #
+  # This is the same class of surgery `clang20Slim` above already does (copy out
+  # of the store, then fix up the references), just applied to the whole closure.
+  #
+  # COST. One big layer instead of 115. `contents` cannot be used for it --
+  # streamLayeredImage builds its customisation layer with symlinkJoin, so the
+  # image would be a farm of symlinks back into /nix/store, i.e. exactly the
+  # thing being avoided -- so the tree is copied in as real files via
+  # extraCommands with includeStorePaths = false. That forgoes per-store-path
+  # layer dedup between releases. Acceptable for a consumer that pins a tag and
+  # rebuilds rarely; if it starts to hurt, the fix is to relocate each store path
+  # in its own derivation and hand dockerTools a pre-relocated layer set.
+  portableRoot = pkgs.runCommand "penguin-portable-root" {
+    nativeBuildInputs = [ pkgs.python3 ];
+    closure = pkgs.closureInfo { rootPaths = [ rootEnv hostToolCheck ]; };
+  } ''
+    # `cp -a` out of the store preserves its read-only directory modes, so each
+    # copy has to be made writable before the next one can merge into it (and
+    # before symlinks can be retargeted in place).
+    writable() { find "$out" -type d -exec chmod u+w {} + ; }
+
+    mkdir -p "$out${portablePrefix}"
+
+    # 1. The closure, wholesale. Every path, not just the roots: the references
+    #    being rewritten point at all of them.
+    while read -r p; do
+      cp -a --no-preserve=ownership "$p" "$out${portablePrefix}/"
+    done < "$closure/store-paths"
+    writable
+
+    # 2. The merged root tree (a farm of symlinks into the store, retargeted in
+    #    step 4) and the host-tool assertion marker.
+    cp -a ${rootEnv}/. "$out/"
+    writable
+    cp -a ${hostToolCheck}/. "$out/"
+    writable
+
+    # 3. The same writable dirs + usrmerge restoration the layered image applies,
+    #    verbatim -- it is the identical image, only relocated.
+    ( cd "$out" && ${extraCommands} )
+    writable
+
+    # 4. Rewrite every reference, and fail the build if any survives.
+    python3 ${./relocate-store.py} "$out" "${builtins.storeDir}" "${portablePrefix}"
+  '';
+
+  portableImage = pkgs.dockerTools.buildLayeredImage {
+    name = "rehosting/penguin";
+    inherit tag created config;
+    fromImage = ubuntuBase;
+    contents = [ ];
+    # Nothing may be pulled in by reference: the point is that /nix is empty at
+    # runtime. Without this, dockerTools would helpfully add portableRoot itself
+    # as a store layer -- a second, shadowed copy of the whole image.
+    includeStorePaths = false;
+    extraCommands = ''
+      cp -a ${portableRoot}/. ./
+    '';
+  };
 in
+if portable then
+  assert !stream;
+  portableImage
+else
 (if stream then pkgs.dockerTools.streamLayeredImage else pkgs.dockerTools.buildLayeredImage) {
   name = "rehosting/penguin";
   inherit tag;

--- a/nix/relocate-store.py
+++ b/nix/relocate-store.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Rewrite every Nix store reference under a tree to an equal-length prefix.
+
+Used by the `portable` image variant in mk-image.nix, which has to run where
+something else owns /nix (see the comment there).
+
+The whole technique rests on the replacement prefix being the *same byte
+length* as the real store directory. Nix store paths are absolute and appear
+not just in symlinks and shebangs but baked into binaries: ELF PT_INTERP and
+DT_RUNPATH strings, compiled-in C string constants, .pyc co_filename entries,
+pkg-config files, wrapper scripts. Replacing them in place, byte for byte,
+keeps every one of those structurally valid without this script needing to
+understand a single one of those formats -- no patchelf, no per-format
+handling, no length bookkeeping. Any other length would corrupt the ELF
+sections and offsets that reference them.
+
+Directories must be writable before this runs (symlink retargeting replaces
+the link, which needs write permission on its parent). File modes are
+preserved: each file is made writable only for its own rewrite and restored
+immediately after.
+"""
+
+import os
+import stat
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(f"usage: {sys.argv[0]} <root> <old-prefix> <new-prefix>", file=sys.stderr)
+        return 2
+
+    root, old_s, new_s = sys.argv[1], sys.argv[2], sys.argv[3]
+    old, new = old_s.encode(), new_s.encode()
+
+    if len(old) != len(new):
+        print(
+            f"prefix length mismatch: {old_s!r} is {len(old)} bytes, "
+            f"{new_s!r} is {len(new)}. They must be equal -- see this script's "
+            f"docstring for why.",
+            file=sys.stderr,
+        )
+        return 1
+
+    files = links = refs = 0
+
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        for name in filenames + dirnames:
+            path = os.path.join(dirpath, name)
+
+            if os.path.islink(path):
+                target = os.readlink(path)
+                if old_s in target:
+                    os.unlink(path)
+                    os.symlink(target.replace(old_s, new_s), path)
+                    links += 1
+                continue
+
+            # Regular files only: skip fifos, sockets, devices.
+            try:
+                st = os.lstat(path)
+            except OSError:
+                continue
+            if not stat.S_ISREG(st.st_mode):
+                continue
+
+            try:
+                with open(path, "rb") as fh:
+                    data = fh.read()
+            except OSError as exc:
+                print(f"warning: cannot read {path}: {exc}", file=sys.stderr)
+                continue
+
+            count = data.count(old)
+            if not count:
+                continue
+
+            mode = stat.S_IMODE(st.st_mode)
+            os.chmod(path, mode | stat.S_IWUSR)
+            try:
+                with open(path, "r+b") as fh:
+                    fh.write(data.replace(old, new))
+            finally:
+                os.chmod(path, mode)
+
+            files += 1
+            refs += count
+
+    print(
+        f"relocate-store: {old_s} -> {new_s}: "
+        f"rewrote {refs} references in {files} files, retargeted {links} symlinks",
+        file=sys.stderr,
+    )
+
+    # Verify: nothing may still name the old store. A leftover reference is a
+    # runtime failure in an environment where the old store does not exist, and
+    # those are miserable to debug from a container that half-works, so fail the
+    # build instead.
+    stragglers = []
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        for name in filenames + dirnames:
+            path = os.path.join(dirpath, name)
+            if os.path.islink(path):
+                if old_s in os.readlink(path):
+                    stragglers.append(path)
+                continue
+            try:
+                if not stat.S_ISREG(os.lstat(path).st_mode):
+                    continue
+                with open(path, "rb") as fh:
+                    if old in fh.read():
+                        stragglers.append(path)
+            except OSError:
+                continue
+
+    if stragglers:
+        print(
+            f"relocate-store: {len(stragglers)} path(s) still reference {old_s}:",
+            file=sys.stderr,
+        )
+        for path in stragglers[:20]:
+            print(f"  {path}", file=sys.stderr)
+        if len(stragglers) > 20:
+            print(f"  ... and {len(stragglers) - 20} more", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Makes the nix-built image usable on a host that owns `/nix` itself — concretely, the pwn.college dojo platform, which is what currently freezes the `public_dojo` course at **v3.0.81**, the last release built from the Dockerfile.

## The problem

Every path in the image is a symlink into `/nix/store`: `/bin/bash`, `/bin/python3`, `/usr/local/bin/penguin`, `/igloo_static`, `/pyplugins`. The platform starts every challenge container with

```python
Mount("/nix", f"{HOST_DATA_PATH}/workspace/nix", "bind", read_only=True)
```

because its own workspace userland lives in that store. That mount shadows ours, and the image doesn't degrade — it disappears.

Reproducible against any normal image in one command:

```console
$ mkdir /tmp/empty
$ docker run --rm -v /tmp/empty:/nix:ro rehosting/penguin:latest penguin --version
docker: Error response from daemon: ... exec: "penguin": executable file not found in $PATH
$ echo $?
127
```

**There is no runtime workaround.** Re-mounting our store over theirs needs `mount`, and that platform runs containers under [moby's default seccomp profile](https://raw.githubusercontent.com/moby/profiles/master/seccomp/default.json), which gates `mount`/`umount2`/`unshare`/`setns`/`pivot_root` behind `CAP_SYS_ADMIN`. Challenge containers get only `SYS_PTRACE`, and a user namespace is blocked the same way. I confirmed this by reading the platform source (`dojo_plugin/api/v1/docker.py`, `dojo_plugin/config.py`) rather than inferring it.

## The fix

`.#portableImage` builds the same image with the closure at `/opt/store` and every reference rewritten.

The replacement prefix is deliberately the **same byte length** as `/nix/store`. That is what makes this tractable rather than a patchelf project: the rewrite happens in place, byte for byte, so ELF `PT_INTERP`/`DT_RUNPATH` strings, compiled-in path constants, shebangs and `.pyc` paths all stay structurally valid without the script understanding any of those formats. `nix/relocate-store.py` fails the build if a single reference to the old store survives — a half-relocated image half-works, which is miserable to debug from a container.

This is the same class of surgery `clang20Slim` already does (copy out of the store, fix up references), applied to the whole closure.

Two structural notes:

- **`contents` cannot be used.** `streamLayeredImage` builds its customisation layer with `symlinkJoin`, which would leave the image a farm of symlinks back into `/nix/store` — exactly what we're escaping. The tree is copied in as real files with `includeStorePaths = false`, which also stops dockerTools from adding a second, shadowed copy of the entire image as a store layer.
- **Cost: one large layer instead of 115.** So this is a variant, not a replacement — prefer the normal image wherever `/nix` is yours. If the pull cost starts to matter, the fix is to relocate each store path in its own derivation and hand dockerTools a pre-relocated layer set.

Publishing is **on demand** (`publish-portable.yaml`, `workflow_dispatch` taking a release tag) for the same reason: sharing no blobs with the normal image, building it per release would add its full compressed size to registry storage for a consumer that pins exact tags and bumps deliberately.

## Verification

Built locally and exercised with `/nix` bind-mounted empty and read-only, exactly as the platform does it:

```
relocate-store: /nix/store -> /opt/store: rewrote 27907 references in 15238 files, retargeted 6387 symlinks
image tarball: 1.745 GB          (normal image: 1.750 GB)
```

| Image | `/nix` intact | `/nix` shadowed |
|---|---|---|
| `:latest` (nix) | v3.1.3 ✓ | **exit 127**, `executable file not found` |
| `:v3.0.81` (pre-nix Docker) | ✓ | ✓ — why the dojo works today |
| `:portable` | ✓ | **✓** |

Inside the shadowed portable container (`ls -A /nix` → empty):

```
penguin      -> /opt/store/…-python3-3.13.12-env/bin/penguin
bash         -> /opt/store/…-bash-interactive-5.3p9/bin/bash
python        3.13.12 penguin import OK
clang-20      clang version 20.1.8
mke2fs        mke2fs 1.47.3
qemu-img      qemu-img version 11.0.50
wget          GNU Wget 1.25.0
fw2tar        OK
igloo_static  27 entries; busybox arches: 11
pyplugins     126 files
apt           apt 2.4.14 (amd64)
```

`igloo_static`'s per-arch busybox and `apt` both matter downstream: the dojo's challenges depend on `/igloo_static/<arch>/busybox`, and every `rehostings`/`examples` Dockerfile starts with `apt-get install`.

All four image outputs evaluate. Note the validated build predates `86a0be51` (igloo_driver repin) on main; that repin is orthogonal to the relocation mechanism, and the eval check was re-run on top of it.

## Not in this PR

The dojo-side rewrite. `public_dojo/dockerfiles/build.sh` still clones penguin and runs `docker build --build-arg KEEP_WHEELS=true`, then repackages `/wheels` into a venv — a path that has no analogue here (no Dockerfile, no `/wheels`, no pip, python 3.13 not 3.10). That is a separate change in that repo, unblocked by this one.
