### PR TITLE
Portable image fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -407,6 +407,39 @@ jobs:
       - name: QMP hook test
         run: timeout 10m python3 $GITHUB_WORKSPACE/tests/integration/qmp_hook/test.py --image rehosting/penguin:${{ github.sha }}
 
+  # The portable image is built and pushed only at release time
+  # (publish.yaml's build-portable), so nothing on a PR ever exercised the
+  # store relocation -- three defects shipped across four releases with CI
+  # green throughout, because every guest-boot job above builds
+  # `.#dockerImage`. This builds `.#portableImage` and stops there: no push, so
+  # it does not touch the registry storage that kept the variant on-demand in
+  # the first place, and the assertions that matter live inside the relocation
+  # (nix/relocate-store.py), so a broken rewrite fails the build itself.
+  #
+  # ~1 minute with a warm cache: 15 derivations, everything heavy shared with
+  # build_container via the rehosting-tools cache.
+  portable_image:
+    needs: [changes, lint]
+    if: ${{ !github.event.pull_request.draft && needs.changes.outputs.run_tests == 'true' }}
+    runs-on: rehosting-arc
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Set up Nix
+        uses: rehosting/ci/actions/nix-setup@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-backend: cachix
+          cachix-name: rehosting-tools
+          cachix-auth-token: ${{ secrets.CACHIX_REHOSTING }}
+          # Same Nix pin as build_container: install-nix-action's default
+          # (2.22.1) computes different tarball-input narHashes and rejects our lock.
+          install-url: https://releases.nixos.org/nix/nix-2.31.2/install
+          enable-kvm: false
+      - name: Build the portable image
+        run: nix build .#portableImage -L --no-link
+
   # Single required status check for branch protection + the merge queue.
   #
   # The per-arch run_tests matrix and build_container are conditionally skipped
@@ -420,7 +453,7 @@ jobs:
   ci_gate:
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: [changes, lint, unit_tests, build_container, run_tests, run_compose, run_qmp_hook]
+    needs: [changes, lint, unit_tests, build_container, portable_image, run_tests, run_compose, run_qmp_hook]
     steps:
       - name: Require no gated job to have failed
         run: |
@@ -429,6 +462,7 @@ jobs:
             [lint]='${{ needs.lint.result }}'
             [unit_tests]='${{ needs.unit_tests.result }}'
             [build_container]='${{ needs.build_container.result }}'
+            [portable_image]='${{ needs.portable_image.result }}'
             [run_tests]='${{ needs.run_tests.result }}'
             [run_compose]='${{ needs.run_compose.result }}'
             [run_qmp_hook]='${{ needs.run_qmp_hook.result }}'

--- a/flake.nix
+++ b/flake.nix
@@ -604,6 +604,10 @@
               ./tests/unit
               ./pengutils
               ./pyplugins
+              # test_portable_relocate.py runs this script as a subprocess, the
+              # way mk-image.nix runs it. Without it the tests see python's
+              # "can't open file" exit 2, not a relocation result.
+              ./nix/relocate-store.py
             ];
           };
         in

--- a/nix/mk-image.nix
+++ b/nix/mk-image.nix
@@ -532,6 +532,10 @@ let
   # shebangs and .pyc paths all stay valid with no patchelf and no per-format
   # knowledge. See nix/relocate-store.py.
   #
+  # Only OUR store moves: the tool closure baked into the guest at
+  # /igloo/nix/store is a different store, and the rewrite skips it. Rewriting
+  # it shipped portable images whose guests would not build at all.
+  #
   # This is the same class of surgery `clang20Slim` above already does (copy out
   # of the store, then fix up the references), just applied to the whole closure.
   #

--- a/nix/mk-image.nix
+++ b/nix/mk-image.nix
@@ -592,6 +592,23 @@ let
     includeStorePaths = false;
     extraCommands = ''
       cp -a ${portableRoot}/. ./
+
+      # Restore the writable dirs. portableRoot ran ${"$"}{extraCommands} itself, but
+      # nix strips write bits from a store path once its builder finishes, and
+      # `cp -a` faithfully carries those read-only modes into the layer -- the
+      # same trap noted for `var` above. /tmp and /var/tmp are the ones that
+      # bite: the wrapper runs the container as the invoking user (`-u`), so a
+      # 0555 /tmp means no temp dir for the image build and nowhere for qemu's
+      # snapshot overlay.
+      #
+      # State the rule rather than list the paths -- an enumeration drifts the
+      # moment a writable dir is added, which is the failure mode this whole
+      # file is a fix for. Everything OUTSIDE the relocated store is content
+      # the layered image would have made 0755; the store itself stays read-only
+      # there, so it stays read-only here.
+      find . -path ".${portablePrefix}" -prune -o -type d -exec chmod u+w {} +
+      chmod 1777 tmp var/tmp
+      chmod 0777 root
     '';
   };
 in

