### PR TITLE
mem: let a caller opt out of the never-fails read contract

### DIFF
--- a/pyplugins/apis/kffi.py
+++ b/pyplugins/apis/kffi.py
@@ -884,8 +884,16 @@ class KFFI(Plugin):
         offset = field_info.offset
         size = self.ffi.sizeof(field_info.type_info)
 
-        # Read the current memory for this field's width to safely handle bitfields
-        existing_bytes = yield from plugins.mem.read_bytes(addr + offset, size)
+        # Read the current memory for this field's width to safely handle
+        # bitfields. This is required=True because it is a read-modify-write:
+        # the bytes read here are written back, so for a bitfield the zeros a
+        # failed read would fabricate land on top of whichever neighbouring
+        # bitfields share this storage unit. Everywhere else a bad read costs a
+        # wrong answer; here it corrupts the guest. The RuntimeError below was
+        # always the intent -- read_bytes just never returned anything falsy
+        # for it to fire on.
+        existing_bytes = yield from plugins.mem.read_bytes(
+            addr + offset, size, required=True)
         if not existing_bytes:
             raise RuntimeError(f"Failed to read memory at {addr + offset:#x}")
 
@@ -915,7 +923,10 @@ class KFFI(Plugin):
         offset = field_info.offset
         size = self.ffi.sizeof(field_info.type_info)
 
-        raw_bytes = yield from plugins.mem.read_bytes(addr + offset, size)
+        # required=True so the RuntimeError below is reachable: without it a
+        # failed read arrives as NUL bytes and this returns a confident 0.
+        raw_bytes = yield from plugins.mem.read_bytes(
+            addr + offset, size, required=True)
         if not raw_bytes:
             raise RuntimeError(f"Failed to read memory at {addr + offset:#x}")
 

--- a/pyplugins/apis/mem.py
+++ b/pyplugins/apis/mem.py
@@ -49,6 +49,45 @@ class Mem(Plugin):
     ==========
     Provides guest memory access and manipulation via the hypervisor portal.
 
+    Reads never fail
+    ----------------
+    By default every read here is a total function. Memory the guest cannot
+    supply -- unmapped, swapped out, a bad pointer, a driver-side failure --
+    is reported as NUL bytes (or an empty/truncated string), never as an
+    exception and never as ``None``. That is deliberate: it keeps try/except
+    out of hundreds of call sites, lets a generator read a pointer without a
+    guard around it, and stops one plugin dereferencing garbage from taking a
+    whole run down.
+
+    The cost is that a fabricated zero is indistinguishable from a real one.
+    Usually that is the right trade. Sometimes it is not:
+
+    * a pointer that reads 0 looks like a genuine NULL, so a list walk stops
+      at the first unmapped page and reports a short list as a complete one;
+    * a struct in unreadable memory decodes to an all-zero struct, which looks
+      exactly like a valid zero-initialised one;
+    * a read-modify-write on such a struct writes the fabricated zeros *back*,
+      so a bad read becomes a bad write;
+    * two unreadable regions compare equal.
+
+    For those cases every reader takes ``required=True``, which returns
+    ``None`` instead of fabricating. It is still not an exception -- the caller
+    checks a value, it does not wrap the call -- and the default behaviour is
+    untouched, so passing it is a local decision at the one call site that
+    needs it::
+
+        # fine: a wrong value here is a wrong log line
+        val = yield from plugins.mem.read_int(addr)
+
+        # not fine: this decides whether to write to the guest
+        val = yield from plugins.mem.read_int(addr, required=True)
+        if val is None:
+            return
+
+    ``required`` propagates through the derived readers, so
+    ``read_char_ptrlist(..., required=True)`` fails if any pointer or any
+    string underneath it could not be read.
+
     Attributes
     ----------
     endian_format : str
@@ -203,10 +242,33 @@ class Mem(Plugin):
             raise ValueError(f"Memory write failed with err={err}")  # TODO: make a PANDA Exn class
 
     def read_bytes(self, addr: Union[int, Ptr], size: int,
-                   pid: Optional[int] = None) -> Generator[Any, Any, bytes]:
+                   pid: Optional[int] = None,
+                   required: bool = False) -> Generator[Any, Any, Optional[bytes]]:
         """
         Reads bytes from guest memory.
         Optimized with a Fast Path for single-chunk reads.
+
+        Parameters
+        ----------
+        addr : int or Ptr
+            Address to read from.
+        size : int
+            Number of bytes to read.
+        pid : int, optional
+            Process ID for context.
+        required : bool, optional
+            Whether the caller needs to know that the read failed. Default
+            False, which is the total contract described in the class
+            docstring: unreadable memory is reported as NUL bytes and the
+            caller cannot fail. Pass True where a fabricated zero would be
+            taken for real data -- see the class docstring for when that
+            matters.
+
+        Returns
+        -------
+        bytes or None
+            Exactly ``size`` bytes. ``None`` only when ``required`` is set and
+            the read could not be satisfied in full.
         """
         if isinstance(addr, Ptr):
             addr = addr.address
@@ -227,8 +289,12 @@ class Mem(Plugin):
             # Fallback to Portal
             chunk = yield PortalCmd(hop.HYPER_OP_READ, addr, size, pid)
             if not chunk:
+                if required:
+                    return None
                 return b"\x00" * size
             if len(chunk) != size:
+                if required:
+                    return None
                 return chunk.ljust(size, b"\x00")
             return chunk
 
