### PR TITLE
nix: take kernels from linux_builder's flake, not a release tarball

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -143,17 +143,39 @@
         "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.96/igloo_driver.tar.gz"
       }
     },
-    "kernels": {
+    "igloo_driver": {
       "flake": false,
       "locked": {
-        "lastModified": 1785247557,
-        "narHash": "sha256-b90flBGCisEptuaPEIdW9rMTwfE+6ZyklTnlDk4xSU0=",
-        "type": "tarball",
-        "url": "https://github.com/rehosting/linux_builder/releases/download/v3.6.5/kernels-latest.tar.gz"
+        "lastModified": 1786551192,
+        "narHash": "sha256-zeOP0nQEb/uns46MizbcX3DpS4or4EM8XuOmRRIPbo4=",
+        "owner": "rehosting",
+        "repo": "igloo_driver",
+        "rev": "243c889e2b3360b16e5b12d6a20b0c5c0766dd07",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/rehosting/linux_builder/releases/download/v3.6.5/kernels-latest.tar.gz"
+        "owner": "rehosting",
+        "repo": "igloo_driver",
+        "type": "github"
+      }
+    },
+    "kernelsmith": {
+      "inputs": {
+        "musl-cross-make": "musl-cross-make",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1786663087,
+        "narHash": "sha256-uynOJDkUTq7V3gZxNre3CmeMwBSYYoToi1kYea52OPU=",
+        "owner": "rehosting",
+        "repo": "kernelsmith",
+        "rev": "f3220b9a1919076317659310d75b28f0c36fab62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rehosting",
+        "repo": "kernelsmith",
+        "type": "github"
       }
     },
     "libhc": {
@@ -189,6 +211,31 @@
         "type": "github"
       }
     },
+    "linux-builder": {
+      "inputs": {
+        "igloo_driver": "igloo_driver",
+        "kernelsmith": "kernelsmith",
+        "nixpkgs": [
+          "linux-builder",
+          "kernelsmith",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786668152,
+        "narHash": "sha256-fA0gyL3VJNbR0jKtCUSj7sxAVy8kqhXXZwb7hdrTOsw=",
+        "owner": "rehosting",
+        "repo": "linux_builder",
+        "rev": "8ff5c95c90321deca40fad58329af6909e9d2332",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rehosting",
+        "ref": "nix-patchset",
+        "repo": "linux_builder",
+        "type": "github"
+      }
+    },
     "ltrace-src": {
       "flake": false,
       "locked": {
@@ -200,6 +247,22 @@
       "original": {
         "type": "tarball",
         "url": "https://src.fedoraproject.org/repo/pkgs/ltrace/ltrace-0.7.91.tar.bz2/9db3bdee7cf3e11c87d8cc7673d4d25b/ltrace-0.7.91.tar.bz2"
+      }
+    },
+    "musl-cross-make": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781646546,
+        "narHash": "sha256-ZGkLvkred/sDa2Mw2/1N+Nh8bvUyujxxOLTZDfd2qN4=",
+        "owner": "richfelker",
+        "repo": "musl-cross-make",
+        "rev": "227df8b99103f9c59f6570babf892978e293082f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "richfelker",
+        "repo": "musl-cross-make",
+        "type": "github"
       }
     },
     "musl-src": {
@@ -216,6 +279,22 @@
       }
     },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1773201692,
         "narHash": "sha256-NXrKzNMniu4Oam2kAFvqJ3GB2kAvlAFIriTAheaY8hw=",
@@ -271,11 +350,11 @@
         "fw2tar": "fw2tar",
         "guesthopper": "guesthopper",
         "igloo-driver": "igloo-driver",
-        "kernels": "kernels",
         "libnvram": "libnvram",
+        "linux-builder": "linux-builder",
         "ltrace-src": "ltrace-src",
         "musl-src": "musl-src",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "penguin-qemu": "penguin-qemu",
         "penguin-tools": "penguin-tools",
         "vhost-device": "vhost-device",

