### PR TITLE
CI:  stop lintly from leaving a sticky changes-requested review

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,14 @@ jobs:
       if: ${{ needs.changes.outputs.run_lint == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
       run: |
         set -o pipefail
-        (flake8 | lintly) 2>lintly.err || {
+        # --no-request-changes: post the annotations as a COMMENTED review rather
+        # than CHANGES_REQUESTED. A bot's changes-requested review counts toward
+        # reviewDecision and sticks until a human dismisses it -- Lintly never
+        # posts an approval to supersede its own, so fixing the lint does not
+        # clear it. The gate is unchanged: lintly still exits nonzero on violations, 
+        # so this step and  the required `lint` check still fail, and a check clears
+        # itself on the next push.
+        (flake8 | lintly --no-request-changes) 2>lintly.err || {
           if grep -q 'diff exceeded the maximum number of lines' lintly.err; then
             echo "Bypassing lint failure due to large diff."
             exit 0

--- a/lint_probe.py
+++ b/lint_probe.py
@@ -1,0 +1,3 @@
+# Temporary: verifies Lintly posts a COMMENTED review instead of
+# CHANGES_REQUESTED. Delete once the review state is confirmed on this PR.
+import os

--- a/lint_probe.py
+++ b/lint_probe.py
@@ -1,3 +1,0 @@
-# Temporary: verifies Lintly posts a COMMENTED review instead of
-# CHANGES_REQUESTED. Delete once the review state is confirmed on this PR.
-import os


### PR DESCRIPTION
Lintly posts violations as a CHANGES_REQUESTED review by default. That review counts toward the PR's review decision and never clears itself.

`--no-request-changes` posts the same inline annotations as a COMMENTED review instead, so the only thing blocking is the required `lint` check (which recomputes on every push and clears itself once the lint is fixed).

Enforcement is unchanged: lintly still exits nonzero on violations, so this step and the `lint` check still fail on a dirty tree.

Throwing in a temporary `lint_probe.py` and removing it before merge to verify behavior.