### PR TITLE
publish: build the portable image on every release

### DIFF
--- a/.github/workflows/publish-portable.yaml
+++ b/.github/workflows/publish-portable.yaml
@@ -5,7 +5,13 @@ name: Release Portable Container
 # host that mounts its own /nix over the container's. See the "Portable variant"
 # comment in nix/mk-image.nix and docs/nix.md.
 #
-# ON DEMAND, not part of every release. The portable image is one large layer
+# BACKFILL. Since publish.yaml gained a `build-portable` job, every new release
+# publishes its own portable image automatically; this workflow exists to build
+# one for a release cut before that change. Note it can only serve tags that
+# already contain the `portableImage` flake attribute -- older tags cannot be
+# built portable at all, which is the reason the per-release job exists.
+#
+# Historical rationale for it having been on demand: The portable image is one large layer
 # rather than 115 (dockerTools' layering can't be used on a relocated store), so
 # it shares no blobs with the normal image and adds its full compressed size to
 # registry storage on every publish. Consumers of it -- currently the

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -70,12 +70,56 @@ jobs:
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
       cachix-auth-token: ${{ secrets.CACHIX_REHOSTING }}
 
+  # 2b. The portable variant of the same release, in lockstep with `build`.
+  #
+  #     Every :<version> gets a matching :<version>-portable, so a consumer that
+  #     pins a release can always obtain the portable form of exactly that
+  #     release. Publishing it on demand instead did not merely defer the storage
+  #     cost -- it created pins that could never be served: the workflow builds
+  #     `.#portableImage` from the requested tag, and that flake attribute does
+  #     not exist in any release older than the commit that introduced it, so
+  #     those tags cannot be built portable at all. The pwn.college dojo hit this
+  #     on a pin it had already validated 42 challenges against.
+  #
+  #     The marginal cost is smaller than it looks: this shares the
+  #     rehosting-tools Cachix cache with `build` above, and the portable image
+  #     is a relocation of a closure that build already produced, so what is paid
+  #     is the relocation and the push rather than a second full build. Registry
+  #     storage is the real cost -- the relocated store cannot use dockerTools'
+  #     layering, so the image is one large layer that shares no blobs with the
+  #     normal one. If that becomes binding, bound it with retention rather than
+  #     by going back to on-demand, so that every pin stays serviceable.
+  build-portable:
+    needs: version
+    uses: rehosting/ci/.github/workflows/nix-image-push.yml@v1
+    with:
+      image: rehosting/penguin
+      flake-attr: .#portableImage
+      cachix-name: rehosting-tools
+      nix-install-url: https://releases.nixos.org/nix/nix-2.31.2/install
+      enable-kvm: false
+      dockerhub-user: rehosting
+      extra-tags: |
+        rehosting/penguin:${{ needs.version.outputs.v }}-portable
+        rehosting/penguin:portable
+      # Same version-injection contract as `build`, so `penguin --version` inside
+      # the portable image reports the release rather than a git-derived version.
+      extra-build-args: --impure
+      build-env: |
+        PENGUIN_OVERRIDE_VERSION=${{ needs.version.outputs.v }}
+    secrets:
+      registry: ${{ secrets.REHOSTING_ARC_REGISTRY }}
+      registry-user: ${{ secrets.REHOSTING_ARC_REGISTRY_USER }}
+      registry-password: ${{ secrets.REHOSTING_ARC_REGISTRY_PASSWORD }}
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+      cachix-auth-token: ${{ secrets.CACHIX_REHOSTING }}
+
   # 3. Config schema + GitHub release (after the image exists). Docs/PDF/Pages
   #    are built out-of-band by docs.yaml, which runs via `workflow_run` after
   #    this workflow completes (a GITHUB_TOKEN-created release can't fire
   #    `on: release`).
   release:
-    needs: [version, build]
+    needs: [version, build, build-portable]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Why

The portable image is published on demand (`publish-portable.yaml`, `workflow_dispatch`) rather than per release, to avoid paying its registry storage cost every time. That deferral has a consequence that wasn't priced:

**A release cut before the portable work landed can never be built portable at all.**

`publish-portable.yaml` does `checkout-ref: ${{ inputs.version }}` and builds `.#portableImage`, so it can only serve tags whose flake already contains that attribute. Dispatching it for `v3.1.7` or `v3.1.8` fails on a missing flake attribute — **v3.1.9** is the first release that can produce one.

The pwn.college dojo hit exactly this. It pinned v3.1.7 and validated 42 challenges against it, then found the image it needs was not merely unpublished but unbuildable, and had to move its pin.

There's a quieter cost too: a consumer pinning `:<version>` has no way to know whether a matching `-portable` exists short of trying to pull it. The two tags drift silently.

## What this does

- Adds a `build-portable` job to `publish.yaml`, parallel to `build` and gated on the same `version` job, so every `:<version>` gets a matching `:<version>-portable` (and refreshes the floating `:portable`).
- Gates `release` on both builds, so a release can't be cut with only half its images.
- Keeps `publish-portable.yaml` for backfilling releases cut before this change, and updates its header to say that's now its role — including the caveat that it still can't serve tags older than the `portableImage` attribute.

## Cost

The marginal **build** cost is small: `build-portable` shares the `rehosting-tools` Cachix cache with `build`, and the portable image is a relocation of a closure the normal build already produced, so what's paid is the relocation and the push rather than a second full build.

Registry **storage** remains the real cost, and this PR does pay it per release — the relocated store can't use dockerTools' layering, so the image is one large layer sharing no blobs with the normal one. That's a deliberate trade: the failure it prevents is silent and lands on a consumer who only discovers it after validating against a pin. If storage becomes binding, the better fix is retention on the `-portable` tags rather than a return to on-demand, since that keeps every pin serviceable while bounding the total.

## Testing

Both workflows parse as YAML and the job graph is as intended (`version → build, build-portable → release`). The workflows themselves can only really be exercised by a release, so this wants a maintainer's eye on the secrets block — it's copied verbatim from the existing `build` job.