### PR TITLE
feat: QMP command hook in the QEMU compat layer

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -376,6 +376,37 @@ jobs:
           name: compose-artifacts
           path: ${{ github.workspace }}/tests/integration/compose/compose_projects/
 
+  run_qmp_hook:
+    # The QMP command hook (custom penguin_handle_qmp weak symbol wired into
+    # qemu's qmp_dispatch) is guest- and arch-independent: it boots
+    # libqemu-system-intel64 with -machine none -S and drives a custom QMP
+    # command through the real dispatcher. So it runs once, outside the
+    # per-arch matrix, like run_compose.
+    needs: [changes, build_container]
+    runs-on: rehosting-arc
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.run_tests == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Set up penguin image
+        uses: rehosting/ci/actions/pull-image@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          target: ${{ env.TARGET }}
+          image: rehosting/penguin
+          tag: ${{ github.sha }}
+          local-tag: rehosting/penguin:${{ github.sha }}
+          username: ${{ env.USER }}
+          password: ${{ secrets.REHOSTING_ARC_REGISTRY_PASSWORD || env.EXTERNAL_REGISTRY_PASS }}
+          install-python: "true"
+          install-cert: "false"
+
+      - name: QMP hook test
+        run: timeout 10m python3 $GITHUB_WORKSPACE/tests/integration/qmp_hook/test.py --image rehosting/penguin:${{ github.sha }}
+
   # Single required status check for branch protection + the merge queue.
   #
   # The per-arch run_tests matrix and build_container are conditionally skipped
@@ -389,7 +420,7 @@ jobs:
   ci_gate:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [changes, lint, unit_tests, build_container, run_tests, run_compose]
+    needs: [changes, lint, unit_tests, build_container, run_tests, run_compose, run_qmp_hook]
     steps:
       - name: Require no gated job to have failed
         run: |
@@ -400,6 +431,7 @@ jobs:
             [build_container]='${{ needs.build_container.result }}'
             [run_tests]='${{ needs.run_tests.result }}'
             [run_compose]='${{ needs.run_compose.result }}'
+            [run_qmp_hook]='${{ needs.run_qmp_hook.result }}'
           )
           ok=true
           for job in "${!r[@]}"; do

--- a/flake.lock
+++ b/flake.lock
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783015421,
-        "narHash": "sha256-Yeid2H11Zbl83pq2McszobFZ634gVwh8gEaSjOGyiAM=",
+        "lastModified": 1786566186,
+        "narHash": "sha256-xwcZg2JtDwmjDZl05g6maR3ndnxTQORk1NdvMvE3ecE=",
         "owner": "rehosting",
         "repo": "qemu",