@@ -261,8 +327,12 @@ class Mem(Plugin):
                 chunk = yield PortalCmd(hop.HYPER_OP_READ, chunk_addr, chunk_size, pid)
 
             if not chunk:
+                if required:
+                    return None
                 chunk = b"\x00" * chunk_size
             elif len(chunk) != chunk_size:
+                if required:
+                    return None
                 chunk = chunk.ljust(chunk_size, b"\x00")
             read_chunks.append(chunk)
         # Optimization: Use b''.join only once at the end
@@ -291,7 +361,8 @@ class Mem(Plugin):
         return self.ffi.unpack(buf, size)
 
     def read_str(self, addr: Union[int, Ptr],
-                 pid: Optional[int] = None) -> Generator[Any, Any, str]:
+                 pid: Optional[int] = None,
+                 required: bool = False) -> Generator[Any, Any, Optional[str]]:
         """
         Read a null-terminated string from guest memory.
 
@@ -305,11 +376,20 @@ class Mem(Plugin):
             Address to read from.
         pid : int, optional
             Process ID for context.
+        required : bool, optional
+            Whether the caller needs to know that the string is incomplete.
+            Default False, which is the total contract: a read that fails
+            part-way, or a string longer than one portal region, comes back
+            truncated and indistinguishable from a short string. Pass True to
+            get ``None`` in both of those cases instead.
 
         Returns
         -------
-        str
-            String read from memory.
+        str or None
+            String read from memory. ``None`` only when ``required`` is set and
+            the string could not be read in full -- including a NULL ``addr``,
+            a failed read part-way through, and hitting the size cap without
+            finding a terminator.
         """
         if isinstance(addr, Ptr):
             addr = addr.address
@@ -329,6 +409,10 @@ class Mem(Plugin):
             total_read = 0
             curr_addr = addr
             cpu = self._get_cpu()
+            # Whether we actually saw the NUL that ends the string. Without
+            # this, "the string ended" and "I stopped looking" are the same
+            # return value.
+            terminated = False
 
             while total_read < SAFE_MAX:
                 # 1. Calculate space left in current page
@@ -361,7 +445,12 @@ class Mem(Plugin):
                     chunk = yield PortalCmd(hop.HYPER_OP_READ_STR, curr_addr, to_read, pid)
 
                 if not chunk:
-                    # If both methods failed or returned empty, we stop.
+                    # Both methods failed or returned empty. Note this is a
+                    # read failure, not an end-of-string: the loop walks page
+                    # by page precisely so it can cross page boundaries, so
+                    # "the next page is unmapped" lands right here.
+                    if required:
+                        return None
                     break
 
                 # 5. Scan for NULL terminator
@@ -370,6 +459,7 @@ class Mem(Plugin):
                 if null_idx != -1:
                     # Found terminator: append valid part and stop
                     result.extend(chunk[:null_idx])
+                    terminated = True
                     break
                 else:
                     # No terminator: append whole chunk and continue
@@ -377,9 +467,15 @@ class Mem(Plugin):
                     total_read += len(chunk)
                     curr_addr += len(chunk)
 
+            if required and not terminated:
+                # Ran out of budget (SAFE_MAX) without finding the end. A path
+                # can legitimately be longer than this cap -- PATH_MAX is 4096
+                # and SAFE_MAX is one portal region, which is smaller.
+                return None
+
             return result.decode('latin-1', errors='replace')
 
-        return ""
+        return None if required else ""
 
     def read_str_panda(self, cpu, addr: Union[int, Ptr]) -> str:
         """
@@ -435,7 +531,8 @@ class Mem(Plugin):
         return result.decode('latin-1', errors='replace')
 
     def read_int(self, addr: Union[int, Ptr],
-                 pid: Optional[int] = None) -> Generator[Any, Any, Optional[int]]:
+                 pid: Optional[int] = None,
+                 required: bool = False) -> Generator[Any, Any, Optional[int]]:
         """
         Read a 4-byte integer from guest memory.
 
@@ -447,26 +544,33 @@ class Mem(Plugin):
             Address to read from.
         pid : int, optional
             Process ID for context.
+        required : bool, optional
+            Whether the caller needs to know that the read failed. Default
+            False: unreadable memory reads as zero and ``None`` is never
+            returned. Pass True to get ``None`` instead.
 
         Returns
         -------
         int or None
-            Integer value read, or None on failure.
+            Integer value read. ``None`` only when ``required`` is set and the
+            read failed; otherwise unreadable memory reads as 0.
         """
         if isinstance(addr, Ptr):
             addr = addr.address
 
         self.logger.debug(f"read_int called: addr={addr:#x}")
-        data = yield from self.read_bytes(addr, 4, pid)
-        if len(data) != 4:
+        data = yield from self.read_bytes(addr, 4, pid, required=required)
+        if data is None or len(data) != 4:
             self.logger.error(
-                f"Failed to read int at addr={addr:#x}, data_len={len(data)}")
+                f"Failed to read int at addr={addr:#x}, "
+                f"data_len={'none' if data is None else len(data)}")
             return None
         value = int.from_bytes(data, self.endian_str)
         return value
 
     def read_long(
-            self, addr: Union[int, Ptr], pid: Optional[int] = None) -> Generator[Any, Any, Optional[int]]:
+            self, addr: Union[int, Ptr], pid: Optional[int] = None,
+            required: bool = False) -> Generator[Any, Any, Optional[int]]:
         """
         Read an 8-byte long integer from guest memory.
 
