### PR TITLE
Make filesystem-order-dependent logic deterministic

### DIFF
--- a/pyplugins/init/base_patch.py
+++ b/pyplugins/init/base_patch.py
@@ -187,7 +187,8 @@ class BasePatch(InitPlugin):
 
         # Always add our utilities into static files
         guest_scripts_dir = os.path.join(STATIC_DIR, "guest-utils", "scripts")
-        for f in os.listdir(guest_scripts_dir):
+        # Sorted so the static_files keys land in a stable order.
+        for f in sorted(os.listdir(guest_scripts_dir)):
             result["static_files"][f"/igloo/utils/{f}"] = {
                 "type": "host_file",
                 "host_path": f"{guest_scripts_dir}/{f}",

--- a/pyplugins/init/kernel_modules.py
+++ b/pyplugins/init/kernel_modules.py
@@ -52,12 +52,17 @@ class KernelModules(InitPlugin):
                 if os.path.isdir(d_path):
                     potential_kernels.add(d)
 
-        # Filter potential kernels to match the expected version pattern
-        potential_kernels = {d for d in potential_kernels if self.is_kernel_version(d)}
+        # Filter potential kernels to match the expected version pattern.
+        # Sorted, not a set: the selection below scans for the first candidate
+        # matching each pattern, and set iteration order over strings varies
+        # from run to run under hash randomization.
+        potential_kernels = sorted(
+            d for d in potential_kernels if self.is_kernel_version(d)
+        )
 
         # Determine the kernel version to use
         if len(potential_kernels) == 1:
-            kernel_version = potential_kernels.pop()
+            kernel_version = potential_kernels[0]
         elif len(potential_kernels) > 1:
             # Prioritize the version names that match more complex patterns with dashes
             for potential_name in potential_kernels:
@@ -77,7 +82,7 @@ class KernelModules(InitPlugin):
                     "Multiple kernel versions look valid (TODO improve selection logic, grabbing first)"
                 )
                 logger.warning(potential_kernels)
-                kernel_version = potential_kernels.pop()
+                kernel_version = potential_kernels[0]
 
         if kernel_version:
             # We have a kernel version, add it to our config

--- a/pyplugins/init/pseudofile_finder.py
+++ b/pyplugins/init/pseudofile_finder.py
@@ -430,8 +430,11 @@ class PseudofileFinder(InitPlugin):
         results = []
 
         if os.path.exists(dev_dir):
-            for root, _, files in os.walk(dev_dir):
-                for f in files:
+            for root, dirs, files in os.walk(dev_dir):
+                # os.walk order is filesystem-dependent; sort so the discovered
+                # device list is reproducible across machines and extractions.
+                dirs.sort()
+                for f in sorted(files):
                     relative_path = os.path.join("/dev", os.path.relpath(os.path.join(root, f), dev_dir))
                     results.append(relative_path)
 

--- a/src/penguin/__main__.py
+++ b/src/penguin/__main__.py
@@ -372,17 +372,19 @@ def _do_package(project_dir, output_path, with_snapshots=()):
     # Include auto-patching files exactly as PENGUIN computes them
     raw_core = raw_config.get("core", {})
     if raw_core.get("auto_patching", True):
-        patch_files = list(Path(project_dir_abs).glob("patch_*.yaml"))
+        # Sort so auto-discovered patches match penguin_config ordering and are
+        # applied deterministically regardless of filesystem enumeration order.
+        patch_files = sorted(Path(project_dir_abs).glob("patch_*.yaml"))
         patches_dir = Path(project_dir_abs, "patches")
 
         if patches_dir.exists():
-            patch_files += list(patches_dir.glob("*.yaml"))
+            patch_files += sorted(patches_dir.glob("*.yaml"))
 
         for pf in patch_files:
             _add_file(pf)
 
         # Catch loose .patch or .diff files too just in case
-        for root_file in os.listdir(project_dir_abs):
+        for root_file in sorted(os.listdir(project_dir_abs)):
             if root_file.endswith(".patch") or root_file.endswith(".diff"):
                 _add_file(root_file)
 