--- a/nix/relocate-store.py
+++ b/nix/relocate-store.py
@@ -38,6 +38,12 @@ from typing import Iterator
 # a path fragment -- the walk starts above the igloo-static store path.
 GUEST_SUBTREES = ("igloo_static/closures",)
 
+# The files in those subtrees whose contents are checked positively (below).
+# Named exactly, not by extension: anything else that lands there -- an index,
+# per-arch metadata -- carries no store path to assert on, and failing the
+# build over it would be a false positive.
+GUEST_MANIFESTS = ("manifest.json",)
+
 # Glued straight on, this marks the guest's store: "igloo/nix/store" is the
 # guest's copy, "/igloo:/nix/store" a host search path.
 GUEST_PREFIX = "igloo"
@@ -209,13 +215,18 @@ def main() -> int:
         return 1
 
     # The pruned subtrees are skipped wholesale, so nothing above would notice
-    # if one arrived already-relocated. Assert positively that the guest's exec
-    # targets still name the guest's store -- the defect that made every
+    # if one arrived already-relocated -- naming the host prefix for exec
+    # targets that only ever exist in the guest, the defect that made every
     # /igloo/utils/<tool> wrapper exec a path that exists nowhere.
+    #
+    # Only that. Demanding the manifest also *contain* the old prefix would
+    # fail the build on one that names no store path at all -- an arch that
+    # ships no tools, a future format that locates them another way -- neither
+    # of which is a relocation defect.
     for subtree in pruned:
         for dirpath, _, filenames in os.walk(subtree):
             for name in filenames:
-                if not name.endswith(".json"):
+                if name not in GUEST_MANIFESTS:
                     continue
                 path = os.path.join(dirpath, name)
                 try:
@@ -223,9 +234,9 @@ def main() -> int:
                         data = fh.read()
                 except OSError:
                     continue
-                if new in data or old not in data:
+                if new in data:
                     print(
-                        f"relocate-store: {path} does not name {old_s}; a guest "
+                        f"relocate-store: {path} names {new_s}; a guest "
                         f"manifest must keep the guest's own store paths.",
                         file=sys.stderr,
                     )

--- a/nix/relocate-store.py
+++ b/nix/relocate-store.py
@@ -14,6 +14,14 @@ understand a single one of those formats -- no patchelf, no per-format
 handling, no length bookkeeping. Any other length would corrupt the ELF
 sections and offsets that reference them.
 
+Only *this image's* store moved. penguin ships a second one -- the tool closure
+baked into the guest at /igloo/nix/store -- and rewriting a literal that names
+it yields a path that exists nowhere: it broke `mke2fs -d` on the base-image
+tarball and pointed every /igloo/utils/<tool> wrapper at nothing. GUEST_SUBTREES
+and GUEST_PREFIX below keep those out of the blast radius; both passes honour
+them identically, or the leftover check fails the build on what the rewrite
+deliberately kept.
+
 Directories must be writable before this runs (symlink retargeting replaces
 the link, which needs write permission on its parent). File modes are
 preserved: each file is made writable only for its own rewrite and restored
@@ -21,8 +29,45 @@ immediately after.
 """
 
 import os
+import re
 import stat
 import sys
+from typing import Iterator
+
+# Guest filesystem payload; every store path in it is a guest path. Matched as
+# a path fragment -- the walk starts above the igloo-static store path.
+GUEST_SUBTREES = ("igloo_static/closures",)
+
+# Glued straight on, this marks the guest's store: "igloo/nix/store" is the
+# guest's copy, "/igloo:/nix/store" a host search path.
+GUEST_PREFIX = "igloo"
+
+
+def in_guest_subtree(path: str) -> bool:
+    """True if `path` is, or lives under, a guest-payload subtree."""
+    p = path.replace(os.sep, "/")
+    return any(p.endswith("/" + frag) or "/" + frag + "/" in p for frag in GUEST_SUBTREES)
+
+
+def walk(root: str, pruned: "list[str] | None" = None) -> Iterator[str]:
+    """Yield every path under `root`, pruning guest-payload subtrees.
+
+    Both passes walk through here so they cannot disagree about what is in
+    scope. Pruned dirs are neither descended into nor yielded (their own names
+    hold no store reference); each is appended to `pruned` if given.
+    """
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        keep = []
+        for d in dirnames:
+            path = os.path.join(dirpath, d)
+            if in_guest_subtree(path):
+                if pruned is not None:
+                    pruned.append(path)
+            else:
+                keep.append(d)
+        dirnames[:] = keep
+        for name in filenames + dirnames:
+            yield os.path.join(dirpath, name)
 
 
 def main() -> int:
@@ -42,76 +87,149 @@ def main() -> int:
         )
         return 1
 
-    files = links = refs = 0
+    # Every occurrence EXCEPT one glued onto "igloo".
+    guest_lit = GUEST_PREFIX.encode() + old
+    ours = re.compile(b"(?<!" + re.escape(GUEST_PREFIX.encode()) + b")" + re.escape(old))
+    ours_s = re.compile("(?<!" + re.escape(GUEST_PREFIX) + ")" + re.escape(old_s))
 
-    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
-        for name in filenames + dirnames:
-            path = os.path.join(dirpath, name)
+    def rewrite(data: bytes) -> "tuple[bytes, int, int]":
+        """Return (rewritten data, references moved, guest references kept).
 