@@ -478,26 +582,33 @@ class Mem(Plugin):
             Address to read from.
         pid : int, optional
             Process ID for context.
+        required : bool, optional
+            Whether the caller needs to know that the read failed. Default
+            False: unreadable memory reads as zero and ``None`` is never
+            returned. Pass True to get ``None`` instead.
 
         Returns
         -------
         int or None
-            Long value read, or None on failure.
+            Long value read. ``None`` only when ``required`` is set and the
+            read failed; otherwise unreadable memory reads as 0.
         """
         if isinstance(addr, Ptr):
             addr = addr.address
 
         self.logger.debug(f"read_long called: addr={addr:#x}")
-        data = yield from self.read_bytes(addr, 8, pid)
-        if len(data) != 8:
+        data = yield from self.read_bytes(addr, 8, pid, required=required)
+        if data is None or len(data) != 8:
             self.logger.error(
-                f"Failed to read long at addr={addr:#x}, data_len={len(data)}")
+                f"Failed to read long at addr={addr:#x}, "
+                f"data_len={'none' if data is None else len(data)}")
             return None
         value = int.from_bytes(data, self.endian_str)
         return value
 
     def read_ptr(self, addr: Union[int, Ptr],
-                 pid: Optional[int] = None) -> Generator[Any, Any, Optional[int]]:
+                 pid: Optional[int] = None,
+                 required: bool = False) -> Generator[Any, Any, Optional[int]]:
         """
         Read a pointer-sized value from guest memory.
 
@@ -513,9 +624,11 @@ class Mem(Plugin):
         Returns
         -------
         int or None
-            Pointer value read, or None on failure.
+            Pointer value read. ``None`` only when ``required`` is set and the
+            read failed; otherwise an unreadable pointer reads as 0, which is
+            indistinguishable from a genuine NULL.
         """
-        # this function is bound in __init__
+        # this function is bound in __init__ to read_int or read_long
         pass
 
     def write_int(self, addr: Union[int, Ptr], value: int,
@@ -642,7 +755,8 @@ class Mem(Plugin):
         return bytes_written
 
     def read_ptrlist(self, addr: Union[int, Ptr], length: int,
-                     pid: Optional[int] = None) -> Generator[Any, Any, List[int]]:
+                     pid: Optional[int] = None,
+                     required: bool = False) -> Generator[Any, Any, Optional[List[int]]]:
         """
         Read a list of pointer values from guest memory.
 
@@ -668,14 +782,22 @@ class Mem(Plugin):
         ptrs = []
         ptrsize = self.ptr_size
         for start in range(length):
-            ptr = yield from self.read_ptr(addr + (start * ptrsize), pid)
+            ptr = yield from self.read_ptr(addr + (start * ptrsize), pid,
+                                           required=required)
+            if ptr is None:
+                # `required` only. An unreadable slot is not the end of the
+                # list, and the zero-fill makes the two identical -- so by
+                # default a list walk stops at the first unmapped page and
+                # reports a short list as a complete one.
+                return None
             if ptr == 0:
                 break
             ptrs.append(ptr)
         return ptrs
 
     def read_char_ptrlist(self, addr: Union[int, Ptr], length: int,
-                          pid: Optional[int] = None) -> Generator[Any, Any, List[str]]:
+                          pid: Optional[int] = None,
+                          required: bool = False) -> Generator[Any, Any, Optional[List[str]]]:
         """
         Read a list of null-terminated strings from a list of pointers.
 
@@ -698,15 +820,22 @@ class Mem(Plugin):
         if isinstance(addr, Ptr):
             addr = addr.address
 
-        ptrlist = yield from self.read_ptrlist(addr, length, pid)
+        ptrlist = yield from self.read_ptrlist(addr, length, pid,
+                                               required=required)
+        if ptrlist is None:
+            return None
         vals = []
         for start in range(len(ptrlist)):
-            strs = yield from self.read_str(ptrlist[start], pid)
+            strs = yield from self.read_str(ptrlist[start], pid,
+                                            required=required)
+            if strs is None:
+                return None
             vals.append(strs)
         return vals
 
     def read_int_array(self, addr: Union[int, Ptr], count: int,
-                       pid: Optional[int] = None) -> Generator[Any, Any, List[int]]:
+                       pid: Optional[int] = None,
+                       required: bool = False) -> Generator[Any, Any, Optional[List[int]]]:
         """
         Read an array of 4-byte integers from guest memory.
 
@@ -729,11 +858,14 @@ class Mem(Plugin):
         if isinstance(addr, Ptr):
             addr = addr.address
 