--- a/flake.lock
+++ b/flake.lock
@@ -222,16 +222,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1786668152,
-        "narHash": "sha256-fA0gyL3VJNbR0jKtCUSj7sxAVy8kqhXXZwb7hdrTOsw=",
+        "lastModified": 1786671278,
+        "narHash": "sha256-rSvxoJrhVBUz20atIwjVNOXDQFzwghxnBzPAvlY3qkI=",
         "owner": "rehosting",
         "repo": "linux_builder",
-        "rev": "8ff5c95c90321deca40fad58329af6909e9d2332",
+        "rev": "2efd7d97f5797a269c05872e77f28c76cbd4b4db",
         "type": "github"
       },
       "original": {
         "owner": "rehosting",
-        "ref": "nix-patchset",
+        "ref": "nixdev_0.1.0",
         "repo": "linux_builder",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -133,14 +133,13 @@
     "igloo-driver": {
       "flake": false,
       "locked": {
-        "lastModified": 1786551473,
-        "narHash": "sha256-K9Jncy3ANJhYZ0GA9nNC0jDdnzPJNKc42elABCQ3DhY=",
+        "narHash": "sha256-+5ycMvtb7rwpyio+5SLEL4uK5JhYdkIZIqsONcktVHw=",
         "type": "tarball",
-        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.96/igloo_driver.tar.gz"
+        "url": "https://github.com/rehosting/igloo_driver/releases/download/nixdev_0.0.1/igloo_driver.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.96/igloo_driver.tar.gz"
+        "url": "https://github.com/rehosting/igloo_driver/releases/download/nixdev_0.0.1/igloo_driver.tar.gz"
       }
     },
     "igloo_driver": {
@@ -165,11 +164,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1786663087,
-        "narHash": "sha256-uynOJDkUTq7V3gZxNre3CmeMwBSYYoToi1kYea52OPU=",
+        "lastModified": 1786744385,
+        "narHash": "sha256-linrkYJ63mdakHdQStEPgUeII3Tn/NGKFBQVCs3QB0w=",
         "owner": "rehosting",
         "repo": "kernelsmith",
-        "rev": "f3220b9a1919076317659310d75b28f0c36fab62",
+        "rev": "03d99e438ecab7a6ffb4d2a3072ef78269b2573c",
         "type": "github"
       },
       "original": {
@@ -219,19 +218,20 @@
           "linux-builder",
           "kernelsmith",
           "nixpkgs"
-        ]
+        ],
+        "nixpkgs-qemu": "nixpkgs-qemu"
       },
       "locked": {
-        "lastModified": 1786671278,
-        "narHash": "sha256-rSvxoJrhVBUz20atIwjVNOXDQFzwghxnBzPAvlY3qkI=",
+        "lastModified": 1786744488,
+        "narHash": "sha256-lvq2IUnrIbxEO0zTvDKlyXjQHZWT1eXT8B1zICk9L+4=",
         "owner": "rehosting",
         "repo": "linux_builder",
-        "rev": "2efd7d97f5797a269c05872e77f28c76cbd4b4db",
+        "rev": "48b318301cafe50adbbca079a3943c7ab8dd9a39",
         "type": "github"
       },
       "original": {
         "owner": "rehosting",
-        "ref": "nixdev_0.1.0",
+        "ref": "nixdev_0.1.1",
         "repo": "linux_builder",
         "type": "github"
       }
@@ -290,6 +290,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-qemu": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -133,13 +133,13 @@
     "igloo-driver": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-+5ycMvtb7rwpyio+5SLEL4uK5JhYdkIZIqsONcktVHw=",
+        "narHash": "sha256-BIqNrEbjrUFsa7ZUmPzhjznjXsSfW4e2DiVqvP8Lw+I=",
         "type": "tarball",