-            if os.path.islink(path):
-                target = os.readlink(path)
-                if old_s in target:
-                    os.unlink(path)
-                    os.symlink(target.replace(old_s, new_s), path)
-                    links += 1
-                continue
+        Almost nothing in the tree mentions the guest, so one substring scan
+        keeps the big binaries on the plain-replace path.
+        """
+        if guest_lit not in data:
+            return data.replace(old, new), data.count(old), 0
+        count = len(ours.findall(data))
+        # A lambda, not `new`: re.sub reads backslashes in a replacement string.
+        return ours.sub(lambda _m: new, data), count, data.count(old) - count
 
-            # Regular files only: skip fifos, sockets, devices.
-            try:
-                st = os.lstat(path)
-            except OSError:
-                continue
-            if not stat.S_ISREG(st.st_mode):
-                continue
+    def names_ours(data: bytes) -> bool:
+        """True if `data` still holds a reference that should have moved."""
+        if old not in data:
+            return False
+        return guest_lit not in data or ours.search(data) is not None
 
-            try:
-                with open(path, "rb") as fh:
-                    data = fh.read()
-            except OSError as exc:
-                print(f"warning: cannot read {path}: {exc}", file=sys.stderr)
-                continue
+    # What a guest-side literal looks like once the rewrite has ruined it. Both
+    # defects this script once shipped had exactly this shape, and the check
+    # rides along on a pass that already reads every file.
+    corrupt = GUEST_PREFIX.encode() + new
 
-            count = data.count(old)
-            if not count:
-                continue
+    files = links = refs = kept = 0
+    pruned: "list[str]" = []
 
-            mode = stat.S_IMODE(st.st_mode)
-            os.chmod(path, mode | stat.S_IWUSR)
-            try:
-                with open(path, "r+b") as fh:
-                    fh.write(data.replace(old, new))
-            finally:
-                os.chmod(path, mode)
+    for path in walk(root, pruned):
+        if os.path.islink(path):
+            target = os.readlink(path)
+            n = len(ours_s.findall(target))
+            kept += target.count(old_s) - n
+            if n:
+                os.unlink(path)
+                os.symlink(ours_s.sub(lambda _m: new_s, target), path)
+                links += 1
+            continue
 
-            files += 1
-            refs += count
+        # Regular files only: skip fifos, sockets, devices.
+        try:
+            st = os.lstat(path)
+        except OSError:
+            continue
+        if not stat.S_ISREG(st.st_mode):
+            continue
+
+        try:
+            with open(path, "rb") as fh:
+                data = fh.read()
+        except OSError as exc:
+            print(f"warning: cannot read {path}: {exc}", file=sys.stderr)
+            continue
+
+        if old not in data:
+            continue
+
+        rewritten, count, preserved = rewrite(data)
+        kept += preserved
+        if not count:
+            continue
+
+        mode = stat.S_IMODE(st.st_mode)
+        os.chmod(path, mode | stat.S_IWUSR)
+        try:
+            with open(path, "r+b") as fh:
+                fh.write(rewritten)
+        finally:
+            os.chmod(path, mode)
+
+        files += 1
+        refs += count
 
     print(
         f"relocate-store: {old_s} -> {new_s}: "
-        f"rewrote {refs} references in {files} files, retargeted {links} symlinks",
+        f"rewrote {refs} references in {files} files, retargeted {links} symlinks, "
+        f"preserved {kept} guest-side references and skipped "
+        f"{len(pruned)} guest subtree(s)",
         file=sys.stderr,
     )
 
-    # Verify: nothing may still name the old store. A leftover reference is a
-    # runtime failure in an environment where the old store does not exist, and
-    # those are miserable to debug from a container that half-works, so fail the
-    # build instead.
+    # Verify: nothing may still name the old store, guest references excepted.
+    # A leftover is a runtime failure in an environment where the old store does
+    # not exist, and those are miserable to debug from a container that
+    # half-works, so fail the build instead.
     stragglers = []
-    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
-        for name in filenames + dirnames:
-            path = os.path.join(dirpath, name)
-            if os.path.islink(path):
-                if old_s in os.readlink(path):
-                    stragglers.append(path)
+    corrupted = []
+    for path in walk(root):
+        if os.path.islink(path):
+            target = os.readlink(path)
+            if ours_s.search(target):
+                stragglers.append(path)
+            if GUEST_PREFIX + new_s in target:
+                corrupted.append(path)
+            continue
+        try:
+            if not stat.S_ISREG(os.lstat(path).st_mode):
                 continue
-            try:
-                if not stat.S_ISREG(os.lstat(path).st_mode):
+            with open(path, "rb") as fh:
+                data = fh.read()
+            if names_ours(data):
+                stragglers.append(path)
+            if corrupt in data:
+                corrupted.append(path)
+        except OSError:
+            continue
+
+    if corrupted:
+        print(
+            f"relocate-store: {len(corrupted)} path(s) name "
+            f"{GUEST_PREFIX}{new_s} -- a guest store reference was rewritten. "
+            f"The guest did not move; see this script's docstring.",
+            file=sys.stderr,
+        )
+        for path in corrupted[:20]:
+            print(f"  {path}", file=sys.stderr)
+        return 1
+
+    # The pruned subtrees are skipped wholesale, so nothing above would notice
+    # if one arrived already-relocated. Assert positively that the guest's exec
+    # targets still name the guest's store -- the defect that made every
+    # /igloo/utils/<tool> wrapper exec a path that exists nowhere.
+    for subtree in pruned:
+        for dirpath, _, filenames in os.walk(subtree):
+            for name in filenames:
+                if not name.endswith(".json"):
                     continue
-                with open(path, "rb") as fh:
-                    if old in fh.read():
-                        stragglers.append(path)
-            except OSError:
-                continue
+                path = os.path.join(dirpath, name)
+                try:
+                    with open(path, "rb") as fh:
+                        data = fh.read()
+                except OSError:
+                    continue
+                if new in data or old not in data:
+                    print(
+                        f"relocate-store: {path} does not name {old_s}; a guest "
+                        f"manifest must keep the guest's own store paths.",
+                        file=sys.stderr,
+                    )
+                    return 1
 
     if stragglers:
         print(

--- a/pyplugins/core/live_image.py
+++ b/pyplugins/core/live_image.py
@@ -131,7 +131,7 @@ class LiveImage(Plugin):
         gdbserver, ltrace, iptables).
 
         penguin-tools ships, per arch:
-          <STATIC_DIR>/closures/<arch>/closure.tar.gz  -- /nix/store/... closure
+          <STATIC_DIR>/closures/<arch>/closure.tar.gz  -- nix/store/... closure
           <STATIC_DIR>/closures/<arch>/manifest.json   -- {tool: in-store exe}
 
         The closure itself (~150-300MB, ~8.4k files) is large, image-level, and
@@ -140,7 +140,7 @@ class LiveImage(Plugin):
         across configs/runs -- NOT re-shipped here every boot. This method only
         stages the tiny per-tool /igloo/utils/<tool> wrappers, which run the
         pristine binary inside a private mount namespace with /igloo/nix
-        bind-mounted onto /nix so the binary's own absolute /nix/store
+        bind-mounted onto /nix so the binary's own absolute, store-rooted
         interpreter/rpath resolve unchanged. (Pristine binaries instead of the
         old ELF-rewritten musl bundles fix intermittent wrong-mm SIGSEGVs on
         MIPS -- penguin #823.)

--- a/tests/unit/test_kvm_runner_final.py
+++ b/tests/unit/test_kvm_runner_final.py
@@ -23,11 +23,16 @@ from unittest.mock import MagicMock, patch
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src")))
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../pyplugins")))
 
-# gen_image pulls in image-build machinery irrelevant here; stub it before import.
+# gen_image pulls in image-build machinery irrelevant here; stub it for the
+# import below, then put the real module back -- left in place, the stub hands
+# every module collected after this one a MagicMock instead of penguin.gen_image.
 sys.modules["penguin.gen_image"] = MagicMock()
 sys.modules["penguin.gen_image"].make_image = MagicMock()
 
 from penguin.penguin_run import run_config  # noqa: E402
+
+del sys.modules["penguin.gen_image"]
+import penguin.gen_image  # noqa: E402,F401  (also restores the package attribute)
 
 
 class _StopAfterSelection(Exception):

--- a/tests/unit/test_portable_relocate.py
+++ b/tests/unit/test_portable_relocate.py
@@ -142,6 +142,39 @@ def test_a_corrupted_guest_literal_fails_the_build(root):
     assert "already_broken.py" in proc.stderr
 
 
+def test_other_json_in_a_guest_subtree_is_not_a_manifest(root):
+    """Only the tool manifest is asserted on, by name.
+
+    Anything else that lands beside it -- an index, per-arch metadata -- carries
+    no store path to check, so failing the build over it would be a false
+    positive on a file the relocation never had an opinion about.
+    """
+    closures = (root / "opt" / "store" / "hhhh-igloo-static" / "igloo_static"
+                / "closures" / "armel")
+    (closures / "index.json").write_text(json.dumps({"arches": ["armel"]}))
+
+    proc = relocate(root)
+
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_a_store_pathless_guest_manifest_is_not_a_failure(root):
+    """The manifest is checked for the host prefix, not for the guest one.
+
+    An arch that ships no tools, or a future format that locates them some
+    other way, names no store path at all. That is not a relocation defect,
+    and a guard that exists to stop a bad release is the worst place to fail
+    on a file it has no opinion about.
+    """
+    manifest = (root / "opt" / "store" / "hhhh-igloo-static" / "igloo_static"
+                / "closures" / "armel" / "manifest.json")
+    manifest.write_text(json.dumps({}))
+
+    proc = relocate(root)
+
+    assert proc.returncode == 0, proc.stderr
+
+
 def test_a_relocated_guest_manifest_fails_the_build(root):
     """Guest subtrees are skipped wholesale, so assert on them positively.
 