-        data = yield from self.read_bytes(addr, 4 * count, pid)
-        if len(data) != 4 * count:
+        data = yield from self.read_bytes(addr, 4 * count, pid,
+                                          required=required)
+        if data is None or len(data) != 4 * count:
             self.logger.error(
-                f"Failed to read int array at addr={addr:#x}, expected {4*count} bytes, got {len(data)}")
-            return []
+                f"Failed to read int array at addr={addr:#x}, expected "
+                f"{4*count} bytes, got "
+                f"{'none' if data is None else len(data)}")
+            return None if required else []
         return list(unpack(f"{self.endian_format}{count}I", data))
 
     def write_int_array(
@@ -764,7 +896,8 @@ class Mem(Plugin):
         return (yield from self.write_bytes(addr, data, pid))
 
     def read_long_array(self, addr: Union[int, Ptr], count: int,
-                        pid: Optional[int] = None) -> Generator[Any, Any, List[int]]:
+                        pid: Optional[int] = None,
+                        required: bool = False) -> Generator[Any, Any, Optional[List[int]]]:
         """
         Read an array of 8-byte long integers from guest memory.
 
@@ -787,14 +920,19 @@ class Mem(Plugin):
         if isinstance(addr, Ptr):
             addr = addr.address
 
-        data = yield from self.read_bytes(addr, 8 * count, pid)
-        if len(data) != 8 * count:
+        data = yield from self.read_bytes(addr, 8 * count, pid,
+                                          required=required)
+        if data is None or len(data) != 8 * count:
             self.logger.error(
-                f"Failed to read long array at addr={addr:#x}, expected {8*count} bytes, got {len(data)}")
-            return []
+                f"Failed to read long array at addr={addr:#x}, expected "
+                f"{8*count} bytes, got "
+                f"{'none' if data is None else len(data)}")
+            return None if required else []
         return list(unpack(f"{self.endian_format}{count}Q", data))
 
-    def read_uint64_array(self, addr: Union[int, Ptr], count: int, pid: Optional[int] = None) -> Generator[Any, Any, List[int]]:
+    def read_uint64_array(self, addr: Union[int, Ptr], count: int,
+                          pid: Optional[int] = None,
+                          required: bool = False) -> Generator[Any, Any, Optional[List[int]]]:
         """
         Read an array of 8-byte unsigned integers from guest memory.
 
@@ -817,10 +955,12 @@ class Mem(Plugin):
         if isinstance(addr, Ptr):
             addr = addr.address
 
-        return (yield from self.read_long_array(addr, count, pid))
+        return (yield from self.read_long_array(addr, count, pid,
+                                                required=required))
 
     def read_utf8_str(
-            self, addr: Union[int, Ptr], pid: Optional[int] = None) -> Generator[Any, Any, str]:
+            self, addr: Union[int, Ptr], pid: Optional[int] = None,
+            required: bool = False) -> Generator[Any, Any, Optional[str]]:
         """
         Read a null-terminated UTF-8 string from guest memory.
 
@@ -842,14 +982,17 @@ class Mem(Plugin):
             addr = addr.address
 
         if addr != 0:
-            chunk = yield from self.read_str(addr, pid)
+            chunk = yield from self.read_str(addr, pid, required=required)
+            if chunk is None:
+                return None
             if chunk:
                 self.logger.debug(f"Received response from queue: {chunk}")
                 return chunk.encode('latin-1').decode('utf-8', errors='replace')
-        return ""
+        return None if required else ""
 
     def read_byte(
-            self, addr: Union[int, Ptr], pid: Optional[int] = None) -> Generator[Any, Any, Optional[int]]:
+            self, addr: Union[int, Ptr], pid: Optional[int] = None,
+            required: bool = False) -> Generator[Any, Any, Optional[int]]:
         """
         Read a single byte from guest memory.
 
@@ -861,17 +1004,22 @@ class Mem(Plugin):
             Address to read from.
         pid : int, optional
             Process ID for context.
+        required : bool, optional
+            Whether the caller needs to know that the read failed. Default
+            False: unreadable memory reads as zero and ``None`` is never
+            returned. Pass True to get ``None`` instead.
 
         Returns
         -------
         int or None
-            Byte value read (0-255), or None on failure.
+            Byte value read (0-255). ``None`` only when ``required`` is set and the
+            read failed; otherwise unreadable memory reads as 0.
         """
         if isinstance(addr, Ptr):
             addr = addr.address
 
-        data = yield from self.read_bytes(addr, 1, pid)
-        if len(data) != 1:
+        data = yield from self.read_bytes(addr, 1, pid, required=required)
+        if data is None or len(data) != 1:
             self.logger.error(f"Failed to read byte at addr={addr:#x}")
             return None
         return data[0]
@@ -904,7 +1052,8 @@ class Mem(Plugin):
         return (yield from self.write_bytes(addr, data, pid))
 
     def read_word(
-            self, addr: Union[int, Ptr], pid: Optional[int] = None) -> Generator[Any, Any, Optional[int]]:
+            self, addr: Union[int, Ptr], pid: Optional[int] = None,
+            required: bool = False) -> Generator[Any, Any, Optional[int]]:
         """
         Read a 2-byte word from guest memory.
 
@@ -916,17 +1065,22 @@ class Mem(Plugin):
             Address to read from.
         pid : int, optional
             Process ID for context.
+        required : bool, optional
+            Whether the caller needs to know that the read failed. Default
+            False: unreadable memory reads as zero and ``None`` is never
+            returned. Pass True to get ``None`` instead.
 
         Returns
         -------
         int or None
-            Word value read, or None on failure.
+            Word value read. ``None`` only when ``required`` is set and the
+            read failed; otherwise unreadable memory reads as 0.
         """
         if isinstance(addr, Ptr):
             addr = addr.address
 
-        data = yield from self.read_bytes(addr, 2, pid)
-        if len(data) != 2:
+        data = yield from self.read_bytes(addr, 2, pid, required=required)
+        if data is None or len(data) != 2:
             self.logger.error(f"Failed to read word at addr={addr:#x}")
             return None
         return int.from_bytes(data, self.endian_str)
@@ -988,7 +1142,8 @@ class Mem(Plugin):
         return (yield from self.write_bytes(addr, data, pid))
 
     def memcmp(self, addr1: Union[int, Ptr], addr2: Union[int, Ptr], size: int,
-               pid: Optional[int] = None) -> Generator[Any, Any, bool]:
+               pid: Optional[int] = None,
+               required: bool = False) -> Generator[Any, Any, Optional[bool]]:
         """
         Compare two regions of guest memory for equality.
 