--- a/src/penguin/config_patchers.py
+++ b/src/penguin/config_patchers.py
@@ -120,12 +120,14 @@ class FileHelper:
                 if e.is_file and e.executable:
                     yield Path(e.path)
             return
-        for root, _, files in os.walk(tmp_dir):
+        for root, dirs, files in os.walk(tmp_dir):
+            # Deterministic traversal: os.walk order is filesystem-dependent.
+            dirs.sort()
             # Exclude the '/igloo' path
             if "/igloo" in root:
                 continue
 
-            for file in files:
+            for file in sorted(files):
                 file_path = Path(root) / file
                 if file_path.is_file() and os.access(file_path, os.X_OK):
                     yield file_path
@@ -335,7 +337,7 @@ class NvramHelper:
                 candidates = (
                     (os.path.join(root, file), file)
                     for root, _, files in os.walk(fs_path)
-                    for file in files
+                    for file in sorted(files)
                 )
             for abs_path, file in candidates:
                 rel_path = "./" + os.path.relpath(abs_path, fs_path)

--- a/src/penguin/init_plugin.py
+++ b/src/penguin/init_plugin.py
@@ -186,6 +186,10 @@ class FileIndex:
                     is_symlink=os.path.islink(p),
                     executable=os.access(p, os.X_OK),
                 ))
+        # os.walk order depends on the underlying filesystem and is not
+        # reproducible across machines/extractions. Sort by relative path so
+        # every init plugin that iterates self.entries sees a stable order.
+        entries.sort(key=lambda e: e.rel)
         self.entries = entries
 
     def files(self):

--- a/src/penguin/penguin_config/__init__.py
+++ b/src/penguin/penguin_config/__init__.py
@@ -319,10 +319,12 @@ def load_config(proj_dir, path, validate=True, resolved_kernel=None, verbose=Fal
 
     # look for files called patch_*.yaml in the same directory as the config file
     if config.core.auto_patching:
-        patch_files = list(Path(proj_dir).glob("patch_*.yaml"))
+        # glob() returns entries in filesystem order; sort so auto-discovered
+        # patches are always applied in a stable, reproducible order.
+        patch_files = sorted(Path(proj_dir).glob("patch_*.yaml"))
         patches_dir = Path(proj_dir, "patches")
         if patches_dir.exists():
-            patch_files += list(patches_dir.glob("*.yaml"))
+            patch_files += sorted(patches_dir.glob("*.yaml"))
         if patch_files:
             if config.patches is None:
                 config.patches = structure.Patches(root=[])

--- a/src/penguin/static_analyses.py
+++ b/src/penguin/static_analyses.py
@@ -101,7 +101,9 @@ class FileSystemHelper:
 
         # iterate through each file in the extracted root directory
         for root, dirs, files in os.walk(extract_root):
-            for filename in files:
+            # Deterministic traversal independent of filesystem ordering.
+            dirs.sort()
+            for filename in sorted(files):
                 filepath = os.path.join(root, filename)
 
                 # skip our files in the "./igloo" path

--- a/src/penguin/utils.py
+++ b/src/penguin/utils.py
@@ -637,7 +637,7 @@ def get_available_kernel_versions() -> List[Tuple[int, ...]]:
         return []
 
     versions = []
-    for entry in os.listdir(kernels_dir):
+    for entry in sorted(os.listdir(kernels_dir)):
         entry_path = os.path.join(kernels_dir, entry)
         if os.path.isdir(entry_path):
             try:


### PR DESCRIPTION
Directory enumeration (os.walk, os.listdir, glob) returns entries in filesystem-dependent order, which is not reproducible across machines or re-extractions. Sort these sites so config generation and static analysis are deterministic:

- init_plugin.FileIndex: sort the shared os.walk result by relative path so every init plugin iterating ctx.file_index.entries sees a stable order.
- penguin_config/__main__: sort auto-discovered patch_*.yaml / patches/ and loose .patch/.diff files so patches apply in a stable order.
- config_patchers: sort os.walk fallbacks (executable + nvram scans).
- static_analyses: sort os.walk traversal for string matching.
- utils.get_available_kernel_versions: sort kernel dir listing.
- docs menu: sort the *.md glob.