### PR TITLE
config: let a patch switch a pseudofile model instead of failing

### DIFF
--- a/src/penguin/common.py
+++ b/src/penguin/common.py
@@ -167,6 +167,24 @@ def patch_config(logger, base_config, patch, patch_name="patch", origin_map=None
             return base.merge(new)
 
         if hasattr(base, "model_fields_set"):
+            # Two models of different types cannot be field-merged. The merged
+            # result is rebuilt below as type(base), so field-merging a patch
+            # that switches a discriminated-union member -- e.g. a pseudofile
+            # read model from `zero` to `cycle` -- would hand base's class the
+            # new member's fields and fail validation ("Input should be 'zero'",
+            # plus "Extra inputs are not permitted" for fields only the new
+            # member declares). Switching a member is a replacement, not a
+            # merge, so take the new value wholesale.
+            #
+            # This is what a target patch does whenever it overrides a model
+            # that a generated static patch already set (penguin's
+            # expert-knowledge defaults model /dev/watchdog, /dev/wdt,
+            # /dev/gpio, /dev/nvram and friends as read:zero), which is the
+            # normal shape of a delta-only config.
+            if type(base) is not type(new):
+                _record_origins(new, config_option, patch_name)
+                return new
+
             result = dict()
             for base_key in base.model_fields_set:
                 result[base_key] = getattr(base, base_key)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1127,3 +1127,70 @@ def test_legacy_pseudofile_config_unchanged():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+# --------------------------------------------------------------------------- #
+# patch_config: switching a discriminated-union member                        #
+# --------------------------------------------------------------------------- #
+
+def _merge_pseudofiles(base, patch):
+    """Run one patch over a base through the real patch_config merge."""
+    import logging
+    import pydantic
+    from penguin.common import patch_config
+    from penguin.penguin_config.structure import Pseudofiles
+
+    adapter = pydantic.TypeAdapter(Pseudofiles)
+    out = patch_config(
+        logging.getLogger("test"),
+        adapter.validate_python(base),
+        adapter.validate_python(patch),
+        patch_name="patch_test.yaml",
+    )
+    return out.root if hasattr(out, "root") else out
+
+
+def test_patch_can_switch_pseudofile_model():
+    # A patch that changes a pseudofile's model must replace the union member,
+    # not field-merge into the old one. Field-merging rebuilt the result as the
+    # *base* class, so overriding read:zero with read:cycle raised
+    # "Input should be 'zero'" plus "Extra inputs are not permitted" for `val`.
+    #
+    # This is the normal shape of a delta-only target config: penguin's
+    # expert-knowledge defaults already model /dev/watchdog as read:zero, so any
+    # target wanting a different read model is switching a member.
+    merged = _merge_pseudofiles(
+        {"/dev/watchdog": {"read": {"model": "zero"}}},
+        {"/dev/watchdog": {"read": {"model": "cycle", "val": "0"}}},
+    )
+    read = merged["/dev/watchdog"].read
+    read = read.root if hasattr(read, "root") else read
+    assert read.model == "cycle"
+    assert read.val == "0"
+
+
+def test_patch_still_merges_same_model_fields():
+    # The replacement above must not swallow the ordinary case: when the patch
+    # keeps the same model, field-wise merging still applies.
+    merged = _merge_pseudofiles(
+        {"/dev/x": {"read": {"model": "const_buf", "val": "old"}}},
+        {"/dev/x": {"read": {"model": "const_buf", "val": "new"}}},
+    )
+    read = merged["/dev/x"].read
+    read = read.root if hasattr(read, "root") else read
+    assert read.model == "const_buf"
+    assert read.val == "new"
+
+
+def test_patch_switches_model_across_operations():
+    # Switching one operation's model must leave the other operations on the
+    # node intact rather than replacing the whole pseudofile entry.
+    merged = _merge_pseudofiles(
+        {"/dev/watchdog": {"read": {"model": "zero"}, "write": {"model": "discard"}}},
+        {"/dev/watchdog": {"read": {"model": "cycle", "val": "0"}}},
+    )
+    entry = merged["/dev/watchdog"]
+    read = entry.read.root if hasattr(entry.read, "root") else entry.read
+    write = entry.write.root if hasattr(entry.write, "root") else entry.write
+    assert read.model == "cycle"
+    assert write.model == "discard"


### PR DESCRIPTION
Fixes #929.

`patch_config` could not change which model a pseudofile operation used. Overriding a model that an earlier config or a generated static patch already set raised a validation error instead of replacing it:

```
ValidationError: 2 validation errors for Read a zero
model  Input should be 'zero' [input_value='cycle']
val    Extra inputs are not permitted [input_value='0']
```

## Cause

`_recursive_update` field-merges two pydantic models and rebuilds the result as `type(base)`. When base and new are different members of a discriminated union, that hands the *base* member's class the *new* member's fields — `model` becomes the other literal, and any field only the new member declares is rejected as extra.

Switching a member is a replacement, not a merge, so the fix takes the new value wholesale when the types differ. Same-model patches keep merging field-wise.

## Why this is worth fixing rather than working around

penguin's own expert-knowledge defaults model `/dev/watchdog`, `/dev/wdt`, `/dev/gpio` and `/dev/nvram` as `read: zero`, and the generated `static_patches/pseudofiles.expert_knowledge.yaml` carries them. So any config that wants a different read model on one of those paths was switching a member — and there was no way to express it, because every alternative read model is equally a switch.

That blocked the delta-only config style, where a target ships just its differences from what `penguin init` generates. A config that bakes the final model in directly is unaffected, which is why this went unnoticed for so long: the same settings work when committed as a whole config and fail when expressed as a patch.

Not a regression — `_recursive_update` and the `/dev/watchdog` default are both unchanged for many releases.

## Tests

Three tests in `tests/unit/test_config.py` driving the real `patch_config`:

- `test_patch_can_switch_pseudofile_model` — the reported case; **fails without the fix**
- `test_patch_switches_model_across_operations` — a member switch must not replace the sibling operations on the node; **fails without the fix**
- `test_patch_still_merges_same_model_fields` — control: same-model patches must still merge field-wise; passes either way, so the replacement doesn't swallow the ordinary path

682 unit tests pass locally, flake8 clean. (`tests/unit/test_processes.py` and two `test_db.py` cases are excluded locally — they need a newer `pengutils` than this host has, unrelated to this change.)