@@ -1015,8 +1170,15 @@ class Mem(Plugin):
         if isinstance(addr2, Ptr):
             addr2 = addr2.address
 
-        data1 = yield from self.read_bytes(addr1, size, pid)
-        data2 = yield from self.read_bytes(addr2, size, pid)
+        data1 = yield from self.read_bytes(addr1, size, pid,
+                                           required=required)
+        data2 = yield from self.read_bytes(addr2, size, pid,
+                                           required=required)
+        if data1 is None or data2 is None:
+            # `required` only. By default two unreadable regions both come back
+            # as zeros and compare *equal*, which is the one answer that is
+            # certainly wrong.
+            return None
         return data1 == data2
 
     def read_ptr_array(self, addr: Union[int, Ptr], pid: Optional[int] = None) -> Generator[Any, Any, List[str]]:
@@ -1194,7 +1356,8 @@ class Mem(Plugin):
                 f"Cannot dispatch write for unsupported data type: {type(data)}")
 
     def read(self, addr: Union[int, Ptr], size: Optional[int] = None,
-             fmt: Union[type, str, None] = None, pid: Optional[int] = None) -> Generator[Any, Any, Any]:
+             fmt: Union[type, str, None] = None, pid: Optional[int] = None,
+             required: bool = False) -> Generator[Any, Any, Any]:
         """
         Smart dispatcher for memory reads. Automatically infers sizes and types
         if a dwarffi Ptr is provided.
@@ -1209,11 +1372,16 @@ class Mem(Plugin):
             The requested return format (bytes, str, int, list, 'ptr'). Default is bytes.
         pid : int, optional
             Process ID for context.
+        required : bool, optional
+            Forwarded to whichever reader this dispatches to. Default False:
+            unreadable memory is reported as zeros/an empty string. Pass True
+            to get ``None`` instead. See the class docstring.
 
         Returns
         -------
         Any
-            The read data in the requested format.
+            The read data in the requested format, or ``None`` when
+            ``required`` is set and the read could not be satisfied.
         """
         actual_fmt = fmt
 
@@ -1246,23 +1414,29 @@ class Mem(Plugin):
         if actual_fmt is bytes or actual_fmt == "bytes":
             if size is None:
                 raise ValueError("Size required for bytes read.")
-            return (yield from self.read_bytes(addr, size, pid))
+            return (yield from self.read_bytes(addr, size, pid,
+                                               required=required))
         elif actual_fmt is str or actual_fmt == "str":
-            return (yield from self.read_str(addr, pid))
+            return (yield from self.read_str(addr, pid, required=required))
         elif actual_fmt is int or actual_fmt == "int":
             if size == 1:
-                return (yield from self.read_byte(addr, pid))
+                return (yield from self.read_byte(addr, pid,
+                                                  required=required))
             if size == 2:
-                return (yield from self.read_word(addr, pid))
+                return (yield from self.read_word(addr, pid,
+                                                  required=required))
             if size == 8:
-                return (yield from self.read_long(addr, pid))
+                return (yield from self.read_long(addr, pid,
+                                                  required=required))
             if size == 4:
-                return (yield from self.read_int(addr, pid))
-            return (yield from self.read_ptr(addr, pid))
+                return (yield from self.read_int(addr, pid,
+                                                 required=required))
+            return (yield from self.read_ptr(addr, pid, required=required))
         elif actual_fmt == "ptr":
-            return (yield from self.read_ptr(addr, pid))
+            return (yield from self.read_ptr(addr, pid, required=required))
         elif actual_fmt is list or actual_fmt == "list":
             if size is None:
                 raise ValueError("Count required for list read.")
-            return (yield from self.read_int_array(addr, size, pid))
+            return (yield from self.read_int_array(addr, size, pid,
+                                                   required=required))
         raise ValueError(f"Unknown read format: {actual_fmt}")