--- a/tests/unit/test_portable_relocate.py
+++ b/tests/unit/test_portable_relocate.py
@@ -1,0 +1,158 @@
+"""
+Unit tests for the portable-image store relocation (``nix/relocate-store.py``).
+
+The rewrite moves this image's closure out of ``/nix/store``, but penguin ships a
+second store -- the tool closure baked into the guest at ``/igloo/nix/store`` --
+that did not move. Every published ``-portable`` image rewrote two guest-side
+literals anyway: the parent-directory entry in
+``gen_image.tar_add_tool_closure`` (``mke2fs -d`` then refused the base tarball,
+so no guest booted) and ``closures/<arch>/manifest.json`` (every
+``/igloo/utils/<tool>`` wrapper exec'd a nonexistent path).
+
+Below: the two rules that now exclude them, and the host-side rewrite they must
+not weaken. The script runs as a subprocess, the way the build runs it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+RELOCATE = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", "nix", "relocate-store.py"))
+
+# Absent, every test below would fail as python's "can't open file" exit 2
+# rather than as a relocation result. The script has to be staged deliberately
+# (flake.nix's testTree fileset), so say which one broke.
+assert os.path.isfile(RELOCATE), (
+    f"{RELOCATE} not found -- add nix/relocate-store.py to the testTree "
+    f"fileset in flake.nix")
+
+OLD = "/nix/store"
+NEW = "/opt/store"
+
+
+def relocate(root, old=OLD, new=NEW):
+    """Run the relocation over ``root``; return the CompletedProcess."""
+    return subprocess.run(
+        [sys.executable, RELOCATE, str(root), old, new],
+        capture_output=True, text=True)
+
+
+@pytest.fixture
+def root(tmp_path):
+    """An image root with both a host store reference and guest-side payload."""
+    r = tmp_path / "root"
+
+    # Host side: a source file naming the store, and the symlink farm that
+    # points into it. Both must move.
+    (r / "src").mkdir(parents=True)
+    (r / "src" / "host.py").write_text(
+        'GLOB = "/nix/store/*/igloo_static/kernels/*/igloo.ko"\n')
+    (r / "bin").mkdir()
+    (r / "bin" / "bash").symlink_to("/nix/store/aaaa-bash/bin/bash")
+
+    # Guest side: the tool closure's manifest, under the relocated store the
+    # way the build lays it out.
+    closures = r / "opt" / "store" / "hhhh-igloo-static" / "igloo_static" / "closures" / "armel"
+    closures.mkdir(parents=True)
+    (closures / "manifest.json").write_text(json.dumps(
+        {"gdb": "/nix/store/01crmi2lfm14bnl3rydihby3kbprnv2c-gdb-16.3/bin/gdb"}))
+
+    # Guest side: a literal naming the guest's baked store.
+    (r / "src" / "guest.py").write_text(
+        'DIRS = ("igloo/nix/", "igloo/nix/store/", "nix/")\n')
+
+    return r
+
+
+def test_host_references_move(root):
+    """The whole point: this image's own store references are rewritten."""
+    assert relocate(root).returncode == 0
+
+    assert "/opt/store/*/igloo_static" in (root / "src" / "host.py").read_text()
+    assert os.readlink(root / "bin" / "bash") == "/opt/store/aaaa-bash/bin/bash"
+
+
+def test_guest_closure_manifest_is_not_rewritten(root):
+    """The wrapper exec targets name the guest's store, which did not move."""
+    assert relocate(root).returncode == 0
+
+    manifest = json.loads(
+        (root / "opt" / "store" / "hhhh-igloo-static" / "igloo_static"
+         / "closures" / "armel" / "manifest.json").read_text())
+    assert manifest["gdb"].startswith("/nix/store/")
+
+
+def test_igloo_prefixed_literals_are_not_rewritten(root):
+    """``igloo/nix/store`` is the guest's copy; rewriting it broke mke2fs."""
+    assert relocate(root).returncode == 0
+
+    assert (root / "src" / "guest.py").read_text() == (
+        'DIRS = ("igloo/nix/", "igloo/nix/store/", "nix/")\n')
+
+
+def test_preserved_guest_references_do_not_fail_the_build(root):
+    """The leftover check must agree with the rewrite about what is in scope --
+    otherwise every reference deliberately kept is reported as a straggler."""
+    proc = relocate(root)
+
+    assert proc.returncode == 0, proc.stderr
+    assert "still reference" not in proc.stderr
+    assert "preserved 1 guest-side references and skipped 1 guest subtree(s)" in proc.stderr
+
+
+def test_igloo_must_be_glued_on_to_count_as_guest_side(root):
+    """``/igloo:/nix/store/...`` is a host search path listing ``/igloo`` first;
+    only ``igloo/nix/store``, one path, names the guest's copy."""
+    (root / "src" / "boundary.py").write_text(
+        'PATH = "/igloo:/nix/store/aaaa-coreutils/bin"\n'
+        'GUEST = "/igloo/nix/store/aaaa-gdb/bin/gdb"\n')
+
+    assert relocate(root).returncode == 0
+
+    assert (root / "src" / "boundary.py").read_text() == (
+        'PATH = "/igloo:/opt/store/aaaa-coreutils/bin"\n'
+        'GUEST = "/igloo/nix/store/aaaa-gdb/bin/gdb"\n')
+
+
+def test_unequal_prefix_lengths_are_rejected(root):
+    """In-place rewriting is only valid at equal byte length."""
+    proc = relocate(root, new="/somewhere/else")
+
+    assert proc.returncode == 1
+    assert "prefix length mismatch" in proc.stderr
+
+
+def test_a_corrupted_guest_literal_fails_the_build(root):
+    """The signature both shipped defects had: a guest literal, relocated.
+
+    The rules above stop this script from creating one, but a literal can also
+    arrive pre-broken from an input; either way it must never reach an image.
+    """
+    (root / "src" / "already_broken.py").write_text(
+        'DIRS = ("igloo/nix/", "igloo/opt/store/", "nix/")\n')
+
+    proc = relocate(root)
+
+    assert proc.returncode == 1
+    assert "a guest store reference was rewritten" in proc.stderr
+    assert "already_broken.py" in proc.stderr
+
+
+def test_a_relocated_guest_manifest_fails_the_build(root):
+    """Guest subtrees are skipped wholesale, so assert on them positively.
+
+    Nothing in the rewrite pass reads a pruned subtree, so a manifest that
+    arrived already naming the host prefix would otherwise sail through.
+    """
+    manifest = (root / "opt" / "store" / "hhhh-igloo-static" / "igloo_static"
+                / "closures" / "armel" / "manifest.json")
+    manifest.write_text(json.dumps({"gdb": "/opt/store/01crmi2-gdb-16.3/bin/gdb"}))
+
+    proc = relocate(root)
+
+    assert proc.returncode == 1
+    assert "must keep the guest's own store paths" in proc.stderr