-        "url": "https://github.com/rehosting/igloo_driver/releases/download/nixdev_0.0.1/igloo_driver.tar.gz"
+        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.97/igloo_driver.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/rehosting/igloo_driver/releases/download/nixdev_0.0.1/igloo_driver.tar.gz"
+        "url": "https://github.com/rehosting/igloo_driver/releases/download/v0.0.97/igloo_driver.tar.gz"
       }
     },
     "igloo_driver": {
@@ -222,16 +222,16 @@
         "nixpkgs-qemu": "nixpkgs-qemu"
       },
       "locked": {
-        "lastModified": 1786744488,
-        "narHash": "sha256-lvq2IUnrIbxEO0zTvDKlyXjQHZWT1eXT8B1zICk9L+4=",
+        "lastModified": 1786767380,
+        "narHash": "sha256-oLZVUeaYA6mO1aCZeE24LM1qUVY13NPHS54wrIA45So=",
         "owner": "rehosting",
         "repo": "linux_builder",
-        "rev": "48b318301cafe50adbbca079a3943c7ab8dd9a39",
+        "rev": "b87fad4abe85c6f6cdee0ab9e892f9bee5d21798",
         "type": "github"
       },
       "original": {
         "owner": "rehosting",
-        "ref": "nixdev_0.1.1",
+        "ref": "v4.0.1",
         "repo": "linux_builder",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -57,8 +57,13 @@
   # its lockfile was tested with, and lose the Cachix hits. These artifacts link
   # against nothing of ours, so a shared closure buys us nothing here -- the
   # opposite of the penguin-qemu case.
+  # Pinned to the `nixdev_0.1.0` TAG, not the branch: an immutable ref, so this
+  # PR's CI tests a fixed tree rather than a moving target. That tag also cut a
+  # prerelease and, being a push event, populated rehosting-tools with all 19
+  # cells -- so CI here substitutes the kernels instead of cross-building them.
+  # Repin to a release tag (or `main`) once linux_builder#59 lands.
   inputs.linux-builder = {
-    url = "github:rehosting/linux_builder/nix-patchset";
+    url = "github:rehosting/linux_builder/nixdev_0.1.0";
   };
   inputs.igloo-driver = {
     url = "https://github.com/rehosting/igloo_driver/releases/download/v0.0.96/igloo_driver.tar.gz";

--- a/flake.nix
+++ b/flake.nix
@@ -57,16 +57,28 @@
   # its lockfile was tested with, and lose the Cachix hits. These artifacts link
   # against nothing of ours, so a shared closure buys us nothing here -- the
   # opposite of the penguin-qemu case.
-  # Pinned to the `nixdev_0.1.0` TAG, not the branch: an immutable ref, so this
-  # PR's CI tests a fixed tree rather than a moving target. That tag also cut a
-  # prerelease and, being a push event, populated rehosting-tools with all 19
-  # cells -- so CI here substitutes the kernels instead of cross-building them.
+  # Pinned to a TAG, not a branch: an immutable ref, so this PR's CI tests a
+  # fixed tree rather than a moving target. The tag build also cut a prerelease
+  # and, being a push event, populated rehosting-tools with all 19 cells -- so
+  # CI here substitutes the kernels instead of cross-building them.
   # Repin to a release tag (or `main`) once linux_builder#59 lands.
+  #
+  # nixdev_0.1.1, not _0.1.0: that release's 4.10/x86_64 kernel built, linked
+  # and packaged, had the right ELF shape, and did not boot -- binutils >= 2.31
+  # emits R_X86_64_PLT32, which Linux only learned in 4.16. It is why
+  # `run_tests (x86_64, 4.10)` failed here. _0.1.1 also adds linux_builder's
+  # boot gate, which is what would have caught it before this repo ever saw it.
   inputs.linux-builder = {
-    url = "github:rehosting/linux_builder/nixdev_0.1.0";
+    url = "github:rehosting/linux_builder/nixdev_0.1.1";
   };
+  # The nix-built driver, and it MUST move in lockstep with linux-builder above.
+  # v0.0.96 was Docker-built against different kernels: 129 of 221 modversion
+  # CRCs disagreed with these kernels' Module.symvers, which the guest reported
+  # as "igloo: disagrees about version of symbol module_layout" and is why every
+  # 6.13 target failed here. nixdev_0.0.1 is built against the derivations of
+  # the very kernels this flake stages, so that pairing is not expressible.
   inputs.igloo-driver = {
-    url = "https://github.com/rehosting/igloo_driver/releases/download/v0.0.96/igloo_driver.tar.gz";
+    url = "https://github.com/rehosting/igloo_driver/releases/download/nixdev_0.0.1/igloo_driver.tar.gz";
     flake = false;
   };
   # v0.0.25 is the slimmed penguin-tools: it no longer ships the forked guest

--- a/flake.nix
+++ b/flake.nix
@@ -35,9 +35,30 @@
     url = "github:rehosting/qemu";
     inputs.nixpkgs.follows = "nixpkgs";
   };
-  inputs.kernels = {
-    url = "https://github.com/rehosting/linux_builder/releases/download/v3.6.5/kernels-latest.tar.gz";
-    flake = false;
+  # The IGLOO kernels. THIS IS THE kernel SEAM, and unlike the other prebuilt
+  # artifacts above it is a FLAKE, not a release tarball -- linux_builder now
+  # builds from a pristine upstream tarball plus an explicit patch series, with
+  # its cross toolchains resolved by kernelsmith and recorded in its flake.lock
+  # (rehosting/linux_builder#59). We take `packages.<system>.kernels`, the
+  # assembled `<version>/...` tree, rather than `kernels-latest` (the same
+  # payload as a .tar.gz) so we do not pack ~335 MB of archive only to unpack it.
+  #
+  # Why a flake here when `penguin-tools` and `igloo-driver` stay tarballs: the
+  # reason is NOT penguin-qemu's (no /nix/store rpaths to keep alive -- kernel
+  # images are raw and `perf.<target>` is statically linked). It is that the
+  # tarball pin cannot express *which compiler built these kernels*. The Docker
+  # builder fetched its toolchains with unversioned `wget musl.cc/*-cross.tgz`,
+  # so every kernel penguin has ever shipped has no recorded compiler identity.
+  # Consuming the flake puts that identity in our flake.lock.
+  #
+  # Deliberately NO `inputs.nixpkgs.follows`: linux_builder's nixpkgs comes from
+  # kernelsmith, which is what pins the cross toolchains. Forcing it onto ours
+  # would silently rebuild every kernel against a different compiler than the one
+  # its lockfile was tested with, and lose the Cachix hits. These artifacts link
+  # against nothing of ours, so a shared closure buys us nothing here -- the
+  # opposite of the penguin-qemu case.
+  inputs.linux-builder = {
+    url = "github:rehosting/linux_builder/nix-patchset";
   };
   inputs.igloo-driver = {
     url = "https://github.com/rehosting/igloo_driver/releases/download/v0.0.96/igloo_driver.tar.gz";
@@ -136,7 +157,7 @@
       self,
       nixpkgs,
       penguin-qemu,
-      kernels,
+      linux-builder,
       igloo-driver,
       penguin-tools,
       console,
@@ -163,6 +184,11 @@
         let
           pkgs = pkgsFor system;
           lib = pkgs.lib;
+
+          # linux_builder only evaluates its cells for x86_64-linux (the cross
+          # builds are all hosted there); take that set regardless of `system`,
+          # matching how the other prebuilt inputs are consumed below.
+          kernels = linux-builder.packages.x86_64-linux.kernels;
 
           # Package version (penguin reads penguin/version.txt at runtime for
           # `penguin --version`). The version is tag-derived (setuptools_scm

--- a/flake.nix
+++ b/flake.nix
@@ -57,28 +57,40 @@
   # its lockfile was tested with, and lose the Cachix hits. These artifacts link
   # against nothing of ours, so a shared closure buys us nothing here -- the
   # opposite of the penguin-qemu case.
-  # Pinned to a TAG, not a branch: an immutable ref, so this PR's CI tests a
-  # fixed tree rather than a moving target. The tag build also cut a prerelease
-  # and, being a push event, populated rehosting-tools with all 19 cells -- so
-  # CI here substitutes the kernels instead of cross-building them.
-  # Repin to a release tag (or `main`) once linux_builder#59 lands.
+  # A REAL release tag, not a prerelease: v4.0.1 is the first linux_builder
+  # release cut by its nix path, and the first whose kernels are every one of
+  # them boot-tested. An immutable ref either way, so CI tests a fixed tree.
+  # Being a push event, its build populated rehosting-tools with all 19 cells,
+  # so CI here SUBSTITUTES the kernels instead of cross-building them.
   #
-  # nixdev_0.1.1, not _0.1.0: that release's 4.10/x86_64 kernel built, linked
-  # and packaged, had the right ELF shape, and did not boot -- binutils >= 2.31
-  # emits R_X86_64_PLT32, which Linux only learned in 4.16. It is why
-  # `run_tests (x86_64, 4.10)` failed here. _0.1.1 also adds linux_builder's
-  # boot gate, which is what would have caught it before this repo ever saw it.
+  # The version line jumped 3.6.x -> 4.0.x for this: the kernels are now built
+  # from pristine upstream tarballs plus an explicit patch series, cross-
+  # compiled by kernelsmith with a recorded compiler identity.
+  #
+  # Why that matters here specifically: nixdev_0.1.0's 4.10/x86_64 kernel built,
+  # linked and packaged, had the right ELF shape, and did not boot -- binutils
+  # >= 2.31 emits R_X86_64_PLT32, which Linux only learned in 4.16. That was
+  # `run_tests (x86_64, 4.10)` failing in this repo, found three repos and one
+  # release downstream of the cause. linux_builder now boot-tests every kernel
+  # before it can be released.
   inputs.linux-builder = {
-    url = "github:rehosting/linux_builder/nixdev_0.1.1";
+    url = "github:rehosting/linux_builder/v4.0.1";
   };
   # The nix-built driver, and it MUST move in lockstep with linux-builder above.
-  # v0.0.96 was Docker-built against different kernels: 129 of 221 modversion
+  #
+  # v0.0.96 was Docker-built against DIFFERENT kernels: 129 of 221 modversion
   # CRCs disagreed with these kernels' Module.symvers, which the guest reported
-  # as "igloo: disagrees about version of symbol module_layout" and is why every
-  # 6.13 target failed here. nixdev_0.0.1 is built against the derivations of
-  # the very kernels this flake stages, so that pairing is not expressible.
+  # as "igloo: disagrees about version of symbol module_layout" -- and is why
+  # every 6.13 target failed here.
+  #
+  # v0.0.97 is the first release built by igloo_driver's nix path, compiled
+  # against the kernel DERIVATIONS this flake stages rather than an unpacked
+  # kernel-devel tarball, so a mismatched pair is not expressible. Its
+  # `kernels/BUILT_AGAINST.txt` records linux_builder b87fad4 -- the v4.0.1
+  # commit pinned above -- and the same kernel store paths this flake resolves,
+  # so the pairing is verifiable by content rather than by version number.
   inputs.igloo-driver = {
-    url = "https://github.com/rehosting/igloo_driver/releases/download/nixdev_0.0.1/igloo_driver.tar.gz";
+    url = "https://github.com/rehosting/igloo_driver/releases/download/v0.0.97/igloo_driver.tar.gz";
     flake = false;
   };
   # v0.0.25 is the slimmed penguin-tools: it no longer ships the forked guest


### PR DESCRIPTION
Switches the kernel seam from a pinned release tarball to
`rehosting/linux_builder`'s flake.

**Depends on rehosting/linux_builder#59** and is pinned at its branch, so this
is a draft. Repin to a tag/`main` once that lands.

## Why

`inputs.kernels` pinned an opaque artifact:

```nix
url = ".../linux_builder/releases/download/v3.6.5/kernels-latest.tar.gz";
flake = false;
```

That records a narHash and nothing else. In particular it cannot express **which
compiler built these kernels** — the Docker builder fetched its cross toolchains
with unversioned `wget https://musl.cc/*-cross.tgz`, so no kernel penguin has
ever shipped has a recorded compiler identity. There is no way to rebuild an old
penguin release with the toolchain that produced its kernels.

linux_builder#59 replaces that with pristine upstream tarballs + an explicit
patch series, toolchains resolved by kernelsmith and pinned in its `flake.lock`.
Consuming it as a flake puts that identity in ours.

Note this is **not** penguin-qemu's reason. That input is a flake because its
Nix-built `.so`s carry `/nix/store` rpaths a tarball would leave dangling.
Kernel images are raw and `perf.<target>` is statically linked; nothing here
links against our closure. The argument is provenance, not closure integrity —
which is also why `penguin-tools` and `igloo-driver` correctly stay tarballs.

## What changes in the shipped image

CI notes the flake is the sole build path (there is no Dockerfile), so this
changes the kernels penguin actually ships. Two material differences, both
inherited from linux_builder#59:

- **`perf` ships for 19/19 cells instead of 7/19.** `build.sh` swallowed perf
  build failures, so `arm64`, `riscv64`, `x86_64`, the whole ppc family and most
  mips targets have been shipping without `perf` — never a decision, just what
  failed quietly. Purely additive.
- **The `powerpcle` kernel is gone.** It was byte-identical to `powerpc` and
  big-endian despite its name: `CONFIG_CPU_LITTLE_ENDIAN` is
  `depends on PPC_BOOK3S_64`, so `olddefconfig` dropped it without a word.

  I checked this is safe here rather than assuming: `powerpcle` in penguin is
  **not a kernel arch**. It is the 32-bit LE userspace ABI *under* `powerpc64le`
  in `abi_info.py` (`abis.ppcle.target_triple = "powerpcle-linux-musl"`), and
  kernel lookup keys off `q_config['arch']` — i.e. `powerpc64le`. Penguin runs
  `ppcle` userspace on a `powerpc64le` kernel, which is the coherent
  configuration and precisely why a `powerpcle` *kernel* was meaningless.

  Worth a second pair of eyes on whether any private `rehostings` config names
  `powerpcle` as a kernel arch.

## Design notes

- Takes `packages.x86_64-linux.kernels`, a directory of `<version>/...`, added
  in linux_builder for this purpose. Going through `kernels-latest` would mean
  packing ~335 MB of archive for us to immediately unpack. Same payload —
  `kernelsTarball` is now defined in terms of that tree, so they cannot drift.
- `mk-igloo-static.nix` is untouched: it still takes a directory and copies it
  to `/igloo_static/kernels/`.
- **No `inputs.nixpkgs.follows`,** deliberately, and commented at the input.
  linux_builder's nixpkgs comes from kernelsmith, which is what pins the cross
  toolchains; forcing ours would rebuild every kernel against a compiler its
  lockfile was never tested with, and lose the Cachix hits.

## Alternative considered

Keep the artifact pin and just repoint it once linux_builder starts cutting
releases from nix. Less churn, and it keeps the lock graph flat. Rejected
because it preserves exactly the property worth removing — the shipped kernels
stay unattributable — and because the flake works today, whereas no nix-built
release exists yet.

The legacy `Dockerfile` still has `ARG LINUX_VERSION="3.6.5"` +
`get_release.sh`. Left alone: CI does not build it. Removing it belongs with
whatever retires that file.

## Verification

- `nix flake lock` clean; `iglooStatic` and `dockerImage` both **evaluate**
  against the new input.
- **I have not built the image** — that is a CI-scale build, not a local one.
  This needs a green `build_container` before it means anything.
- One piece of lock noise to flag: `linux-builder/igloo_driver` now appears in
  our lock graph. It is linux_builder's *source-only* input for its own
  `igloo.ko` acceptance test, unrelated to the `igloo-driver` tarball we
  consume. Harmless (lazily fetched) but it is an extra edge, and worth deciding
  whether linux_builder should scope that input more narrowly.