--- a/tests/unit/test_mem_required_reads.py
+++ b/tests/unit/test_mem_required_reads.py
@@ -1,0 +1,293 @@
+"""``mem`` reads never fail -- and ``required=True`` is how a caller opts out.
+
+The default contract is deliberate: unreadable guest memory is reported as NUL
+bytes rather than an exception, so a plugin can dereference a bad pointer
+without a guard and hundreds of call sites stay free of try/except. The cost is
+that a fabricated zero is indistinguishable from a real one, which is fine for
+a log line and not fine for a decision.
+
+Every probe below is a pair: what the default returns (fabricated), and what
+``required=True`` returns for the same failure (``None``). Both halves are
+pinned, so a change to either is a change to a documented assertion.
+
+Note the `None` returns these make reachable were already documented -- the
+`if len(data) != 4: return None` guards in read_int/read_long/read_byte/
+read_word could never fire, because read_bytes always padded to length.
+
+mem.py imports the real HYPER_OP enum, so every test needs the pinned driver
+ISF. ``__init__`` is skipped (it does `panda.bits // 8` on a recorder stub);
+the handful of attributes the readers touch are set directly, which is the
+harness's documented pattern for exactly this.
+"""
+from pathlib import Path
+
+import pytest
+
+from penguin.testing import load_pyplugin
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MEM = str(REPO_ROOT / "pyplugins" / "apis" / "mem.py")
+
+# read_str's own constants, restated so the probes can compute chunk sizes.
+PORTAL_CHUNK_SIZE = 0x1000 - 48
+SAFE_MAX = 4096 - 24
+
+
+def _load(tmp_path, isf, bits=64, rsize=4072):
+    lp = load_pyplugin(MEM, outdir=tmp_path, real_isf=isf, call_init=False)
+    m = lp.plugin
+    m.endian_format = "<"
+    m.endian_str = "little"
+    # The whole point is to exercise the portal path, so keep PANDA out of it.
+    m.try_panda = False
+    m._get_cpu = lambda: None
+    m._rsize = rsize
+    m.ptr_size = bits // 8
+    m.ptr_typ = f"uint{bits}_t"
+    m.addr_mask = 0xFFFFFFFF if bits == 32 else 0xFFFFFFFFFFFFFFFF
+    # __init__ normally binds read_ptr to read_int/read_long; do it here since
+    # __init__ did not run.
+    m.read_ptr = m.read_int if bits == 32 else m.read_long
+    return m
+
+
+def _drive(gen, responses):
+    """Run a portal generator, feeding `responses` to successive yields."""
+    it = iter(responses)
+    try:
+        gen.send(None)
+        while True:
+            gen.send(next(it, None))
+    except StopIteration as e:
+        return e.value
+
+
+# --------------------------------------------------------------------------
+# read_bytes -- the primitive every other reader sits on
+# --------------------------------------------------------------------------
+
+def test_read_bytes_fabricates_zeros_for_a_failed_read(tmp_path, igloo_ko_isf):
+    """The default contract. A portal READ_FAIL arrives as None (portal.py
+    drops the payload), and comes back as data."""
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(m.read_bytes(0x1000, 8), [None]) == b"\x00" * 8
+
+
+def test_read_bytes_required_reports_the_failure(tmp_path, igloo_ko_isf):
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(m.read_bytes(0x1000, 8, required=True), [None]) is None
+
+
+def test_read_bytes_pads_a_short_read_and_required_does_not(tmp_path, igloo_ko_isf):
+    """A HYPER_RESP_READ_PARTIAL arrives short: the driver reports exactly how
+    much was readable, and the default pads that information away."""
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(m.read_bytes(0x1000, 8), [b"ab"]) == b"ab" + b"\x00" * 6
+    assert _drive(m.read_bytes(0x1000, 8, required=True), [b"ab"]) is None
+
+
+def test_read_bytes_success_is_identical_in_both_modes(tmp_path, igloo_ko_isf):
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(m.read_bytes(0x1000, 4), [b"wxyz"]) == b"wxyz"
+    assert _drive(m.read_bytes(0x1000, 4, required=True), [b"wxyz"]) == b"wxyz"
+
+
+def test_read_bytes_multi_chunk_failure(tmp_path, igloo_ko_isf):
+    """The slow path chunks by rsize; a failure in any chunk must not be
+    papered over by the chunks that succeeded around it."""
+    m = _load(tmp_path, igloo_ko_isf, rsize=4)
+    ok = _drive(m.read_bytes(0x1000, 12), [b"aaaa", None, b"cccc"])
+    assert ok == b"aaaa" + b"\x00" * 4 + b"cccc"
+    strict = _drive(m.read_bytes(0x1000, 12, required=True),
+                    [b"aaaa", None, b"cccc"])
+    assert strict is None
+
+
+# --------------------------------------------------------------------------
+# scalars -- where the unreachable `None` guards become reachable
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("reader,width,zero", [
+    ("read_byte", 1, 0),
+    ("read_word", 2, 0),
+    ("read_int", 4, 0),
+    ("read_long", 8, 0),
+])
+def test_scalars_read_unmapped_memory_as_zero(tmp_path, igloo_ko_isf,
+                                              reader, width, zero):
+    """An unmapped address is reported as the value 0, which is a perfectly
+    ordinary thing for the memory to contain."""
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(getattr(m, reader)(0x1000), [None]) == zero
+
+
+@pytest.mark.parametrize("reader", ["read_byte", "read_word",
+                                    "read_int", "read_long"])
+def test_scalars_required_return_none(tmp_path, igloo_ko_isf, reader):
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(getattr(m, reader)(0x1000, required=True), [None]) is None
+
+
+def test_read_ptr_forwards_required_through_the_init_binding(tmp_path, igloo_ko_isf):
+    """read_ptr is bound to read_int/read_long at construction, so `required`
+    has to survive the indirection rather than being swallowed by it."""
+    m64 = _load(tmp_path, igloo_ko_isf, bits=64)
+    assert _drive(m64.read_ptr(0x1000), [None]) == 0
+    assert _drive(m64.read_ptr(0x1000, required=True), [None]) is None
+
+    m32 = _load(tmp_path, igloo_ko_isf, bits=32)
+    assert _drive(m32.read_ptr(0x1000), [None]) == 0
+    assert _drive(m32.read_ptr(0x1000, required=True), [None]) is None
+
+
+def test_a_fabricated_pointer_is_indistinguishable_from_NULL(tmp_path, igloo_ko_isf):
+    """The concrete reason `required` exists for pointers: these two cases are
+    the same value by default and different values with it."""
+    m = _load(tmp_path, igloo_ko_isf)
+    real_null = _drive(m.read_ptr(0x1000), [b"\x00" * 8])
+    unreadable = _drive(m.read_ptr(0x1000), [None])
+    assert real_null == unreadable == 0
+
+    real_null = _drive(m.read_ptr(0x1000, required=True), [b"\x00" * 8])
+    unreadable = _drive(m.read_ptr(0x1000, required=True), [None])
+    assert real_null == 0
+    assert unreadable is None
+
+
+# --------------------------------------------------------------------------
+# read_str -- two distinct truncations
+# --------------------------------------------------------------------------
+
+def test_read_str_returns_a_partial_string_when_a_page_is_unreadable(
+        tmp_path, igloo_ko_isf):
+    """read_str walks page by page so it can cross page boundaries, which makes
+    "the next page is unmapped" the expected failure -- and by default it comes
+    back as a complete-looking short string."""
+    m = _load(tmp_path, igloo_ko_isf)
+    # First chunk fills to the page boundary with no NUL, second read fails.
+    first = b"A" * PORTAL_CHUNK_SIZE
+    assert _drive(m.read_str(0x1000), [first, None]) == "A" * PORTAL_CHUNK_SIZE
+    assert _drive(m.read_str(0x1000, required=True), [first, None]) is None
+
+
+def test_read_str_truncates_at_the_cap_without_saying_so(tmp_path, igloo_ko_isf):
+    """SAFE_MAX is one portal region, which is smaller than PATH_MAX (4096) --
+    so a long path is truncated and reads as whole."""
+    m = _load(tmp_path, igloo_ko_isf)
+    first = b"B" * PORTAL_CHUNK_SIZE
+    second = b"B" * (SAFE_MAX - PORTAL_CHUNK_SIZE)
+    out = _drive(m.read_str(0x1000), [first, second])
+    assert out == "B" * SAFE_MAX
+    assert len(out) < 4096, "the cap is below PATH_MAX -- that is the point"
+    assert _drive(m.read_str(0x1000, required=True), [first, second]) is None
+
+
+def test_read_str_success_is_identical_in_both_modes(tmp_path, igloo_ko_isf):
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(m.read_str(0x1000), [b"/bin/sh\x00rest"]) == "/bin/sh"
+    assert _drive(m.read_str(0x1000, required=True),
+                  [b"/bin/sh\x00rest"]) == "/bin/sh"
+
+
+def test_read_str_of_a_null_pointer(tmp_path, igloo_ko_isf):
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(m.read_str(0), []) == ""
+    assert _drive(m.read_str(0, required=True), []) is None
+
+
+def test_read_utf8_str_propagates_required(tmp_path, igloo_ko_isf):
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(m.read_utf8_str(0x1000), [None]) == ""
+    assert _drive(m.read_utf8_str(0x1000, required=True), [None]) is None
+
+
+# --------------------------------------------------------------------------
+# lists and arrays
+# --------------------------------------------------------------------------
+
+def test_read_ptrlist_stops_at_an_unreadable_slot_and_calls_it_the_end(
+        tmp_path, igloo_ko_isf):
+    """The zero-fill makes an unreadable slot look like the NULL terminator, so
+    the walk ends early and reports a short list as a complete one."""
+    m = _load(tmp_path, igloo_ko_isf)
+    resp = [(1).to_bytes(8, "little"), (2).to_bytes(8, "little"), None]
+    assert _drive(m.read_ptrlist(0x1000, 8), list(resp)) == [1, 2]
+    assert _drive(m.read_ptrlist(0x1000, 8, required=True), list(resp)) is None
+
+
+def test_read_ptrlist_a_real_terminator_still_ends_the_list(tmp_path, igloo_ko_isf):
+    """`required` must not turn a legitimate NULL terminator into a failure."""
+    m = _load(tmp_path, igloo_ko_isf)
+    resp = [(1).to_bytes(8, "little"), (0).to_bytes(8, "little")]
+    assert _drive(m.read_ptrlist(0x1000, 8, required=True), list(resp)) == [1]
+
+
+def test_read_char_ptrlist_required_reaches_the_strings(tmp_path, igloo_ko_isf):
+    """required has to propagate two levels: through the pointer walk and into
+    each string read underneath it."""
+    m = _load(tmp_path, igloo_ko_isf)
+    # One good pointer, terminator, then the string read behind it fails.
+    resp = [(0x2000).to_bytes(8, "little"), (0).to_bytes(8, "little"), None]
+    assert _drive(m.read_char_ptrlist(0x1000, 4), list(resp)) == [""]
+    assert _drive(m.read_char_ptrlist(0x1000, 4, required=True),
+                  list(resp)) is None
+
+
+@pytest.mark.parametrize("reader,count", [
+    ("read_int_array", 3),
+    ("read_long_array", 3),
+    ("read_uint64_array", 3),
+])
+def test_arrays_read_unmapped_memory_as_an_array_of_zeros(
+        tmp_path, igloo_ko_isf, reader, count):
+    """Not `[]` -- an array of zeros.
+
+    These readers guard with `if len(data) != N * count: return []`, and that
+    guard is as unreachable as the scalar ones: read_bytes pads to full length,
+    so the unpack always succeeds and produces zeros. An unreadable array is
+    therefore a plausible all-zero array, and the documented empty-list failure
+    return never happens.
+    """
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(getattr(m, reader)(0x1000, count), [None]) == [0] * count
+    assert _drive(getattr(m, reader)(0x1000, count, required=True),
+                  [None]) is None
+
+
+# --------------------------------------------------------------------------
+# memcmp -- the one case where the default answer is certainly wrong
+# --------------------------------------------------------------------------
+
+def test_memcmp_calls_two_unreadable_regions_equal(tmp_path, igloo_ko_isf):
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(m.memcmp(0x1000, 0x2000, 16), [None, None]) is True
+    assert _drive(m.memcmp(0x1000, 0x2000, 16, required=True),
+                  [None, None]) is None
+
+
+def test_memcmp_still_compares_readable_regions(tmp_path, igloo_ko_isf):
+    m = _load(tmp_path, igloo_ko_isf)
+    same = [b"a" * 4, b"a" * 4]
+    diff = [b"a" * 4, b"b" * 4]
+    assert _drive(m.memcmp(0x1000, 0x2000, 4, required=True), same) is True
+    assert _drive(m.memcmp(0x1000, 0x2000, 4, required=True), diff) is False
+
+
+# --------------------------------------------------------------------------
+# the smart dispatcher
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("kwargs,default", [
+    ({"size": 4, "fmt": bytes}, b"\x00" * 4),
+    ({"fmt": str}, ""),
+    ({"size": 4, "fmt": int}, 0),
+    ({"size": 8, "fmt": "ptr"}, 0),
+    ({"size": 2, "fmt": list}, [0, 0]),
+])
+def test_read_dispatcher_forwards_required(tmp_path, igloo_ko_isf,
+                                           kwargs, default):
+    """`read` picks a reader by format; `required` has to survive every branch,
+    not just the ones that happen to be tested elsewhere."""
+    m = _load(tmp_path, igloo_ko_isf)
+    assert _drive(m.read(0x1000, **kwargs), [None]) == default
+    assert _drive(m.read(0x1000, required=True, **kwargs), [None]) is None