--- a/tests/unit/test_tool_closure_tar.py
+++ b/tests/unit/test_tool_closure_tar.py
@@ -60,9 +60,15 @@ def base_tar(tmp_path, monkeypatch):
 
 
 def _members(path):
-    """Member names, as tarfile reports them (trailing slashes normalised off)."""
+    """Member names with any trailing slash removed.
+
+    The parent-entry check below compares a member's name against the set of
+    directory names, so the two spellings of a directory have to be one. Done
+    here rather than relied upon: tarfile happens to strip the slash on read,
+    but that is its behaviour, not this helper's contract.
+    """
     with tarfile.open(path) as tf:
-        return tf.getnames()
+        return [name.rstrip("/") for name in tf.getnames()]
 
 
 def test_every_member_has_a_parent_directory_entry(base_tar):

--- a/tests/unit/test_tool_closure_tar.py
+++ b/tests/unit/test_tool_closure_tar.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for ``gen_image.tar_add_tool_closure``.
+
+The closure is appended re-rooted under ``igloo/``; the function pre-creates the
+parent directory entries its members need and skips the closure's own bare
+``nix/`` and ``nix/store/`` entries so they are not added twice. The two halves
+have to agree, and in every published ``-portable`` image they did not: the
+pre-created entry read ``igloo/opt/store/`` while members landed under
+``igloo/nix/store/``, leaving thousands with no parent entry, which ``mke2fs -d``
+refuses. (Cause: the portable store relocation -- see test_portable_relocate.py.)
+
+The invariant below catches it cheaply: every member has a parent entry.
+"""
+
+import io
+import tarfile
+
+import pytest
+
+from penguin import gen_image
+
+ARCH = "armel"
+STORE_PATH = "01crmi2lfm14bnl3rydihby3kbprnv2c-gdb-16.3"
+
+CONFIG = {"core": {"arch": ARCH}}
+
+
+def _closure_tar(path):
+    """A miniature closure tarball, shaped like the real one: bare ``nix/`` and
+    ``nix/store/`` dir entries, then one store path with a binary in it."""
+    with tarfile.open(path, "w:gz") as tf:
+        for name in ("nix/", "nix/store/", f"nix/store/{STORE_PATH}/",
+                     f"nix/store/{STORE_PATH}/bin/"):
+            di = tarfile.TarInfo(name=name)
+            di.type = tarfile.DIRTYPE
+            di.mode = 0o755
+            tf.addfile(di)
+        fi = tarfile.TarInfo(name=f"nix/store/{STORE_PATH}/bin/gdb")
+        fi.mode = 0o755
+        fi.size = 4
+        tf.addfile(fi, io.BytesIO(b"ELF\n"))
+
+
+@pytest.fixture
+def base_tar(tmp_path, monkeypatch):
+    """An (uncompressed) base tarball plus a staged closure to append into it."""
+    closure_dir = tmp_path / "static" / "closures" / ARCH
+    closure_dir.mkdir(parents=True)
+    _closure_tar(closure_dir / "closure.tar.gz")
+    monkeypatch.setattr(gen_image, "static_dir", str(tmp_path / "static"))
+    monkeypatch.setattr(gen_image, "get_arch_subdir", lambda config: ARCH)
+
+    path = tmp_path / "image.tar"
+    with tarfile.open(path, "w") as tf:
+        di = tarfile.TarInfo(name="igloo/")
+        di.type = tarfile.DIRTYPE
+        di.mode = 0o755
+        tf.addfile(di)
+    return path
+
+
+def _members(path):
+    """Member names, as tarfile reports them (trailing slashes normalised off)."""
+    with tarfile.open(path) as tf:
+        return tf.getnames()
+
+
+def test_every_member_has_a_parent_directory_entry(base_tar):
+    """The invariant ``mke2fs -d`` enforces, and defect-1 broke."""
+    gen_image.tar_add_tool_closure(str(base_tar), CONFIG)
+
+    names = _members(base_tar)
+    dirs = {n.rstrip("/") for n in names}
+    for name in names:
+        parent = name.rstrip("/").rpartition("/")[0]
+        while parent:
+            assert parent in dirs, f"{name!r} has no directory entry for {parent!r}"
+            parent = parent.rpartition("/")[0]
+
+
+def test_closure_lands_under_the_guest_store(base_tar):
+    """The wrappers bind ``/igloo/nix`` onto ``/nix``; the store has to be there."""
+    gen_image.tar_add_tool_closure(str(base_tar), CONFIG)
+
+    assert f"igloo/nix/store/{STORE_PATH}/bin/gdb" in _members(base_tar)
+
+
+def test_parent_directory_entries_are_not_duplicated(base_tar):
+    """The closure's own bare ``nix/``/``nix/store/`` entries give way to the
+    pre-created ones -- exactly once each."""
+    gen_image.tar_add_tool_closure(str(base_tar), CONFIG)
+
+    names = _members(base_tar)
+    assert len(names) == len(set(names))
+
+
+def test_absent_closure_is_skipped(tmp_path, monkeypatch, base_tar):
+    """Older images and arches without a closure must still build an image."""
+    monkeypatch.setattr(gen_image, "static_dir", str(tmp_path / "nothing-here"))
+
+    gen_image.tar_add_tool_closure(str(base_tar), CONFIG)
+
+    assert _members(base_tar) == ["igloo"]


### PR DESCRIPTION
# nix: stop the portable image rewriting guest store paths

Three defects in the `-portable` image, all from 0ed42c52, shipped in **v3.1.9
through v3.1.14**. The first two mean no guest boots at all. Non-portable images
are unaffected — the source is correct; only the built artifact is wrong.

## Cause

`relocate-store.py` replaces the byte string `/nix/store` format-blind, which is
right for the host closure that really moved to `/opt/store`. But penguin ships a
**second** store: the debugging-tool closure baked into the *guest* at
`/igloo/nix/store` and bind-mounted onto the guest's `/nix` (ddd637df, Jun 20).
Nothing about the guest moved. The rewrite could not tell them apart.

Neither change was wrong alone — the defect lives only in their intersection,
which is why reviewing either diff would not have caught it.

| # | symptom | mechanism |
|---|---|---|
| 1 | no guest filesystem builds | the parent-dir tuple in `tar_add_tool_closure` became `igloo/opt/store/`, orphaning every `igloo/nix/store/` member; `mke2fs -d` refuses it (and `mke2fs` is innocent) |
| 2 | every `/igloo/utils/<tool>` wrapper execs nothing | `closures/<arch>/manifest.json` named `/opt/store/<hash>/…` while the tarball lays it at `igloo/nix/store/<hash>/…` |
| 3 | container dies before that | `/tmp` ships 0555 — `portableRoot` is a store path, nix strips write bits, `cp -a` carries them into the layer. Only bites non-root, which is the normal case (`penguin` runs docker with `-u`) |

Defect 1 masks 2: nothing boots, so nobody reaches the wrappers. Defect 3 is
independent of the rewrite; published images confirm it (`v3.1.11-portable` and
`v3.1.14-portable` ship `/tmp` as `dr-xr-xr-x`, non-portable as `drwxrwxrwt`).

## Fix

Fix the rewrite, not the two call sites, or the next guest-side literal added
anywhere acquires the same defect silently:

- **`GUEST_SUBTREES`** prunes `igloo_static/closures` — guest payload whose every
  store path is a guest path by construction.
- **`GUEST_PREFIX`** skips an occurrence glued straight onto `igloo`.
  `igloo/nix/store` is the guest's copy; `/igloo:/nix/store` is a host search path
  that merely lists `/igloo` first.

Both passes share one walk and one expression, so the leftover check cannot
disagree with the rewrite about scope.

Two guards ride on the pass that already reads every file, so a bad rewrite fails
the **build**: no path may name `igloo/opt/store` (the signature both defects
had), and a guest manifest must still name the guest's own store.

## Verification

CI cannot reproduce any of this today — no PR job builds the portable image (the
last commit fixes that). All of the below is local, against a real build.

**The guards catch the original bug.** Restoring the pre-fix blind rewrite now
stops the build:

```
relocate-store: 4 path(s) name igloo/opt/store -- a guest store reference was
rewritten. The guest did not move; see this script's docstring.
error: Cannot build '...-penguin-portable-root.drv'
```

**The `mke2fs` invariant, on the real shipped closure** — every member needs a
directory entry for its parent:

| tuple | members | missing parents |
|---|---|---|
| fixed | 9327 | **0** |
| corrupted | 9327 | **9324** |

**End to end**, armel / kernel 6.13 on a locally built portable image: it starts
under a shadowed `/nix` (`docker run -v empty:/nix:ro … penguin --version`), the
guest boots, `penguin_tools.yaml` passes with all four wrappers exec'ing their
in-store binaries, and `/igloo/utils/gdb` attaches to a live process and unwinds:

```
* 1    process 153 "busybox" 0x0014a188 in __syscall_cp_c ()
#1  0x00156c38 in __clock_nanosleep_time64 ()
#4  0x000f14e0 in sleep_main ()
[Inferior 1 (process 153) detached]
```

The relocation itself: 27918 references rewritten across 15245 files, 7
guest-side references preserved, 1 guest subtree skipped.
`nix build .#checks.x86_64-linux.unit-tests` → 802 passed.

## Commits

Each passes the unit suite standalone.

1. `tests: scope the gen_image stub to the import that needs it` — pre-existing
   `sys.modules` leak that made the new closure test pass alone and fail in the
   suite, silently.
2. `nix: stage relocate-store.py into the unit-test tree` — the check's fileset
   omits `nix/`, so the new tests saw exit 2, not a relocation result.
3. `nix: stop the portable rewrite from relocating guest store paths` — defects 1
   and 2, the guards, and both test files.
4. `nix: restore the portable image's writable directories` — defect 3.
5. `ci: build the portable image on pull requests` — the systemic gap (~1 min,
   build only, no push, so it does not touch the registry storage that kept the
   variant on-demand).

## Follow-ups

- **Load and boot the portable image in CI.** This PR only builds it. Covering
  defect 3 and the wrappers needs a build-only path through the shared
  `nix-image-push` workflow.
- **gdb-attach coverage.** `indiv_debug.yaml` proves gdbserver binds; nothing
  proves gdb attaches and unwinds. Out of scope here — unvalidated outside armel,
  and `penguin_tools.yaml` already covers this PR's defect (gdb and gdbserver are
  the same store path on all 13 arches).
- Unrelated, found in passing: `nix-dev.sh doctor` reports flakes disabled on
  Determinate installs, and `junit-xml` is missing from `src[test]` so the
  workflow in `tests/unit/README.md` cannot pass on a bare host.