-        "rev": "3795e4c1ed1600c54688853ed9609f68e5c50b64",
+        "rev": "b853deff4cf6fed5e23dc5135160a118c5b825c3",
         "type": "github"
       },
       "original": {

--- a/pyplugins/apis/qmp.py
+++ b/pyplugins/apis/qmp.py
@@ -1,0 +1,203 @@
+"""
+QMP command API plugin.
+
+Owns the mapping of custom QMP command names to Python handlers, mirroring
+:class:`apis.hypercall.Hypercall`. ``qemu_compat`` installs a single C-level
+QMP trampoline and forwards each unrecognized QMP command here; this plugin
+resolves the command name to a registered handler and marshals the result.
+
+The C trampoline is installed **lazily**: it is wired up only when the first
+command is registered (usually in a consumer plugin's ``__init__``), so a
+loaded-but-unused Qmp plugin never touches the QEMU callback.
+
+This plugin is **opt-in**: unlike ``Hypercall`` it is not loaded automatically.
+List ``qmp`` in the config ``plugins`` to enable it. On load it opens a QMP
+socket for QEMU itself -- it appends ``-qmp unix:<outdir>/qmp.sock,...`` to the
+QEMU argv (which penguin has assembled but not yet launched) -- so no
+``penguin_run``/config-schema change is needed. The socket path can be
+overridden with the ``socket`` arg; ``server``/``nowait`` keep QEMU from
+blocking on a client.
+
+Registration reads like every other plugin-facing capability::
+
+    from penguin import plugins
+
+    @plugins.qmp.command("penguin-snapshot-save")
+    def save(args):
+        plugins.snapshot.save(args["name"])
+        return {"saved": args["name"]}
+
+A handler receives the decoded ``arguments`` object (a dict) and returns one
+of:
+
+  * ``None`` / ``False`` -- decline the command. If no handler claims it,
+    QEMU reports ``CommandNotFound``.
+  * ``True`` -- handled, empty ``{"return": {}}`` response.
+  * any JSON-serializable object -- used as the QMP ``return`` value.
+
+Handler contract / caveats
+--------------------------
+
+* Handlers run **on the QEMU main loop with the BQL held** (QMP dispatch is
+  not in guest context). A handler that blocks waiting on the guest freezes
+  timers and I/O -- keep them short and non-blocking.
+* Because dispatch is on the main loop rather than in a guest hypercall,
+  guest-memory access via the portal (``yield from plugins.mem.read_*``) is
+  **not** serviceable here. A handler that returns a generator is rejected
+  explicitly (logged) rather than silently failing to serialize.
+* The current QEMU ABI (``penguin_qmp_cb_t``) can only express "handled +
+  result string" or "not handled". It cannot carry a structured
+  ``{"error": {...}}``, so a handler that raises or returns a non-serializable
+  value is reported to the client as ``CommandNotFound`` (with the real cause
+  logged host-side). A dedicated error out-param in the QEMU fork
+  (``char **error``) would let a handler surface a real ``GenericError``; that
+  ABI change is intentionally deferred so nothing depends on it yet.
+"""
+import os
+from collections.abc import Iterator
+from typing import Any, Callable, Dict
+
+from penguin import Plugin, PluginArgs
+from pydantic import Field
+
+
+class Qmp(Plugin):
+    """QMP custom-command registry (host-side control plane).
+
+    Replaces the compat layer's single global ``cb_qmp`` handler with a
+    proper registry so multiple plugins can each own distinct QMP commands.
+    """
+
+    class Args(PluginArgs):
+        socket: str = Field(
+            default="qmp.sock",
+            description=(
+                "QMP UNIX socket path. Relative paths resolve under the run's "
+                "results dir (outdir)."
+            ),
+        )
+
+    def __init__(self) -> None:
+        # command name -> handler. One handler per command; a second
+        # registration for the same name is a hard error (see register()).
+        self.handlers: Dict[str, Callable] = {}
+        self.qemu_compats = []
+        # Open a QMP socket for QEMU by appending to the argv penguin has
+        # assembled but not yet launched (plugin __init__ runs before
+        # panda.run()). This keeps the feature reachable purely by loading the
+        # plugin -- no penguin_run.py / config-schema change.
+        self._open_qmp_socket()
+        self._bind_active_qemu_compats()
+
+    def _open_qmp_socket(self) -> None:
+        # Tolerate standalone construction (e.g. unit tests) where the plugin
+        # manager hasn't run __preinit__, so self.panda/get_arg/logger are unset.
+        panda = getattr(self, "panda", None)
+        args = getattr(panda, "panda_args", None)
+        if args is None:
+            return
+        if "-qmp" in args:
+            # Respect an already-configured QMP socket (e.g. extra_qemu_args).
+            self.logger.info("QMP socket already configured; not adding one")
+            return
+
+        sock = self.get_arg("socket") or "qmp.sock"
+        outdir = self.get_arg("outdir")
+        if not os.path.isabs(sock) and outdir:
+            sock = os.path.join(outdir, sock)
+        self.sock_path = sock
+        args += ["-qmp", f"unix:{sock},server,nowait"]
+        self.logger.info("QMP socket at %s", sock)
+
+    def _bind_active_qemu_compats(self) -> None:
+        try:
+            from compat.qemu_compat import QemuCompat
+        except Exception:
+            try:
+                from pyplugins.compat.qemu_compat import QemuCompat
+            except Exception:
+                return
+
+        for qemu_compat in QemuCompat.active_instances():
+            self.bind_qemu_compat(qemu_compat)
+
+    def bind_qemu_compat(self, qemu_compat) -> None:
+        """Attach to a QemuCompat instance.
+
+        The C-level QMP trampoline is installed lazily -- only once at least one
+        command is registered (see register()). Binding a compat that already
+        has commands to serve installs immediately; otherwise it waits, so a
+        loaded-but-unused Qmp plugin never touches the QEMU callback.
+        """
+        if qemu_compat not in self.qemu_compats:
+            self.qemu_compats.append(qemu_compat)
+        if self.handlers:
+            self._install_dispatch(qemu_compat)
+
+    def _install_dispatch(self, qemu_compat) -> None:
+        install = getattr(qemu_compat, "install_qmp_dispatch", None)
+        if install is not None:
+            install(self)
+
+    def register(self, name: str, func: Callable) -> Callable:
+        """Register ``func`` as the handler for QMP command ``name``.
+
+        Raises if ``name`` is already registered: silently replacing a handler
+        (the old compat-layer behavior) means the second plugin to register
+        would knock the first offline with no warning.
+        """
+        name = str(name)
+        existing = self.handlers.get(name)
+        if existing is not None and existing is not func:
+            raise ValueError(
+                f"QMP command {name!r} is already registered by "
+                f"{getattr(existing, '__qualname__', existing)!r}; "
+                "command names must be unique across plugins"
+            )
+        first_command = not self.handlers
+        self.handlers[name] = func
+        # Lazy: the first registered command installs the C trampoline on every
+        # bound QemuCompat. Registering more commands is then a no-op install
+        # (install_qmp_dispatch is idempotent).
+        if first_command:
+            for qemu_compat in self.qemu_compats:
+                self._install_dispatch(qemu_compat)
+        return func
+
+    def command(self, name: str) -> Callable[[Callable], Callable]:
+        """Decorator: register the wrapped function for QMP command ``name``."""
+        def decorator(func: Callable) -> Callable:
+            return self.register(name, func)
+        return decorator
+
+    def __call__(self, name: str) -> Callable[[Callable], Callable]:
+        return self.command(name)
+
+    def _run_result(self, command: str, result: Any) -> Any:
+        """Reject generator handlers with a clear error.
+
+        Guest-memory access via the portal isn't serviceable from the QMP
+        main-loop context, so a handler that ``yield from plugins.mem.*``
+        cannot work here. Fail loudly instead of letting ``json.dumps`` choke
+        on a generator and surface as ``CommandNotFound``.
+        """
+        if isinstance(result, Iterator):
+            raise RuntimeError(
+                f"QMP handler for {command!r} returned a generator; guest "
+                "portal access is not serviceable from QMP main-loop context"
+            )
+        return result
+
+    def dispatch(self, command: str, args: Any) -> Any:
+        """Resolve and invoke the handler for ``command``.
+
+        Returns the handler's result (None/False/True/JSON-able object) for
+        the compat trampoline to marshal, or None if no handler is registered
+        (so QEMU reports CommandNotFound). Handler exceptions propagate to the
+        trampoline, which logs and declines.
+        """
+        handler = self.handlers.get(command)
+        if handler is None:
+            return None
+        result = handler(args)
+        return self._run_result(command, result)

--- a/pyplugins/compat/qemu_compat.py
+++ b/pyplugins/compat/qemu_compat.py
@@ -81,6 +81,11 @@ int penguin_write_guest_reg(CPUState *cs, int regnum, const uint8_t *buf,
                             int len);
 void *penguin_cpu_env(CPUState *cs);
 void penguin_sync_cpu_state(CPUState *cs);
+typedef bool (*penguin_qmp_cb_t)(const char *command, const char *args,
+                                 char **result, void *opaque);
+void set_penguin_qmp_callback(penguin_qmp_cb_t cb, void *opaque);
+bool penguin_handle_qmp(const char *command, const char *args, char **result);
+char *strdup(const char *s);
 """
 
 # Alternate spellings under which a QEMU build may have published its
@@ -594,6 +599,18 @@ class QemuCompat:
                 "penguin_mmio_read_cb_t read_cb, "
                 "penguin_mmio_write_cb_t write_cb, void *opaque);\n"
             )
+        if "penguin_qmp_cb_t" not in cdef_source:
+            cdef_source += (
+                "\ntypedef bool (*penguin_qmp_cb_t)(const char *command, "
+                "const char *args, char **result, void *opaque);\n"
+            )
+        if "set_penguin_qmp_callback" not in cdef_source:
+            cdef_source += (
+                "\nvoid set_penguin_qmp_callback("
+                "penguin_qmp_cb_t cb, void *opaque);\n"
+            )
+        if "char *strdup" not in cdef_source:
+            cdef_source += "\nchar *strdup(const char *s);\n"
         self.ffi.cdef(cdef_source)
 
         flags = getattr(os, "RTLD_GLOBAL", 0) | getattr(os, "RTLD_NOW", 0)
@@ -617,6 +634,8 @@ class QemuCompat:
         self.arch = QemuArch(self)
         self._thread_state = threading.local()
         self._pre_shutdown_cb = None
+        self._qmp_callback = None
+        self._bound_qmp_plugin = None
         self.panda_args = []
 
         self._active_instances.append(self)
@@ -624,6 +643,16 @@ class QemuCompat:
         plugin = self.hypercall_plugin
         if plugin is not None:
             self.bind_hypercall_plugin(plugin)
+        qmp_plugin = self.qmp_plugin
+        if qmp_plugin is not None:
+            # Let the plugin decide whether to install now: it binds this
+            # instance and installs the C trampoline lazily, only if it already
+            # has commands registered.
+            bind = getattr(qmp_plugin, "bind_qemu_compat", None)
+            if bind is not None:
+                bind(self)
+            else:
+                self.install_qmp_dispatch(qmp_plugin)
 
     def _callback_state(self):
         state = self._thread_state
@@ -845,6 +874,83 @@ class QemuCompat:
     def cb_pre_shutdown(self, f):
         self._pre_shutdown_cb = f
         return f
+
+    @property
+    def qmp_plugin(self):
+        if self._bound_qmp_plugin is not None:
+            return self._bound_qmp_plugin
+
+        try:
+            from penguin import plugins
+        except ImportError:
+            return None
+
+        plugin = plugins.__dict__.get("qmp")
+        if plugin is not None:
+            return plugin
+
+        try:
+            return plugins.qmp
+        except Exception:
+            return None
+
+    def install_qmp_dispatch(self, plugin):
+        """Bind the Qmp pyplugin and install the single C-level QMP trampoline.
+
+        The plugin owns the command name -> handler registry; the compat layer
+        only forwards unrecognized QMP commands to it (mirroring how the
+        hypercall trampoline forwards to the Hypercall plugin). Idempotent: the
+        C callback is installed once and re-binding just updates the plugin.
+        """
+        self._bound_qmp_plugin = plugin
+
+        setter = self._lib_symbol("set_penguin_qmp_callback")
+        if setter is None:
+            logger.warning(
+                "QEMU library does not expose set_penguin_qmp_callback; "
+                "custom QMP commands require a rebuilt penguin-qemu")
+            return
+        if self._qmp_callback is None:
+            ctype = "bool(const char *, const char *, char **, void *)"
+            self._qmp_callback = self.ffi.callback(ctype)(self._dispatch_qmp)
+            setter(self._qmp_callback, self.ffi.NULL)
+
+    def _dispatch_qmp(self, command_ptr, args_ptr, result_ptr, opaque=None):
+        # command_ptr/args_ptr are C strings; decode up front so log lines show
+        # the command name (not "<cdata 'char *'>").
+        command = self.ffi.string(command_ptr).decode("utf-8", "replace")
+        plugin = self.qmp_plugin
+        if plugin is None:
+            return False
+        try:
+            raw_args = self.ffi.string(args_ptr).decode("utf-8", "replace")
+            try:
+                args = json.loads(raw_args) if raw_args else {}
+            except json.JSONDecodeError:
+                args = {}
+            outcome = plugin.dispatch(command, args)
+        except Exception:
+            # The current QMP ABI (bool + result string) can't carry a
+            # structured error, so a failing handler is reported to the client
+            # as CommandNotFound. Log the real cause host-side.
+            logger.exception("QMP handler for %r raised", command)
+            return False
+        if outcome is None or outcome is False:
+            return False
+        if outcome is not True:
+            try:
+                payload = json.dumps(outcome).encode("utf-8")
+            except (TypeError, ValueError):
+                logger.exception(
+                    "QMP handler for %r returned non-serializable result",
+                    command)
+                return False
+            # Ownership of the returned buffer transfers to QEMU, which
+            # g_free()s it after decoding. glib's g_free is compatible with
+            # the system allocator, so a libc strdup() buffer is correct; a
+            # cffi-managed ffi.new() buffer would be GC-freed underneath QEMU.
+            result_ptr[0] = self.lib.strdup(payload)
+        return True
 
     def _guest_addr(self, addr):
         mask = (1 << self.bits) - 1

--- a/tests/integration/qmp_hook/patch.yaml
+++ b/tests/integration/qmp_hook/patch.yaml
@@ -1,0 +1,31 @@
+core:
+  # Bound the run: the host-side probe drives QMP and writes the marker;
+  # verifier.continuous_eval ends the run on success, this is the backstop.
+  timeout: 180
+
+env:
+  # Empty busybox rootfs has no init: idle so the guest stays up long enough
+  # for the host-side probe to connect over QMP. The probe is entirely
+  # host-side, so the guest need not do anything else.
+  igloo_init: /init.sh
+
+static_files:
+  /init.sh:
+    type: inline_file
+    mode: 73  # 0o111 (as in basic_target's init.sh)
+    contents: |
+      #!/igloo/utils/sh
+      /busybox sleep 120
+
+plugins:
+  # Loading the qmp plugin opens the QMP socket itself (appends -qmp to the
+  # QEMU argv) and installs the command trampoline -- no core knob needed.
+  qmp: {}
+  qmp_probe: {}
+  verifier:
+    continuous_eval: true
+    conditions:
+      qmp_probe_ok:
+        type: file_contains
+        file: qmp_probe_result
+        string: "qmp-probe-ok"

--- a/tests/integration/qmp_hook/qmp_probe.py
+++ b/tests/integration/qmp_hook/qmp_probe.py
@@ -1,0 +1,107 @@
+"""
+QMP integration-test probe plugin.
+
+A project-local pyplugin that exercises the full QMP command hook through a
+real ``penguin run``:
+
+  1. registers a custom QMP command (``penguin-qmp-probe``) via the ``qmp``
+     plugin, and
+  2. from a background host thread, connects to the QMP socket that
+     ``core.qmp: true`` opened at ``<results>/qmp.sock``, negotiates
+     capabilities, sends the custom command, and -- if the JSON round-trips --
+     writes a marker file the ``verifier`` plugin checks.
+
+This is deliberately end-to-end: the command travels the real path
+(client -> qemu qmp_dispatch -> weak penguin_handle_qmp -> CFFI trampoline ->
+Qmp plugin -> handler -> strdup'd JSON -> qemu decode/g_free -> client), driven
+by penguin rather than a hand-built KVMQemu.
+"""
+import json
+import os
+import socket
+import threading
+import time
+
+from penguin import plugins, Plugin
+
+PROBE_CMD = "penguin-qmp-probe"
+DECLINED_CMD = "penguin-qmp-not-registered"
+MARKER_NAME = "qmp_probe_result"
+PROBE_ARGS = {"a": 1, "b": "two", "nested": {"x": [1, 2, 3]}}
+
+
+class QmpProbe(Plugin):
+    def __init__(self) -> None:
+        self.outdir = self.get_arg("outdir")
+
+        @plugins.qmp.command(PROBE_CMD)
+        def handle(args):
+            return {"echo": args, "ok": True}
+
+        self._thread = threading.Thread(target=self._probe, daemon=True)
+        self._thread.start()
+
+    def _recv_json(self, stream):
+        line = stream.readline()
+        if not line:
+            raise AssertionError("QMP connection closed unexpectedly")
+        return json.loads(line.decode())
+
+    def _probe(self) -> None:
+        sock_path = os.path.join(self.outdir, "qmp.sock")
+
+        # Wait for QEMU to create the QMP socket, then for it to accept.
+        deadline = time.time() + 60
+        sock = None
+        while time.time() < deadline:
+            if os.path.exists(sock_path):
+                try:
+                    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    sock.connect(sock_path)
+                    break
+                except OSError:
+                    sock = None
+            time.sleep(0.2)
+        if sock is None:
+            self.logger.error("QMP socket never became connectable: %s", sock_path)
+            return
+
+        try:
+            stream = sock.makefile("rwb", buffering=0)
+
+            def send(obj):
+                stream.write((json.dumps(obj) + "\n").encode())
+
+            greeting = self._recv_json(stream)
+            assert "QMP" in greeting, f"unexpected QMP greeting: {greeting!r}"
+            send({"execute": "qmp_capabilities"})
+            caps = self._recv_json(stream)
+            assert caps.get("return") == {}, f"qmp_capabilities failed: {caps!r}"
+
+            # 1. Handled command: arguments + return value round-trip.
+            send({"execute": PROBE_CMD, "arguments": PROBE_ARGS})
+            resp = self._recv_json(stream)
+            self.logger.info("QMP probe response: %s", resp)
+            expected = {"echo": PROBE_ARGS, "ok": True}
+            assert resp.get("return") == expected, (
+                f"probe did not round-trip: got {resp!r}, want return={expected!r}"
+            )
+
+            # 2. Unregistered command still yields CommandNotFound.
+            send({"execute": DECLINED_CMD})
+            resp2 = self._recv_json(stream)
+            self.logger.info("QMP declined response: %s", resp2)
+            assert "error" in resp2 and resp2["error"].get("class") == "CommandNotFound", (
+                f"unregistered command should be CommandNotFound, got {resp2!r}"
+            )
+        except Exception:
+            self.logger.exception("QMP probe failed")
+            return
+        finally:
+            sock.close()
+
+        # Success: write the marker the verifier checks.
+        marker = os.path.join(self.outdir, MARKER_NAME)
+        with open(marker, "w") as f:
+            f.write("qmp-probe-ok")
+        self.logger.info("QMP probe passed; wrote marker %s", marker)

--- a/tests/integration/qmp_hook/test.py
+++ b/tests/integration/qmp_hook/test.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""End-to-end integration test for the Penguin QMP command hook.
+
+This drives the feature through a real ``penguin run`` (init -> run), the same
+way the other integration tests do, rather than hand-building a KVMQemu. That
+is the point: if the feature can't be reached from ``penguin`` with a config
+knob and a plugin, then something user-facing is missing.
+
+The project loads the ``qmp`` plugin (which opens a QMP socket at
+``<results>/qmp.sock`` by appending to the QEMU argv, and installs the command
+trampoline) plus a project-local ``qmp_probe`` plugin. ``qmp_probe`` registers a
+custom QMP command via
+``plugins.qmp.command`` and, from a host thread, connects to that socket and
+sends the command -- exercising the full path:
+
+    client -> qemu qmp_dispatch -> weak penguin_handle_qmp -> CFFI trampoline
+      -> Qmp plugin -> handler -> strdup'd JSON -> qemu decode/g_free -> client
+
+On success it writes a marker file that the ``verifier`` plugin checks; the run
+ends when the condition passes (``continuous_eval``). The test then asserts the
+marker is present.
+
+Arch-independent (QMP dispatch is host-side, not guest/arch specific), so it
+runs once on x86_64 like the compose test rather than across the arch matrix.
+"""
+import logging
+from pathlib import Path
+import shutil
+import subprocess
+
+import click
+import yaml
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("penguin.tests.qmp")
+
+TEST_DIR = Path(__file__).resolve().parent
+PENGUIN = str(TEST_DIR.parent.parent.parent / "penguin")
+FS_DIR = TEST_DIR / "fs"
+MARKER_NAME = "qmp_probe_result"
+
+
+def run_cmd(cmd, **kwargs):
+    logger.info(f"Running command: {cmd}")
+    return subprocess.check_output(cmd, **kwargs)
+
+
+def _penguin(image, *args):
+    log = TEST_DIR / "test_log.txt"
+    try:
+        subprocess.run(
+            " ".join([PENGUIN, "--image", image, *args]),
+            cwd=TEST_DIR,
+            shell=True,
+            check=True,
+            stdout=open(log, "w"),
+            stderr=subprocess.STDOUT,
+        )
+    except subprocess.CalledProcessError:
+        logger.error("penguin %s failed; tail of %s:", args[0], log)
+        subprocess.run(["tail", "-n", "200", str(log)])
+        raise
+
+
+def run_test(arch, image):
+    FS_DIR.mkdir(exist_ok=True)
+    # Minimal rootfs: just busybox from the image (mirrors basic_target).
+    cid = run_cmd(f"docker create {image}", shell=True).decode().strip()
+    run_cmd(
+        f"docker cp -L {cid}:/igloo_static/utils.bin/busybox.{arch} {FS_DIR}/busybox",
+        shell=True,
+    )
+    run_cmd(f"docker rm -v {cid}", shell=True)
+    (FS_DIR / "bin").mkdir(exist_ok=True)
+    run_cmd(f"tar -czf {TEST_DIR}/qmp_fs.tar.gz -C {FS_DIR} .", shell=True)
+
+    _penguin(image, "init", f"{TEST_DIR}/qmp_fs.tar.gz", "--force")
+
+    project_path = TEST_DIR / "projects" / "qmp_fs"
+
+    # Ship the project-local qmp_probe plugin.
+    (project_path / "plugins").mkdir(parents=True, exist_ok=True)
+    shutil.copy(TEST_DIR / "qmp_probe.py", project_path / "plugins" / "qmp_probe.py")
+
+    # Layer our knobs via a patch (patches win over the generated base configs;
+    # editing config.yaml directly gets clobbered by base.yaml). patch.yaml sets
+    # an idle init and loads qmp + qmp_probe + verifier.
+    shutil.copy(TEST_DIR / "patch.yaml", project_path / "patch.yaml")
+    config = str(project_path / "config.yaml")
+    with open(config) as f:
+        conf = yaml.safe_load(f)
+    conf.setdefault("patches", []).append("patch.yaml")
+    conf["core"]["kernel"] = "6.13"
+    with open(config, "w") as f:
+        yaml.dump(conf, f, sort_keys=False)
+
+    _penguin(image, "run", config)
+
+    marker = project_path / "results" / "latest" / MARKER_NAME
+    if not marker.exists():
+        latest = project_path / "results" / "latest"
+        console = latest / "console.log"
+        if console.exists():
+            logger.error("--- console.log tail ---")
+            for line in console.read_text(errors="replace").splitlines()[-60:]:
+                logger.error(line)
+        raise AssertionError(f"QMP probe marker not written: {marker}")
+    contents = marker.read_text()
+    if "qmp-probe-ok" not in contents:
+        raise AssertionError(f"QMP probe marker unexpected contents: {contents!r}")
+
+    logger.info("QMP hook integration test PASSED")
+
+
+@click.command()
+@click.option("--arch", "-a", default="x86_64")
+@click.option("--image", "-i", default="rehosting/penguin:latest")
+def test(arch, image):
+    try:
+        run_test(arch, image)
+    finally:
+        run_cmd(
+            f"rm -rf {TEST_DIR}/projects {FS_DIR} {TEST_DIR}/qmp_fs.tar.gz "
+            f"{TEST_DIR}/test_log.txt",
+            shell=True,
+        )
+
+
+if __name__ == "__main__":
+    test()

--- a/tests/unit/test_kvm_logic.py
+++ b/tests/unit/test_kvm_logic.py
@@ -1,3 +1,4 @@
+import json
 import os
 import importlib.util
 import sys
@@ -22,6 +23,14 @@ _hypercall_spec = importlib.util.spec_from_file_location(
 _hypercall_module = importlib.util.module_from_spec(_hypercall_spec)
 _hypercall_spec.loader.exec_module(_hypercall_module)
 Hypercall = _hypercall_module.Hypercall
+
+_qmp_spec = importlib.util.spec_from_file_location(
+    "penguin_test_qmp",
+    Path(__file__).resolve().parents[2] / "pyplugins" / "apis" / "qmp.py",
+)
+_qmp_module = importlib.util.module_from_spec(_qmp_spec)
+_qmp_spec.loader.exec_module(_qmp_module)
+Qmp = _qmp_module.Qmp
 
 
 class FakeHypercallPlugin:
@@ -61,6 +70,20 @@ def fake_plugins_hypercall(hypercall):
             del plugins.__dict__["hypercall"]
         else:
             plugins.__dict__["hypercall"] = original
+
+
+@contextmanager
+def fake_plugins_qmp(qmp):
+    sentinel = object()
+    original = plugins.__dict__.get("qmp", sentinel)
+    plugins.__dict__["qmp"] = qmp
+    try:
+        yield
+    finally:
+        if original is sentinel:
+            del plugins.__dict__["qmp"]
+        else:
+            plugins.__dict__["qmp"] = original
 
 
 class TestHypercallRegistry(unittest.TestCase):
@@ -235,6 +258,264 @@ class TestKVMQemu(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             qemu.virtual_memory_read(qemu.ffi.NULL, 0, 1, fmt="ptrlist")
+
+
+class TestQmpCallback(unittest.TestCase):
+    """Branch coverage for QemuCompat._dispatch_qmp (the QMP command hook).
+
+    The compat layer only marshals: it decodes command/args, forwards to the
+    bound Qmp plugin's dispatch(), and encodes the result. Registration and the
+    name->handler map live in the Qmp plugin (see TestQmpRegistry). The
+    end-to-end wiring (qemu's qmp_dispatch -> weak penguin_handle_qmp -> CFFI
+    trampoline -> plugin) is exercised by tests/integration/qmp_hook/.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.lib_path = Path(self.tmpdir.name) / "libqemu-kvm-x86_64.so"
+        self.header_path = Path(self.tmpdir.name) / "qemu_cffi_kvm_x86_64.h"
+        self.lib_path.write_text("fake")
+        self.header_path.write_text(MINIMAL_CDEF)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _fake_lib(self):
+        lib = MagicMock()
+        lib.set_kvm_penguin_hypercall_callback = MagicMock()
+        lib.set_penguin_guest_hypercall_callback = MagicMock()
+        lib.set_kvm_penguin_after_guest_init_callback = MagicMock()
+        lib.set_penguin_qmp_callback = MagicMock()
+        return lib
+
+    def _make_qemu(self, mock_dlopen):
+        mock_dlopen.return_value = self._fake_lib()
+        qemu = KVMQemu(str(self.lib_path), "x86_64", header_path=str(self.header_path))
+
+        # _dispatch_qmp writes result_ptr[0] = self.lib.strdup(payload). Model
+        # strdup with a real cffi buffer and keep references alive so the test
+        # can read the JSON back out (a MagicMock would return a Mock, not a
+        # readable char*).
+        self._strdup_bufs = []
+
+        def fake_strdup(data):
+            buf = qemu.ffi.new("char[]", data)
+            self._strdup_bufs.append(buf)
+            return buf
+
+        qemu.lib.strdup = fake_strdup
+        return qemu
+
+    def _ptrs(self, qemu, command, args_json):
+        command_ptr = qemu.ffi.new("char[]", command.encode())
+        args_ptr = qemu.ffi.new("char[]", args_json.encode())
+        result_ptr = qemu.ffi.new("char *[1]")
+        # Hold refs so the input buffers aren't GC'd during the call.
+        self._input_bufs = (command_ptr, args_ptr)
+        return command_ptr, args_ptr, result_ptr
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_install_qmp_dispatch_installs_callback(self, mock_dlopen):
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+        qemu.install_qmp_dispatch(qmp)
+        self.assertIs(qemu._bound_qmp_plugin, qmp)
+        self.assertTrue(qemu.lib.set_penguin_qmp_callback.called)
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_bind_without_commands_does_not_install(self, mock_dlopen):
+        # Lazy: binding a Qmp plugin that has no commands registered must not
+        # touch the QEMU callback.
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+        qmp.bind_qemu_compat(qemu)
+        self.assertIn(qemu, qmp.qemu_compats)
+        self.assertFalse(qemu.lib.set_penguin_qmp_callback.called)
+        self.assertIsNone(qemu._bound_qmp_plugin)
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_first_command_installs_callback(self, mock_dlopen):
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+        qmp.bind_qemu_compat(qemu)
+        self.assertFalse(qemu.lib.set_penguin_qmp_callback.called)
+
+        qmp.command("cmd-a")(lambda args: 1)
+        self.assertTrue(qemu.lib.set_penguin_qmp_callback.called)
+        self.assertIs(qemu._bound_qmp_plugin, qmp)
+
+        # A second command must not re-install (idempotent).
+        qemu.lib.set_penguin_qmp_callback.reset_mock()
+        qmp.command("cmd-b")(lambda args: 2)
+        self.assertFalse(qemu.lib.set_penguin_qmp_callback.called)
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_no_handler_declines(self, mock_dlopen):
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+        with fake_plugins_qmp(qmp):
+            cmd, args, res = self._ptrs(qemu, "anything", "{}")
+            self.assertFalse(qemu._dispatch_qmp(cmd, args, res))
+        self.assertEqual(res[0], qemu.ffi.NULL)
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_handler_returns_none_declines(self, mock_dlopen):
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+        qmp.command("cmd")(lambda args: None)
+        with fake_plugins_qmp(qmp):
+            cmd, args, res = self._ptrs(qemu, "cmd", "{}")
+            self.assertFalse(qemu._dispatch_qmp(cmd, args, res))
+        self.assertEqual(res[0], qemu.ffi.NULL)
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_handler_returns_false_declines(self, mock_dlopen):
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+        qmp.command("cmd")(lambda args: False)
+        with fake_plugins_qmp(qmp):
+            cmd, args, res = self._ptrs(qemu, "cmd", "{}")
+            self.assertFalse(qemu._dispatch_qmp(cmd, args, res))
+        self.assertEqual(res[0], qemu.ffi.NULL)
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_handler_returns_true_empty_response(self, mock_dlopen):
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+        qmp.command("cmd")(lambda args: True)
+        with fake_plugins_qmp(qmp):
+            cmd, args, res = self._ptrs(qemu, "cmd", "{}")
+            # True -> handled, no result buffer (empty {} supplied by C).
+            self.assertTrue(qemu._dispatch_qmp(cmd, args, res))
+        self.assertEqual(res[0], qemu.ffi.NULL)
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_handler_returns_object_roundtrips(self, mock_dlopen):
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+        seen = {}
+
+        @qmp.command("mycmd")
+        def handler(args):
+            seen["args"] = args
+            return {"echo": args, "ok": True}
+
+        with fake_plugins_qmp(qmp):
+            cmd, args, res = self._ptrs(
+                qemu, "mycmd", json.dumps({"a": 1, "b": "two"}))
+            self.assertTrue(qemu._dispatch_qmp(cmd, args, res))
+            self.assertNotEqual(res[0], qemu.ffi.NULL)
+            payload = json.loads(qemu.ffi.string(res[0]).decode())
+        self.assertEqual(payload, {"echo": {"a": 1, "b": "two"}, "ok": True})
+        # Decoded args are passed through to the handler.
+        self.assertEqual(seen["args"], {"a": 1, "b": "two"})
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_empty_args_decode_to_dict(self, mock_dlopen):
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+        seen = {}
+        qmp.command("cmd")(lambda args: seen.setdefault("args", args) or True)
+        with fake_plugins_qmp(qmp):
+            cmd, args, res = self._ptrs(qemu, "cmd", "")
+            self.assertTrue(qemu._dispatch_qmp(cmd, args, res))
+        self.assertEqual(seen["args"], {})
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_garbage_args_decode_to_dict(self, mock_dlopen):
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+        seen = {}
+        qmp.command("cmd")(lambda args: seen.setdefault("args", args) or True)
+        with fake_plugins_qmp(qmp):
+            cmd, args, res = self._ptrs(qemu, "cmd", "not-json{{")
+            self.assertTrue(qemu._dispatch_qmp(cmd, args, res))
+        self.assertEqual(seen["args"], {})
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_non_serializable_result_declines(self, mock_dlopen):
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+        qmp.command("cmd")(lambda args: {"bad": object()})
+        with fake_plugins_qmp(qmp):
+            cmd, args, res = self._ptrs(qemu, "cmd", "{}")
+            # json.dumps raises TypeError -> not handled. The compat layer logs
+            # the failure via logger.exception; silence it for clean output.
+            with self.assertLogs("pyplugins.qemu_compat", level="ERROR"):
+                self.assertFalse(qemu._dispatch_qmp(cmd, args, res))
+        self.assertEqual(res[0], qemu.ffi.NULL)
+
+    @patch.object(cffi.FFI, "dlopen")
+    def test_handler_exception_declines(self, mock_dlopen):
+        qemu = self._make_qemu(mock_dlopen)
+        qmp = Qmp()
+
+        def boom(args):
+            raise RuntimeError("handler blew up")
+
+        qmp.command("cmd")(boom)
+        with fake_plugins_qmp(qmp):
+            cmd, args, res = self._ptrs(qemu, "cmd", "{}")
+            with self.assertLogs("pyplugins.qemu_compat", level="ERROR"):
+                self.assertFalse(qemu._dispatch_qmp(cmd, args, res))
+        self.assertEqual(res[0], qemu.ffi.NULL)
+
+
+class TestQmpRegistry(unittest.TestCase):
+    """Registration semantics owned by the Qmp plugin (no QEMU library needed)."""
+
+    def test_command_decorator_registers(self):
+        qmp = Qmp()
+
+        @qmp.command("penguin-test")
+        def handler(args):
+            return {"ok": True}
+
+        self.assertIs(qmp.handlers["penguin-test"], handler)
+
+    def test_two_commands_both_dispatch(self):
+        # The concrete bug the plugin fixes: a second registration used to
+        # silently replace the first via a single global handler. With a real
+        # registry, two distinct commands both keep answering.
+        qmp = Qmp()
+        qmp.command("cmd-a")(lambda args: {"who": "a"})
+        qmp.command("cmd-b")(lambda args: {"who": "b"})
+
+        self.assertEqual(qmp.dispatch("cmd-a", {}), {"who": "a"})
+        self.assertEqual(qmp.dispatch("cmd-b", {}), {"who": "b"})
+
+    def test_duplicate_command_raises(self):
+        qmp = Qmp()
+        qmp.command("dup")(lambda args: 1)
+        with self.assertRaises(ValueError):
+            qmp.command("dup")(lambda args: 2)
+
+    def test_reregister_same_func_is_idempotent(self):
+        qmp = Qmp()
+
+        def handler(args):
+            return 1
+
+        qmp.register("cmd", handler)
+        qmp.register("cmd", handler)  # same func, no error
+        self.assertIs(qmp.handlers["cmd"], handler)
+
+    def test_unregistered_command_returns_none(self):
+        qmp = Qmp()
+        self.assertIsNone(qmp.dispatch("nope", {}))
+
+    def test_generator_result_rejected(self):
+        # Guest portal access isn't serviceable from QMP main-loop context, so
+        # a generator handler is a hard error rather than a confusing
+        # CommandNotFound after json.dumps chokes.
+        qmp = Qmp()
+
+        def gen_handler(args):
+            yield 1
+
+        qmp.command("gen")(gen_handler)
+        with self.assertRaises(RuntimeError):
+            qmp.dispatch("gen", {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Expose the new QEMU penguin_qmp_cb_t hook to plugins via QemuCompat.cb_qmp: register a handler that is invoked for custom QMP commands not known to QEMU. The handler receives (command, args) with args decoded from JSON; returning None/False declines (QEMU reports CommandNotFound), True yields an empty {"return": {}}, and any JSON-serializable object becomes the QMP return value. The result buffer is strdup'd so QEMU's g_free consumes it correctly.

Add coverage on both layers:
  * tests/unit/test_kvm_logic.py: TestQmpCallback exercises every branch of _dispatch_qmp (decline/empty/object results, arg decoding, and the non-serializable / handler-raises error paths) with a mocked lib.
  * tests/integration/qmp_hook/: an end-to-end test that boots the real libqemu-system-intel64 with -machine none -S, registers a handler, and drives a custom QMP command through qemu's actual dispatcher, asserting the JSON round-trips and that a declined command still yields CommandNotFound. Wired into CI as the run_qmp_hook job.

Bump the penguin-qemu flake input to rehosting/qemu main (b853deff4c), which includes the merged QMP callback + CFFI bindings, so the image builds a QEMU that exports set_penguin_qmp_callback / penguin_handle_qmp.