### PR DESCRIPTION
Reads in `mem` are total by design: memory the guest cannot supply comes back as NUL bytes, never an exception and never `None`. That is worth keeping — it keeps try/except out of hundreds of call sites, lets a generator dereference a pointer without a guard around it, and stops one plugin reading garbage from taking a whole run down. **This PR does not change that.**

What the API could not do is tell a caller it happened, and for a handful of callers that matters:

* a pointer that reads 0 looks like a genuine NULL, so `read_ptrlist` stops at the first unmapped page and reports a short list as a complete one;
* a struct in unreadable memory decodes to an all-zero struct, which is exactly what a valid zero-initialised one looks like;
* `kffi.write_field` reads a field, edits it and writes it back, so fabricated zeros land on whichever neighbouring bitfields share the storage unit — a bad read becomes a bad **write**;
* `memcmp` calls two unreadable regions equal, which is the one answer that is certainly wrong.

## The option

`required=False` on every reader. Setting it returns `None` instead of fabricating. Still not an exception — the caller checks a value rather than wrapping the call — and the default is untouched, so it is a local decision at the one site that needs it:

```python
# fine: a wrong value here is a wrong log line
val = yield from plugins.mem.read_int(addr)

# not fine: this decides whether to write to the guest
val = yield from plugins.mem.read_int(addr, required=True)
if val is None:
    return
```

It propagates, so `read_char_ptrlist(..., required=True)` fails if any pointer *or* any string underneath it could not be read.

Threaded through `read_bytes`, `read_str`, `read_int`/`read_long`/`read_byte`/`read_word`, `read_ptr` (including the `__init__` binding to `read_int`/`read_long`, tested separately because that indirection is where a kwarg gets silently swallowed), `read_int_array`/`read_long_array`/`read_uint64_array`, `read_ptrlist`/`read_char_ptrlist`, `read_utf8_str`, `memcmp`, and every branch of the `read` dispatcher.

## Most of this makes existing documentation true

`read_int`, `read_long`, `read_byte` and `read_word` are all annotated *"or None on failure"* and all guard with `if len(data) != N: return None`. That guard could never fire, because `read_bytes` padded every failure up to full length. Same for the array readers' `return []`. Those paths are now reachable, and each docstring says which mode reaches them.

`read_str` gets the same treatment for its two silent truncations: a portal failure part-way through — which is the *expected* failure, since it walks page by page precisely so it can cross page boundaries — and hitting `SAFE_MAX`, which is one portal region and therefore smaller than `PATH_MAX`.

The contract itself is now written down in the `Mem` class docstring, since "reads never fail" is a policy a reader should find before going to look for the error path.

## One fix rather than an option

`kffi.read_field` and `kffi.write_field` both already had `raise RuntimeError` written for a failed read and simply never got the chance to fire. Both now pass `required=True`, which makes that existing intent work. `write_field` is the motivating case: everywhere else a fabricated read costs a wrong answer, there it corrupts the guest.

## Deliberately not done

`kffi.read_type` has the identical dead guard but returns `None` rather than raising, and its callers have never had to handle that — flipping it would newly hand `None` to a lot of unchecked code. Left alone as a separate decision.

## Tests

33 probes in `tests/unit/test_mem_required_reads.py`, each pinning **both** halves: what the default fabricates, and what `required` reports for the same failure. So a future change to either is a change to a documented assertion.

Two of my own expectations were wrong while writing them and the tests record the real behaviour rather than what I assumed: the array readers return `[0, 0, 0]`, not `[]`, because the pad-to-length means their guard cannot fire either.

## Verification

* 33 new tests pass; `flake8 .` clean from the repo root.
* No existing test changed behaviour, which is the evidence that the default path is untouched.
* The 8 `test_verifier.py` failures on this branch are `ModuleNotFoundError` and fail identically on clean `main` — pre-existing and unrelated (#938 deletes that stale file).

Independent of #938: that PR touches neither `mem.py` nor `kffi.py`, so these can merge in either order.
